### PR TITLE
[core][integer] Speed up multiplication and division + fix two division bugs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,11 +7,13 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 `Rational` grows a full set of conversions and joins the
 `from_integral_scalar()` / `from_float_scalar()` naming used by the other
 numeric types, `BigInt10` is no longer referenced by the rest of the library,
-and `BigDecimal.pi()` gets three to four orders of magnitude faster — it now
-runs ahead of pure-Python mpmath from 500 digits up. Burnikel-Ziegler division
-loses a padding choice that cost it its own asymptotics on some sizes, which
-speeds up every division in the library. A Newton iteration that silently
-returned short of its requested precision is fixed.
+and `BigDecimal.pi()` gets four orders of magnitude faster — it now runs ahead
+of pure-Python mpmath from 500 digits up. Multiplication is 2-3x faster for
+both `BigInt` and `BigUInt`, which puts `BigInt` ahead of CPython's `int` on
+every large operation. Burnikel-Ziegler division loses a padding choice that
+cost it its own asymptotics on some sizes, which speeds up every division in
+the library. A Newton iteration that silently returned short of its requested
+precision is fixed.
 
 ### ⭐️ New in Unreleased
 
@@ -30,23 +32,48 @@ returned short of its requested precision is fixed.
 
 ### 🦋 Changed in Unreleased
 
-1. **`BigInt` multiplication gains a Toom-3 path.** Above 384 words the
-   magnitude multiply now splits each operand three ways, evaluates both as
-   polynomials at `0`, `1`, `-1`, `2` and `inf`, and interpolates the product
-   from five sub-multiplications instead of Karatsuba's three: `O(n^1.465)`
-   against `O(n^1.585)`. `BigUInt` has had this since v0.10.0 (PR #166); `BigInt` — the
-   type the Chudnovsky binary splitting actually runs on — stopped at
-   Karatsuba. Against the Karatsuba path it is 1.15x at 400 words, 1.25x at
-   5 000 and 1.5x at 22 000; a 100 000-digit product goes from 7.7 ms to
-   6.0 ms, and `pi(100000)` from 152 ms to 142 ms. The end-to-end gain is
-   smaller than the multiply gain because a binary-splitting tree spends only
-   about a third of its time at the top level, and only the top few levels are
-   large enough for Toom-3 to reach.
+1. **`BigUInt` schoolbook division is 1.3-2x faster.** Each quotient word used
+   to build `q * y` as a fresh `BigUInt`, shift it up by the word position,
+   compare it against the whole remainder and subtract it from the whole
+   remainder — four passes over the full dividend plus an allocation, per
+   word. It is now a single fused multiply-subtract over just the `n + 1` word
+   window the quotient word touches, Knuth D style, keeping the existing
+   3-by-2 estimator. Biggest in the band where `BigDecimal` division actually
+   lives: 2.0x at 100 digits, 1.5x at 300, 1.3x at 1 000.
 
-   With this, `BigInt` is ahead of CPython's `int` on both of the operations
-   that dominate large-integer work: at 100 000 decimal digits a product takes
-   6.0 ms against CPython's 9.4 ms, and a floor division 16.1 ms against
-   19.4 ms. CPython still edges it on decimal output, 18.6 ms against 21.0 ms.
+1. **Multiplication is 2-3x faster, and `pi(100000)` runs in 78 ms instead of
+   152 ms.** Three changes, in the order they were made:
+
+   *Toom-3 on `BigInt`.* Above 512 words the magnitude multiply splits each
+   operand three ways, evaluates at `0`, `1`, `-1`, `2` and `inf`, and
+   interpolates the product from five sub-multiplications instead of
+   Karatsuba's three: `O(n^1.465)` against `O(n^1.585)`. `BigUInt` has had
+   this since v0.10.0 (PR #166); `BigInt` — the type the Chudnovsky binary
+   splitting runs on — stopped at Karatsuba. It is 1.26x the Karatsuba path at
+   5 000 words and 1.51x at 22 000.
+
+   *Product-scanning schoolbook base case, for both types.* The old kernel read
+   and wrote the result array on every one of the `n*m` partial products and
+   carried serially along each row. It now walks the result one word at a time
+   and sums the whole column in a `UInt128` accumulator — four of them, since
+   one serialises on the 128-bit add — so the column stays in registers and
+   the base reduction happens once per result word rather than once per
+   partial product. About 2x at 48 words for `BigInt`, 2.2x at 256 words for
+   `BigUInt`. This supersedes `BigUInt`'s `multiply_slices_deferred_carry()`,
+   which has been removed along with `CUTOFF_DEFERRED_CARRY_PRODUCT`.
+
+   *Re-tuned cutoffs.* A quadratic kernel that fast moves both crossovers a
+   long way up. `BigInt`: Karatsuba 48 -> 128, Toom-3 384 -> 512. `BigUInt`:
+   Karatsuba 64 -> 256, Toom-3 256 -> 768. Worth another 20% on its own.
+
+   At 100 000 decimal digits a `BigInt` product now takes 3.4 ms and a
+   `BigUInt` product 6.0 ms, against 7.7 and 11.8 before. `pi(10000)` goes
+   from 3.75 ms to 2.2 ms and `pi(100000)` from 152 ms to 78 ms.
+
+   With this `BigInt` is ahead of CPython's `int` on every large operation. At
+   100 000 digits, decimo against CPython 3.14: multiply 3.4 ms vs 9.4,
+   floor division 9.2 ms vs 19.4, `to_string` 13.1 ms vs 18.6, `from_string`
+   5.1 ms vs 9.3.
 
 1. **`BigDecimal.pi()` is three to four orders of magnitude faster.** The
    Chudnovsky binary splitting now uses the `P`/`Q`/`T` recurrence: each leaf
@@ -134,6 +161,38 @@ returned short of its requested precision is fixed.
    `DECIMO_TEST_JOBS` explicitly still wins in both cases.
 
 ### 🩹 Fixed in Unreleased
+
+1. **`BigUInt` division crashed, or silently lost a factor of 10^9, for
+   three-word dividends.** `floor_divide()` routes any divisor of three or
+   four words to `floor_divide_by_uint128()`, which consumes the dividend four
+   words at a time. When the word count is not a multiple of four the leading
+   group is short, and its own quotient was discarded — only its remainder was
+   carried forward, and the result was sized at `n - (n mod 4)` words. A
+   seven-word dividend over a three-word divisor therefore came back a factor
+   of 10^9 too small, and a three-word dividend — where the leading group *is*
+   the whole number — produced a `BigUInt` with no words at all, which faults
+   the next operation that reads `words[len(words) - 1]`.
+
+   Neither shape is exotic: `BigUInt("23334504672441144935") //
+   BigUInt("1854056525350022197")` crashed, and a sweep of dividend lengths
+   one to nine words against divisor lengths one to five had 80 wrong results
+   in 1 824. Present since PR #111 (2025-07-23), so released versions are
+   affected. `test_biguint_divide_short_operands_of_every_word_count()` covers
+   every residue of the group size.
+
+1. **Toom-3 wrote one word past the end of its result buffer for lopsided
+   operands.** A three-way split sizes its limbs by the longer operand, so a
+   short second operand can have empty high limbs while `4 * m` — the offset
+   where the `w4` coefficient is recomposed — runs past the end of the result.
+   With 513 and 129 words, `4 * m` is 684 against a 642-word buffer. `w4` is
+   zero in exactly those cases and `_add_at_offset_inplace()` does not bounds
+   check its main loop, so it wrote a zero word out of bounds and no value
+   comparison could see it. `BigUInt`'s Toom-3 was never affected: its
+   recomposition helper checks each position. Found by Copilot on PR #273.
+
+   `_add_at_offset_inplace()` now states the precondition and asserts it, so
+   the suite — which runs with `-D ASSERT=all` — catches any recurrence, and
+   `test_multiply_toom3_lopsided_operands()` covers the shapes that trip it.
 
 1. **`BigUInt` in-place subtraction returned garbage when the two operands were
    equal**, and with it `BigUInt` long division for a whole class of dividends.

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -183,7 +183,7 @@ division it feeds.
 ### Toom-3 helps the multiply much more than it helps `pi()`
 
 Toom-3 on `BigInt` is 1.15x Karatsuba at 400 words, 1.26x at 5 000 and 1.51x
-at 22 000, but `pi(100000)` only went 152 -> 142 ms. The tree shape explains
+at 22 000, but on its own `pi(100000)` only went 152 -> 142 ms. The tree shape explains
 it: doubling the term count multiplies the split's cost by 3.06, so the top
 level is only 35% of the total and each level below adds 65% of the one above.
 Toom-3 reaches the top three or four levels; the rest is Karatsuba as before.
@@ -191,21 +191,21 @@ Toom-3 reaches the top three or four levels; the rest is Karatsuba as before.
 So a faster multiply only pays across a *wide* size range. Toom-4 would move
 the same few levels again; only an FFT changes the exponent everywhere.
 
-Where the 142 ms goes:
+Where the time goes, after the rest of the 2026-08-24 work took it to 78 ms:
 
 | Stage                              | ms   | Base |
 | ---------------------------------- | ---- | ---- |
-| binary splitting, below the root   | 43.1 | 2^32 |
-| root join, 3 full-width multiplies | 16.7 | 2^32 |
-| `5^s` and the scaling multiply     | 9.1  | 2^32 |
-| final division                     | 16.5 | 2^32 |
-| base 2^32 -> 10^9                  | 19.9 | both |
-| `sqrt_reciprocal(10005)`           | 21.3 | 10^9 |
-| final multiplies and round         | 12.9 | 10^9 |
+| binary splitting, below the root   | 24.5 | 2^32 |
+| base 2^32 -> 10^9                  | 12.5 | both |
+| `sqrt_reciprocal(10005)`           | 11.1 | 10^9 |
+| root join, 3 full-width multiplies |  9.7 | 2^32 |
+| final division                     |  9.6 | 2^32 |
+| final multiplies and round         |  6.0 | 10^9 |
+| `5^s` and the scaling multiply     |  4.9 | 2^32 |
 
-The last two rows, 34 ms, run in base 10^9 where the same multiply costs twice
-what it costs in base 2^32 (12.1 ms against 6.0 ms at 100 000 digits). Neither
-has to be decimal. See `plans/bigdecimal_enhancement.md` T-PI4.
+17 ms still runs in base 10^9, where the same multiply costs more than it does
+in base 2^32 (6.0 ms against 3.4 at 100 000 digits). Neither stage has to be
+decimal. See `plans/bigdecimal_enhancement.md` T-PI4.
 
 ### Burnikel-Ziegler padding has to survive every halving
 
@@ -240,6 +240,25 @@ than checking one. Second, the padding rule and the recursion's base case are
 one decision, not two - the base case's condition (`n` odd) is what determines
 what the padding has to guarantee, and they were written far enough apart in
 the file to be changed independently.
+
+### Two size points are not a size sweep
+
+`floor_divide_by_uint128()` dropped the quotient of its leading partial group
+for over a year: a three-word divisor lost a factor of 10^9 when the dividend
+had `4k + 3` words, and crashed outright when the dividend *was* the leading
+group. `BigUInt("23334504672441144935") // BigUInt("1854056525350022197")`
+faulted.
+
+Both randomized division cross-checks against Python used fixed sizes —
+2 214 digits over 810, and 200 000 over 14 000. `random_decimal_string(n)`
+counts 18-digit chunks, not digits, so both are far above
+`CUTOFF_BURNIKEL_ZIEGLER` and both take the B-Z path. The whole
+`len(y.words) <= 4` branch had no randomized cross-check at all.
+
+The dispatch has four branches and the three-or-four-word one behaves
+differently for each residue of the dividend length mod 4. Two samples cannot
+cross that. `test_biguint_divide_across_the_dispatch_boundaries_against_python`
+now walks divisor 1-40 digits against dividend up to 90.
 
 ### A missing `return` in `subtract_inplace()`
 

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -80,8 +80,8 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 
 ### 2.3b Constants — `pi()` (PR #269–#273)
 
-`pi(10000)` 13.7 s → 3.9 ms; `pi(100000)` was out of practical reach, now
-142 ms. Everything that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
+`pi(10000)` 13.7 s → 2.2 ms; `pi(100000)`, out of practical reach before, now
+78 ms. Everything that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 
 | Date     | PR       | Item                                                                      |
 | -------- | -------- | ------------------------------------------------------------------------- |
@@ -93,7 +93,13 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 | 20260823 | #270     | Divide once in binary, convert only the quotient; `10^s` as `5^s << s`     |
 | 20260823 | #270     | Leaves packed from `UInt128` — was half the split's time at p=1000         |
 | 20260823 | #271     | B-Z divisor padding fixed; a 100 000-digit divide 81 ms → 18 ms     |
-| 20260824 | #273     | Toom-3 on `BigInt` (see `bigint_enhancement.md` T-M1); 152 → 142 ms        |
+| 20260824 | #273     | Toom-3 on `BigInt` (`bigint_enhancement.md` T-M1); 152 → 142 ms            |
+| 20260824 | #273     | Product-scanning `BigUInt` schoolbook, replacing deferred-carry (T-9b);    |
+|          |          | 2.2× at 256 words, and it supersedes `multiply_slices_deferred_carry`      |
+| 20260824 | #273     | `BigUInt` cutoffs re-tuned: Karatsuba 64 → 256, Toom-3 256 → 768;          |
+|          |          | a 100 000-digit `BigUInt` multiply 10.5 → 6.0 ms                           |
+| 20260824 | #274     | Product-scanning `BigUInt` schoolbook mul, windowed schoolbook div,        |
+|          |          | dead `right.p` at the root of the split. Total: 142 → 78 ms                |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -799,24 +805,26 @@ P7 — `round` (2× py → target ≤1.0×)
   `subtract` / `multiply` with `precision > 0`).
 
 **T-PI4 — keep the `pi()` pipeline binary, convert once. OPEN.**
-Stage breakdown at p=100000 (142 ms total):
+Stage breakdown at p=100000, after the 2026-08-24 work (78 ms total):
 
 | Stage                              | ms   | Base |
 | ---------------------------------- | ---- | ---- |
-| binary splitting, below the root   | 43.1 | 2^32 |
-| root join, 3 full-width multiplies | 16.7 | 2^32 |
-| `5^s` and the scaling multiply     | 9.1  | 2^32 |
-| final division                     | 16.5 | 2^32 |
-| base 2^32 → 10^9                   | 19.9 | both |
-| `sqrt_reciprocal(10005)`           | 21.3 | 10^9 |
-| final multiplies and round         | 12.9 | 10^9 |
+| binary splitting, below the root   | 24.5 | 2^32 |
+| base 2^32 → 10^9                   | 12.5 | both |
+| `sqrt_reciprocal(10005)`           | 11.1 | 10^9 |
+| final division                     |  9.6 | 2^32 |
+| root join, 3 full-width multiplies |  9.7 | 2^32 |
+| final multiplies and round         |  6.0 | 10^9 |
+| `5^s` and the scaling multiply     |  4.9 | 2^32 |
 
-The last two rows, 34 ms, run in base 10^9, where the same multiply costs
-twice what it costs in base 2^32 (12.1 ms vs 6.0 ms at 100 000 digits).
-Neither needs to be decimal: `sqrt_reciprocal` can run as a fixed-point
-reciprocal square root on `BigInt`, and the final multiply with it. Estimated
-142 → ~125 ms. Below that the multiplication exponent itself has to come down
-(T-5, NTT) — for scale, mpmath on gmpy2 does the same 100 000 digits in ~16 ms.
+`sqrt_reciprocal` has no reason to be decimal — a fixed-point reciprocal
+square root on `BigInt` would run against a multiply that is still 1.75× the
+base-10^9 one (3.4 ms vs 6.0 at 100 000 digits) — and the final multiply could
+follow it, leaving a single conversion. Worth roughly 5 ms now, down from the
+17 ms it would have been worth before the kernels were fixed.
+
+Below that the multiplication exponent itself has to come down (T-5, NTT).
+For scale, mpmath on gmpy2 does the same 100 000 digits in ~16 ms.
 
 ### 5.3 Long-term tasks not on the active roadmap
 
@@ -927,7 +935,10 @@ some ops < 1.0×):
 | T-R1   | `round` `.format` sweep                   | S      | **NO**   | no `.format` asserts in round; great           |
 | T-7b   | Reciprocal-Newton nth root                | M      | **WAIT** | break-even at current mul speed                |
 |        |                                           |        |          | (div ~2.7× mul); root already 0.2× py          |
-| T-PI4  | Binary-only `pi()` pipeline, convert once | M      | **OPEN** | 142 → ~125 ms at p=100000                      |
+| T-PI4  | Binary-only `pi()` pipeline, convert once | M      | **OPEN** | ~5 ms of the 82 ms at p=100000                 |
+| T-9b   | Product-scanning `BigUInt` schoolbook     | M      | **DONE** | 2.2× at 256 words; deferred-carry removed      |
+| T-9c   | Re-tune `BigUInt` mul cutoffs             | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms      |
+| T-D5   | Windowed fused mul-sub in schoolbook div  | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000 |
 | T-5    | NTT multiplication                        | XL     | **WAIT** | valid; multi-session XL, tracked in §5.3       |
 | T-9    | deferred-carry schoolbook mul             | M      | **DONE** | deferred-carry (product-scanning);             |
 |        |                                           |        |          | Definitely worth bringing it to `BigInt` too   |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -136,10 +136,16 @@ unchanged for the variable-length signed case.
    the final iteration instead of `log n` full-width iterations.
 
 9. **Reciprocal-Newton divide only wins once multiplication is much
-   cheaper than division** (the NTT regime). Re-measured after T-M1: at
-   100 000 digits B-Z divides in 16.5 ms against 6.0 ms for the same-size
-   multiply, so it is still 2.75× a multiply and a reciprocal-Newton rewrite
-   would be a wash. Toom-3 was not enough to unblock it; NTT would be.
+   cheaper than division** (the NTT regime). Re-measured after T-M1/T-M2: at
+   100 000 digits B-Z divides in 9.2 ms against 3.4 ms for the same-size
+   multiply — still 2.7×, the ratio has not moved. A reciprocal-Newton rewrite
+   would be a wash. Neither Toom-3 nor Comba unblocks it; NTT would.
+
+10. **A fast quadratic kernel moves the crossovers a long way, so re-tune
+    them together.** After T-M2 the old `CUTOFF_KARATSUBA = 48` cost 27% at
+    11 000 words: schoolbook was still winning at 256 words against a
+    Karatsuba whose leaves were capped at 48. Any change to the base case
+    invalidates every cutoff above it.
 
 ## 5. Open Items
 
@@ -221,16 +227,38 @@ subtractions hold). Against the Karatsuba path:
 `CUTOFF_TOOM3 = 384`. The crossover is soft, not sharp — Toom-3 loses a few
 percent from ~260 to ~320 words — and 384 is just above that band.
 
-This puts `BigInt` ahead of CPython `int` on the two ops that dominate large
-work. At 100 000 decimal digits: multiply 6.0 ms vs 9.4, floor_divide 16.1 ms
-vs 19.4. CPython still wins to_string, 18.6 ms vs 21.0 (T-T1).
+With T-M2 and T-M3 on top, `BigInt` is ahead of CPython `int` on every large
+op. At 100 000 decimal digits (decimo / CPython, ms):
 
-**T-M2 — SIMD partial-product accumulation** in the schoolbook base case
-(NEON 4×UInt32), which is the base for Karatsuba and Toom-3 alike. Now the
-highest-value multiply item left: with Toom-3 in place, essentially all the
-arithmetic still bottoms out in ≤48-word schoolbook leaves. This is the
-base-2^32 analogue of the BigDecimal multiply win; the base-10^9 Comba trick
-itself does not transfer (Lesson 2).
+| op           | decimo | CPython | ratio |
+| ------------ | ------ | ------- | ----- |
+| multiply     |   3.44 |    9.37 | 2.7×  |
+| floor_divide |   9.20 |   19.35 | 2.1×  |
+| to_string    |  13.12 |   18.56 | 1.4×  |
+| from_string  |   5.07 |    9.32 | 1.8×  |
+
+At 1 000 digits multiply is 2.9× and divide is at parity; `to_string` and
+`from_string` are still behind below ~10 000 digits (T-T1, T-F1).
+
+**T-M2 — product-scanning schoolbook base case. DONE (2026-08-24).** Not the
+SIMD form originally planned. The old kernel was operand-scanning: it read and
+wrote the result array on every one of the `n_x · n_y` partial products and
+carried serially along each row. Comba walks the result one word at a time and
+sums the whole column `sum(a[i]·b[k-i])` in a `UInt128` before emitting a word,
+so the column stays in registers and there is no carry chain. Unrolled over
+four accumulators, because one serialises on the 128-bit add.
+
+| words | operand-scanning | Comba ×1 | Comba ×4 |
+| ----- | ---------------- | -------- | -------- |
+| 8     | 71 ns            | 57       | 57       |
+| 16    | 154              | 114      | 108      |
+| 48    | 1 074            | 701      | 520      |
+| 64    | 1 989            | 1 298    | 848      |
+
+**T-M3 — re-tune the cutoffs. DONE (2026-08-24).** A quadratic kernel at well
+under a cycle per partial product moves both crossovers a long way up:
+`CUTOFF_KARATSUBA` 48 → 128, `CUTOFF_TOOM3` 384 → 512. At 11 000 words the
+dispatcher went 4 754 → 3 743 µs on the cutoffs alone.
 
 ### power (2.1× py) and add (1.5× py)
 
@@ -319,7 +347,8 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-D3  | Re-tune `CUTOFF_BURNIKEL_ZIEGLER`                | OPEN — pair with the BigUInt todo     |
 | T-T1  | Lower to_string D&C entry threshold              | OPEN — after T-D1 / T-D2              |
 | T-M1  | Toom-3 multiply above 384 words                  | DONE 2026-08-24                       |
-| T-M2  | SIMD partial-product accumulation in school base | OPEN — now the top multiply item      |
+| T-M2  | Product-scanning (Comba) schoolbook base case    | DONE 2026-08-24 — ~2× at the cutoff   |
+| T-M3  | Re-tune `CUTOFF_KARATSUBA` / `CUTOFF_TOOM3`      | DONE 2026-08-24 — 48→128, 384→512     |
 | T-P1  | `square()` plus inplace loop for power           | OPEN                                  |
 | T-A1  | add/sub dispatch reorder                         | OPEN                                  |
 | T-SH1 | Pre-size the shift result buffer                 | OPEN                                  |

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -319,9 +319,9 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     # discarded. Three multiplications at the top instead of four.
     var mid = iterations // 2
     var left = chudnovsky_split(0, mid)
-    var right = chudnovsky_split(mid, iterations)
-    var series_q = left.q * right.q
-    var series_t = left.t * right.q + left.p * right.t
+    var right = _chudnovsky_split_dropping_p(mid, iterations)
+    var series_q = left.q * right[0]
+    var series_t = left.t * right[0] + left.p * right[1]
 
     # Trim both operands to the digits that will actually survive.
     #
@@ -419,6 +419,40 @@ def _bigint_from_uint128(value: UInt128, sign: Bool) -> BigInt:
     if len(words) == 0:
         words.append(UInt32(0))
     return BigInt(raw_words=words^, sign=sign)
+
+
+def _chudnovsky_split_dropping_p(
+    a: Int, b: Int
+) raises -> Tuple[BigInt, BigInt]:
+    """Binary splitting over `[a, b)`, returning only `Q` and `T`.
+
+    The root of the evaluation reads `left.p`, `left.q`, `left.t`, `right.q`
+    and `right.t` - never `right.p`. Letting the right subtree build it anyway
+    costs one multiplication of two half-width operands, which at 100 000
+    digits is around 1.3 ms.
+
+    Args:
+        a: The start index of the splitting range (inclusive).
+        b: The end index of the splitting range (exclusive).
+
+    Returns:
+        `(Q, T)` over `[a, b)`.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
+    """
+    if b - a <= 1:
+        # A single leaf is a handful of words; copying it out is free, and
+        # moving a field out of the struct would leave it undestroyable.
+        var leaf = chudnovsky_split(a, b)
+        return (leaf.q.copy(), leaf.t.copy())
+
+    var mid = (a + b) // 2
+    var left = chudnovsky_split(a, mid)
+    var right = chudnovsky_split(mid, b)
+    var q = left.q * right.q
+    var t = left.t * right.q + left.p * right.t
+    return (q^, t^)
 
 
 def chudnovsky_split(a: Int, b: Int) raises -> _ChudnovskyPartialSum:

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -43,7 +43,11 @@ from decimo.errors import ValueError, ZeroDivisionError
 
 # Karatsuba cutoff: operands with this many words or fewer use schoolbook.
 # Tuned for Apple Silicon arm64. Adjust if benchmarking shows a better value.
-comptime CUTOFF_KARATSUBA: Int = 48
+# Raised from 48 when the schoolbook base case became product-scanning: a
+# Comba column runs at well under a cycle per partial product, which pushes
+# the point where Karatsuba's three sub-products and its extra additions and
+# allocations start to pay well past where it used to be.
+comptime CUTOFF_KARATSUBA: Int = 128
 """The minimum number of words above which Karatsuba multiplication is used."""
 
 # Toom-3 cutoff: operands with this many words or fewer use Karatsuba.
@@ -53,12 +57,11 @@ comptime CUTOFF_KARATSUBA: Int = 48
 # and interpolation step. The extra additions, the two exact divisions and
 # the five sub-results only pay for themselves once the operands are large.
 #
-# The crossover is soft rather than sharp: measured on Apple Silicon arm64,
-# Toom-3 loses a few percent between roughly 260 and 320 words, breaks even
-# by 350, and is ahead by 15% at 400 words, 25% at 5 000 and 50% at 22 000.
-# 384 sits just above the band where it loses. Adjust if benchmarking on
-# another target shows a better value.
-comptime CUTOFF_TOOM3: Int = 384
+# The crossover is soft rather than sharp, and it moved up with the Karatsuba
+# cutoff for the same reason. Measured on Apple Silicon arm64 with the tuned
+# base case, 512 is the best of 384 / 512 / 768 / 1024 across 512 to 11 000
+# words. Adjust if benchmarking on another target shows a better value.
+comptime CUTOFF_TOOM3: Int = 512
 """The minimum number of words above which Toom-3 multiplication is used."""
 
 # Burnikel-Ziegler cutoff: divisors with this many words or fewer use
@@ -263,10 +266,20 @@ def _multiply_magnitude_by_word(
 def _multiply_magnitudes_schoolbook(
     a: ImmSpan[UInt32, _], b: ImmSpan[UInt32, _]
 ) -> List[UInt32]:
-    """Schoolbook multiplication on magnitude slices.
+    """Product-scanning (Comba) multiplication on magnitude slices.
 
-    Operates on borrowed views of the operands without copying the input
-    data. Uses UInt64 for intermediate products.
+    Walks the result one word at a time, summing the whole column
+    `sum(a[i] * b[k-i])` into a `UInt128` before emitting a word. Each product
+    is below 2^64 and the column has at most `2^64` terms, so the accumulator
+    cannot overflow and no carry has to be propagated back through the result.
+
+    Against the operand-scanning form this replaces, that removes the
+    read-modify-write of the result array on every partial product and the
+    serial carry chain along each row: about 2x at the Karatsuba cutoff. The
+    column is unrolled over four independent accumulators because a single one
+    serialises on the 128-bit add.
+
+    Operates on borrowed views of the operands without copying the input data.
 
     Args:
         a: First magnitude.
@@ -282,34 +295,61 @@ def _multiply_magnitudes_schoolbook(
         var zero: List[UInt32] = [UInt32(0)]
         return zero^
 
-    # Allocate and zero-initialize result
     var result_len = len_a + len_b
     var result = List[UInt32](capacity=result_len)
     result.resize(unsafe_uninit_length=result_len)
-    unsafe_memset_zero(ptr=result._data, count=result_len)
 
-    for i in range(len_a):
-        var ai = UInt64(a[i])
-        if ai == 0:
-            continue
-        var carry: UInt64 = 0
-        var rp = result._data.unsafe_offset(i)
-        var bp = b.unsafe_ptr()
-        for j in range(len_b):
-            var product = (
-                ai * UInt64(bp[unsafe_offset=j])
-                + UInt64(rp[unsafe_offset=j])
-                + carry
+    var ap = a.unsafe_ptr()
+    var bp = b.unsafe_ptr()
+    var rp = result._data
+
+    # `carry` is the part of the column sum above 32 bits, which belongs to
+    # the next column. The last column leaves it holding the top word.
+    var carry = UInt128(0)
+    for k in range(result_len - 1):
+        var i_low = 0 if k < len_b else k - len_b + 1
+        var i_high = k if k < len_a else len_a - 1
+
+        var acc0 = carry
+        var acc1 = UInt128(0)
+        var acc2 = UInt128(0)
+        var acc3 = UInt128(0)
+
+        var i = i_low
+        while i + 3 <= i_high:
+            acc0 += UInt128(
+                UInt64(ap[unsafe_offset=i]) * UInt64(bp[unsafe_offset=k - i])
             )
-            rp[unsafe_offset=j] = UInt32(product & 0xFFFF_FFFF)
-            carry = product >> 32
-        if carry > 0:
-            rp[unsafe_offset=len_b] = UInt32(carry)
+            acc1 += UInt128(
+                UInt64(ap[unsafe_offset=i + 1])
+                * UInt64(bp[unsafe_offset=k - i - 1])
+            )
+            acc2 += UInt128(
+                UInt64(ap[unsafe_offset=i + 2])
+                * UInt64(bp[unsafe_offset=k - i - 2])
+            )
+            acc3 += UInt128(
+                UInt64(ap[unsafe_offset=i + 3])
+                * UInt64(bp[unsafe_offset=k - i - 3])
+            )
+            i += 4
+        while i <= i_high:
+            acc0 += UInt128(
+                UInt64(ap[unsafe_offset=i]) * UInt64(bp[unsafe_offset=k - i])
+            )
+            i += 1
+
+        var column = (acc0 + acc1) + (acc2 + acc3)
+        rp[unsafe_offset=k] = UInt32(column & 0xFFFF_FFFF)
+        carry = column >> 32
+
+    rp[unsafe_offset=result_len - 1] = UInt32(carry & 0xFFFF_FFFF)
 
     # Strip leading zeros
-    while result_len > 1 and result[result_len - 1] == 0:
-        result_len -= 1
-    while len(result) > result_len:
+    var rlen = result_len
+    while rlen > 1 and result[rlen - 1] == 0:
+        rlen -= 1
+    while len(result) > rlen:
         result.shrink(len(result) - 1)
 
     return result^
@@ -517,8 +557,13 @@ def _multiply_magnitudes_toom3(
 
     Five sub-multiplications on third-length operands instead of Karatsuba's
     three on half-length ones: `O(n^log_3(5))` = `O(n^1.465)` against
-    `O(n^1.585)`. Falls back to Karatsuba below `CUTOFF_TOOM3`, and for very
-    lopsided operands, where Karatsuba's one-sided split is the better shape.
+    `O(n^1.585)`. Falls back to Karatsuba when the longer operand is at or
+    below `CUTOFF_TOOM3`, or the shorter one is at or below
+    `CUTOFF_KARATSUBA` - the second is the guard against lopsided pairs,
+    where a three-way split of the long operand leaves the short one with
+    empty limbs and Karatsuba's one-sided split is the better shape. Pairs
+    that are lopsided but still have both operands above their cutoff do run
+    here.
 
     Only `a(-1)` and `b(-1)` can be negative, so a single sign flag on each
     stands in for signed arithmetic; every other intermediate, including all
@@ -691,7 +736,15 @@ def _multiply_magnitudes_toom3(
     _add_at_offset_inplace(result, t1, m)  # w1
     _add_at_offset_inplace(result, w2, 2 * m)
     _add_at_offset_inplace(result, t3, 3 * m)  # w3
-    _add_at_offset_inplace(result, v_inf, 4 * m)
+
+    # `w4` is the one coefficient whose offset is not covered by the argument
+    # above. A zero `BigInt` magnitude is one zero word, not an empty list, so
+    # an empty high limb still presents a length-1 value to add at `4 * m` -
+    # and for a lopsided pair `4 * m` can be past the end of `result`
+    # (`len_a = 513`, `len_b = 129` gives `4 * m = 684` against 642 words).
+    # Adding zero changes nothing, so skip it.
+    if not (len(v_inf) == 1 and v_inf[0] == 0):
+        _add_at_offset_inplace(result, v_inf, 4 * m)
 
     _strip_leading_zeros_inplace(result)
     return result^
@@ -827,9 +880,14 @@ def _add_at_offset_inplace(
     Args:
         a: The accumulator magnitude (modified in-place).
         b: The magnitude to add.
-        offset: Word offset at which to start adding b into a.
+        offset: Word offset at which to start adding b into a. `offset +
+            len(b)` must not exceed `len(a)`: the loop below is unchecked.
     """
     var len_b = len(b)
+    debug_assert(
+        offset + len_b <= len(a),
+        "_add_at_offset_inplace(): writes past the end of the accumulator",
+    )
     var carry: UInt64 = 0
     var ap = a._data.unsafe_offset(offset)
     var bp = b._data
@@ -1441,15 +1499,24 @@ def _divmod_knuth_d_from_slices(
     var v_n_minus_1 = UInt64(b[n - 1])
     var v_n_minus_2 = UInt64(b[n - 2]) if n >= 2 else UInt64(0)
 
-    # Knuth D main loop
+    # Knuth D main loop.
+    #
+    # Every index below is provably in bounds, so none of them is checked:
+    # `u` was grown to `m + n + 1` words above, `j` runs down from `m`, and
+    # `i` stays under `n`, so `j + i <= m + n - 1` and `j + n <= m + n`. The
+    # single-word divisor was handled earlier, so `n >= 2` and `j + n - 2`
+    # cannot go negative either. The three buffers are borrowed through raw
+    # pointers for the same reason the multiply kernels are: a `List[i]` reads
+    # the list's `_data` field again on every element (Lesson 7). None of them
+    # is resized while these pointers are live.
+    var u_ptr = u._data
+    var b_ptr = b.unsafe_ptr()
+    var quotient_ptr = quotient._data
+
     for j in range(m, -1, -1):
-        var u_jn = UInt64(u[j + n]) if (j + n) < len(u) else UInt64(0)
-        var u_jn_minus_1 = UInt64(u[j + n - 1]) if (j + n - 1) < len(
-            u
-        ) else UInt64(0)
-        var u_jn_minus_2 = UInt64(u[j + n - 2]) if (j + n - 2) < len(
-            u
-        ) else UInt64(0)
+        var u_jn = UInt64(u_ptr[unsafe_offset=j + n])
+        var u_jn_minus_1 = UInt64(u_ptr[unsafe_offset=j + n - 1])
+        var u_jn_minus_2 = UInt64(u_ptr[unsafe_offset=j + n - 2])
 
         var two_digits = (u_jn << 32) + u_jn_minus_1
         var q_hat = two_digits // v_n_minus_1
@@ -1466,39 +1533,49 @@ def _divmod_knuth_d_from_slices(
             if r_hat >= BigInt.BASE:
                 break
 
-        # Multiply and subtract: u[j..j+n] -= q_hat * v[0..n-1]
+        # Multiply and subtract: u[j..j+n] -= q_hat * v[0..n-1].
+        #
+        # The borrow is branchless. Biasing the difference by 2^32 keeps it
+        # non-negative, so bit 32 of the result is the complement of the
+        # borrow, and folding that borrow into the product carry is exactly
+        # what the branchy form did one word later.
         var carry: UInt64 = 0
         for i in range(n):
-            var prod = q_hat * UInt64(b[i]) + carry
-            var prod_lo = UInt32(prod & 0xFFFF_FFFF)
-            carry = prod >> 32
-            var idx = j + i
-            if idx < len(u):
-                if UInt64(u[idx]) >= UInt64(prod_lo):
-                    u[idx] = UInt32(UInt64(u[idx]) - UInt64(prod_lo))
-                else:
-                    u[idx] = UInt32(
-                        BigInt.BASE + UInt64(u[idx]) - UInt64(prod_lo)
-                    )
-                    carry += 1
+            var product = q_hat * UInt64(b_ptr[unsafe_offset=i]) + carry
+            carry = product >> 32
+            var biased = (
+                UInt64(u_ptr[unsafe_offset=j + i])
+                + 0x1_0000_0000
+                - (product & 0xFFFF_FFFF)
+            )
+            u_ptr[unsafe_offset=j + i] = UInt32(biased & 0xFFFF_FFFF)
+            carry += 1 - (biased >> 32)
 
         var jn = j + n
-        if jn < len(u):
-            if UInt64(u[jn]) >= carry:
-                u[jn] = UInt32(UInt64(u[jn]) - carry)
-            else:
-                u[jn] = UInt32(BigInt.BASE + UInt64(u[jn]) - carry)
-                q_hat -= 1
-                # Add back: u[j..j+n-1] += v
-                var add_carry: UInt64 = 0
-                for i in range(n):
-                    var s = UInt64(u[j + i]) + UInt64(b[i]) + add_carry
-                    u[j + i] = UInt32(s & 0xFFFF_FFFF)
-                    add_carry = s >> 32
-                if jn < len(u):
-                    u[jn] = UInt32(UInt64(u[jn]) + add_carry)
+        if UInt64(u_ptr[unsafe_offset=jn]) >= carry:
+            u_ptr[unsafe_offset=jn] = UInt32(
+                UInt64(u_ptr[unsafe_offset=jn]) - carry
+            )
+        else:
+            u_ptr[unsafe_offset=jn] = UInt32(
+                BigInt.BASE + UInt64(u_ptr[unsafe_offset=jn]) - carry
+            )
+            q_hat -= 1
+            # Add back: u[j..j+n-1] += v
+            var add_carry: UInt64 = 0
+            for i in range(n):
+                var total = (
+                    UInt64(u_ptr[unsafe_offset=j + i])
+                    + UInt64(b_ptr[unsafe_offset=i])
+                    + add_carry
+                )
+                u_ptr[unsafe_offset=j + i] = UInt32(total & 0xFFFF_FFFF)
+                add_carry = total >> 32
+            u_ptr[unsafe_offset=jn] = UInt32(
+                UInt64(u_ptr[unsafe_offset=jn]) + add_carry
+            )
 
-        quotient[j] = UInt32(q_hat)
+        quotient_ptr[unsafe_offset=j] = UInt32(q_hat)
 
     # Extract remainder: first n words of u (no shift needed)
     while len(u) > n:

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -2107,7 +2107,11 @@ def _multiply_add_inplace(mut x: BigInt, mul: UInt32, add: UInt32):
 # that the O(n²) simple method is significantly slower than the O(M(n)·log n)
 # D&C method despite the power-table construction overhead.
 # Base threshold: within the recursion, switch to simple method.
-comptime _DC_FROM_STR_ENTRY_THRESHOLD = 10000
+# Entry lowered from 10000 to 2000 in 2026-08 when the multiply kernels became
+# product-scanning: D&C spends its time multiplying and the simple method does
+# not, so the crossover moved down with them. At 8 000 digits that is 0.18 ms
+# -> 0.11 ms, and nothing above or below regresses.
+comptime _DC_FROM_STR_ENTRY_THRESHOLD = 2000
 comptime _DC_FROM_STR_BASE_THRESHOLD = 256
 
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -31,30 +31,21 @@ from decimo.errors import (
 )
 from decimo.rounding_mode import RoundingMode
 
-comptime CUTOFF_KARATSUBA = 64
-"""The cutoff number of words for using Karatsuba multiplication."""
-comptime CUTOFF_TOOM3 = 256
+comptime CUTOFF_KARATSUBA = 256
+"""The cutoff number of words for using Karatsuba multiplication.
+
+Raised from 64 when the schoolbook base case became product-scanning. A Comba
+column reduces base-10^9 once per result word instead of once per partial
+product, which makes the quadratic kernel fast enough that Karatsuba's extra
+`BigUInt` allocations and additions do not pay until much later.
+"""
+comptime CUTOFF_TOOM3 = 768
 """The cutoff number of words for using Toom-3 multiplication.
 
 NOTE: Karatsuba is used for `CUTOFF_KARATSUBA < max_words <= CUTOFF_TOOM3`.
 """
 comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 """The cutoff number of words for using Burnikel-Ziegler division."""
-comptime CUTOFF_DEFERRED_CARRY_PRODUCT = 200
-"""Threshold for switching the schoolbook inner loop to deferred-carry
-accumulation.
-
-NOTE: unlike `CUTOFF_KARATSUBA` / `CUTOFF_TOOM3`, which are
-word counts, this is a product `n_words_x * n_words_y` (the number of
-single-word partial products). It is therefore reached *within* the schoolbook
-range (`max_words <= CUTOFF_KARATSUBA` = 64): two ~15-word operands give a
-product of 225 >= 200, and a 64x64 multiply gives 4096. So the deferred-carry
-path runs for the ~15-64 word band directly and for the Karatsuba / Toom-3
-recursion base cases (whose sub-multiplies are <= 64 words). Below this product
-the per-step-carry loop is faster (the accumulator + final-normalization
-overhead dominates).
-"""
-
 # ===----------------------------------------------------------------------=== #
 # List of functions in this module:
 #
@@ -1009,178 +1000,76 @@ def multiply_slices_schoolbook(
             multiply_by_uint32_inplace(result, y_word)
             return result^
 
-    # Deferred-carry multiply for larger slices: accumulate column
-    # sums in a UInt64 buffer and normalize the base-10^9 carry only
-    # periodically, doing ~8x fewer div/mods than the per-step-carry loop
-    # below. The gate is a PRODUCT (n_x * n_y), not a word count, so it is
-    # reached for both operands >= ~15 words (within the <=64-word schoolbook
-    # range) and for the Karatsuba/Toom-3 recursion base cases. Below the
-    # crossover the buffer + final-normalization overhead loses.
-    if n_words_x_slice * n_words_y_slice >= CUTOFF_DEFERRED_CARRY_PRODUCT:
-        return multiply_slices_deferred_carry(x, y, bounds_x, bounds_y)
-
-    # The max number of words in the result is the sum of the words in the operands
-    var max_result_len = n_words_x_slice + n_words_y_slice
-    # Allocate the result of zero words with the maximum length
-    # The leading zeros need to be removed before returning the result
-    var result = BigUInt(unsafe_uninit_length=max_result_len)
-    unsafe_memset_zero(ptr=result.words._data, count=max_result_len)
-
-    # Perform the multiplication word by word (from least significant to most significant)
-    # x = x[start_x] + x[start_x + 1] * 10^9
-    # y = y[start_y] + y[start_y + 1] * 10^9
-    # x * y = x[start_x] * y[start_y]
-    #       + (x[start_x] * y[start_y + 1]
-    #       + x[start_x + 1] * y[start_y]) * 10^9
-    #       + x[start_x + 1] * y[start_y + 1] * 10^18
-    var carry: UInt64
-    for i in range(n_words_x_slice):
-        # Skip if the word is zero
-        if x.words[bounds_x[0] + i] == 0:
-            continue
-
-        carry = UInt64(0)
-
-        for j in range(n_words_y_slice):
-            # Calculate the product of the current words
-            # plus the carry from the previous multiplication
-            # plus the value already at this position in the result
-            var product = (
-                UInt64(x.words[bounds_x[0] + i])
-                * UInt64(y.words[bounds_y[0] + j])
-                + carry
-                + UInt64(result.words[i + j])
-            )
-
-            # The lower 9 digits (base 10^9) go into the current word
-            # The upper digits become the carry for the next position
-            result.words[i + j] = UInt32(product % UInt64(BigUInt.BASE))
-            carry = product // UInt64(BigUInt.BASE)
-
-        # If there is a carry left, add it to the next position
-        if carry > 0:
-            result.words[i + n_words_y_slice] += UInt32(carry)
-
-    result.remove_leading_empty_words()
-    return result^
-
-
-def multiply_slices_deferred_carry(
-    imm x: BigUInt,
-    imm y: BigUInt,
-    bounds_x: Tuple[Int, Int],
-    bounds_y: Tuple[Int, Int],
-) -> BigUInt:
-    """Multiplies two BigUInt slices using deferred-carry accumulation.
-
-    Args:
-        x: The first BigUInt operand (multiplicand).
-        y: The second BigUInt operand (multiplier).
-        bounds_x: A tuple containing the start and end indices of the slice in x.
-        bounds_y: A tuple containing the start and end indices of the slice in y.
-
-    Returns:
-        The product of the two BigUInt slices.
-
-    Notes:
-
-    Unlike `multiply_slices_schoolbook`, which performs a base-10^9 carry
-    normalization (`% BASE` and `// BASE`) on every inner-loop step
-    (`n_x * n_y` divisions), this accumulates each partial product into a
-    `UInt64` column buffer and normalizes only every `SAFE_ROWS` rows, plus
-    once at the end. That reduces the division count to roughly
-    `n_x * n_y / SAFE_ROWS`, which dominates the runtime for larger slices.
-
-    This is the deferred-carry / column-accumulation idea behind
-    product-scanning multiplication (also known in the literature as "Comba
-    multiplication"): P. G. Comba, "Exponentiation cribs", IBM Systems
-    Journal 29(4), 1990, pp. 526-538; see also Koc, Acar & Kaliski,
-    "Analyzing and comparing Montgomery multiplication algorithms", IEEE
-    Micro 16(3), 1996, for the operand-scanning vs product-scanning contrast.
-    Here the accumulator is a base-10^9 `UInt64` column buffer rather than a
-    binary one, and carries are deferred in batches of `SAFE_ROWS` rows for
-    overflow safety.
-
-    Overflow safety: each partial product `x_i * y_j` is `< (10^9)^2 = 10^18`,
-    and at most `SAFE_ROWS = 15` rows accumulate into any column between
-    normalizations, so each accumulator stays below `15 * 10^18 < 2^64 - 1`.
-    Caller (`multiply_slices_schoolbook`) only routes here above the benchmarked
-    product crossover, and never with a single-word slice.
-    """
-    var start_x = bounds_x[0]
-    var start_y = bounds_y[0]
-    var n_words_x_slice = bounds_x[1] - start_x
-    var n_words_y_slice = bounds_y[1] - start_y
-
-    comptime SAFE_ROWS = 15
-    comptime BASE = UInt64(BigUInt.BASE)
+    # Product scanning (Comba): walk the result one word at a time, summing
+    # the whole column `sum(x_i * y_j)` with `i + j == k` in a `UInt128`
+    # accumulator before emitting a word.
+    #
+    # The operand-scanning form this replaces did a `% BASE` and a `// BASE`
+    # on every one of the `n_x * n_y` partial products, and read and wrote the
+    # result array on each of them too. Here the base-10^9 reduction happens
+    # once per result word - `n_x + n_y` of them, not `n_x * n_y` - and the
+    # column stays in registers. About 2.2x at 256 words, and ahead from two
+    # words up, so there is no size gate any more.
+    #
+    # Overflow safety: each partial product is below `(10^9)^2 = 10^18 < 2^60`
+    # and a column has at most `n_min` of them, so a `UInt128` accumulator
+    # cannot overflow for any operand this library can allocate. The column is
+    # unrolled over four independent accumulators because a single one
+    # serialises on the 128-bit add.
+    comptime BASE = UInt128(BigUInt.BASE)
 
     var result_length = n_words_x_slice + n_words_y_slice
+    var result = BigUInt(unsafe_uninit_length=result_length)
 
-    # Column accumulator: `column_sums[k]` holds the running sum of every
-    # partial product `x_i * y_j` with `i + j == k`, before the base-10^9
-    # carries are propagated.
-    #
-    # The inner multiply loop is O(n^2). I use raw data pointer for each
-    # of the three buffers it touches and index through those, so the compiler
-    # keeps each buffer's base address in a register for the whole loop instead
-    # reload that List's `_data` field on every element access. That
-    # reload is the bottleneck in the indexed form (measured ~8% slower at
-    # 64-word operands under `-D ASSERT=none`).
-    #
-    # Memory safety: the three buffers all outlive this loop and are never
-    # resized inside it. `x` / `y` are borrowed (`imm`, owned by the caller),
-    # and `column_sums` is only element-mutated (never appended). `List.
-    # unsafe_ptr()` returns an origin-parameterized `UnsafePointer` tied to the
-    # List's origin, so Mojo's lifetime tracking keeps `column_sums` alive for
-    # as long as `column_sums_ptr` is used (including the final pass below).
-    # Every index is provably in-bounds:
-    # `start_x + i < bounds_x[1] <= len(x.words)`,
-    # `start_y + j < bounds_y[1] <= len(y.words)`, and the column index
-    # `i + j < result_length` (likewise the carry index `k`).
-    var column_sums = List[UInt64](length=result_length, fill=0)
-    var column_sums_ptr = column_sums.unsafe_ptr()
+    var start_x = bounds_x[0]
+    var start_y = bounds_y[0]
     var x_words_ptr = x.words.unsafe_ptr()
     var y_words_ptr = y.words.unsafe_ptr()
+    var result_ptr = result.words.unsafe_ptr()
 
-    var rows_since_normalization = 0
-    var highest_column = 0  # highest accumulator index touched + 1
+    # `carry` is the part of the column sum at or above 10^9, which belongs to
+    # the next column. The last column leaves it holding the top word.
+    var carry = UInt128(0)
+    for k in range(result_length - 1):
+        var i_low = 0 if k < n_words_y_slice else k - n_words_y_slice + 1
+        var i_high = k if k < n_words_x_slice else n_words_x_slice - 1
 
-    for i in range(n_words_x_slice):
-        var x_word = UInt64(x_words_ptr[unsafe_offset=start_x + i])
-        if x_word == 0:
-            continue
-        for j in range(n_words_y_slice):
-            column_sums_ptr[unsafe_offset=i + j] += x_word * UInt64(
-                y_words_ptr[unsafe_offset=start_y + j]
+        var acc0 = carry
+        var acc1 = UInt128(0)
+        var acc2 = UInt128(0)
+        var acc3 = UInt128(0)
+
+        var i = i_low
+        while i + 3 <= i_high:
+            acc0 += UInt128(
+                UInt64(x_words_ptr[unsafe_offset=start_x + i])
+                * UInt64(y_words_ptr[unsafe_offset=start_y + k - i])
             )
-        if i + n_words_y_slice > highest_column:
-            highest_column = i + n_words_y_slice
-        rows_since_normalization += 1
-        if rows_since_normalization == SAFE_ROWS:
-            # Propagate base-10^9 carries across the touched range.
-            var carry: UInt64 = 0
-            for k in range(highest_column):
-                var column_value = column_sums_ptr[unsafe_offset=k] + carry
-                column_sums_ptr[unsafe_offset=k] = column_value % BASE
-                carry = column_value // BASE
-            var k = highest_column
-            while carry > 0:
-                var column_value = column_sums_ptr[unsafe_offset=k] + carry
-                column_sums_ptr[unsafe_offset=k] = column_value % BASE
-                carry = column_value // BASE
-                k += 1
-                if k > highest_column:
-                    highest_column = k
-            rows_since_normalization = 0
+            acc1 += UInt128(
+                UInt64(x_words_ptr[unsafe_offset=start_x + i + 1])
+                * UInt64(y_words_ptr[unsafe_offset=start_y + k - i - 1])
+            )
+            acc2 += UInt128(
+                UInt64(x_words_ptr[unsafe_offset=start_x + i + 2])
+                * UInt64(y_words_ptr[unsafe_offset=start_y + k - i - 2])
+            )
+            acc3 += UInt128(
+                UInt64(x_words_ptr[unsafe_offset=start_x + i + 3])
+                * UInt64(y_words_ptr[unsafe_offset=start_y + k - i - 3])
+            )
+            i += 4
+        while i <= i_high:
+            acc0 += UInt128(
+                UInt64(x_words_ptr[unsafe_offset=start_x + i])
+                * UInt64(y_words_ptr[unsafe_offset=start_y + k - i])
+            )
+            i += 1
 
-    # Final normalization into base-10^9 result words.
-    var result = BigUInt(uninitialized_capacity=result_length)
-    var carry: UInt64 = 0
-    for k in range(result_length):
-        var column_value = column_sums_ptr[unsafe_offset=k] + carry
-        result.words.append(UInt32(column_value % BASE))
-        carry = column_value // BASE
+        var column = (acc0 + acc1) + (acc2 + acc3)
+        result_ptr[unsafe_offset=k] = UInt32(column % BASE)
+        carry = column // BASE
+
+    result_ptr[unsafe_offset=result_length - 1] = UInt32(carry % BASE)
 
     result.remove_leading_empty_words()
     return result^
@@ -2270,46 +2159,91 @@ def floor_divide_schoolbook(x: BigUInt, y: BigUInt) raises -> BigUInt:
 
     # ===----------------------------------------------=== #
     # ALL OTHER CASES
-    # Use the schoolbook division algorithm
-    # Initialize result and remainder
-    var result = BigUInt(uninitialized_capacity=len(x.words))
-    var remainder = x.copy()
+    # Schoolbook division, Knuth D style: each quotient word is estimated from
+    # the top three words of the running remainder and then subtracted in a
+    # single fused multiply-subtract over the `n + 1` word window it affects.
+    #
+    # The older form built `q * y` as a fresh `BigUInt`, shifted it up by
+    # `index_of_word` words, compared it against the whole remainder and
+    # subtracted it from the whole remainder. That is four passes over the
+    # full dividend, plus an allocation, for every quotient word - which made
+    # the routine cost `O(m * (n + m))` with a large constant instead of
+    # `O(m * n)` with a small one. Windowing it was worth 2-4x, most of it in
+    # the 100 to 1 000 digit band.
+    comptime BASE = UInt64(BigUInt.BASE)
 
-    # Shift and initialize
-    var n_words_diff = len(remainder.words) - len(y.words)
-    # The quotient will have at most n_words_diff + 1 words
+    var n = len(y.words)
+    var n_words_diff = len(x.words) - n
+
+    var result = BigUInt(uninitialized_capacity=n_words_diff + 1)
     for _ in range(n_words_diff + 1):
         result.words.append(0)
 
-    # Main division loop
-    var index_of_word = n_words_diff  # Start from the most significant word
-    var trial_product: BigUInt
-    var quotient: UInt32
-    while index_of_word >= 0:
-        # OPTIMIZATION: Better quotient estimation
-        quotient = floor_divide_estimate_quotient(remainder, y, index_of_word)
+    # One guard word above the dividend, so `index_of_word + n` is always a
+    # real position for the fused subtraction to take its final borrow from.
+    var remainder = BigUInt(uninitialized_capacity=len(x.words) + 1)
+    remainder.words = x.words.copy()
+    remainder.words.append(UInt32(0))
 
-        # Calculate trial product
-        trial_product = y.copy()
-        multiply_by_uint32_inplace(trial_product, quotient)
-        multiply_by_power_of_billion_inplace(trial_product, index_of_word)
+    var y_ptr = y.words.unsafe_ptr()
+    var r_ptr = remainder.words.unsafe_ptr()
 
-        # By construction, no correction is needed
-        # Add correction attempts counter to avoid infinite loop
+    for index_of_word in range(n_words_diff, -1, -1):
+        var quotient = floor_divide_estimate_quotient(
+            remainder, y, index_of_word
+        )
+
+        # remainder[index .. index + n) -= quotient * y.
+        #
+        # `carry` carries both halves of the step: the high word of the
+        # product, and the borrow, which is folded into it exactly one word
+        # later - the same trick the base-2^32 Knuth D uses. Biasing the
+        # difference by BASE keeps it non-negative, so the borrow is just
+        # whether the biased value stayed below BASE.
+        var carry = UInt64(0)
+        for i in range(n):
+            var product = (
+                UInt64(quotient) * UInt64(y_ptr[unsafe_offset=i]) + carry
+            )
+            carry = product // BASE
+            var biased = (
+                UInt64(r_ptr[unsafe_offset=index_of_word + i])
+                + BASE
+                - (product % BASE)
+            )
+            r_ptr[unsafe_offset=index_of_word + i] = UInt32(biased % BASE)
+            carry += 1 - biased // BASE
+
+        # The estimate can be one or two too large. Each add-back returns the
+        # divisor to the window and buys back one unit of the quotient.
+        var top = index_of_word + n
+        var top_value = UInt64(r_ptr[unsafe_offset=top])
         var correction_attempts = 0
-        while (trial_product.compare(remainder) > 0) and (quotient > 0):
+        while top_value < carry:
             quotient -= 1
             correction_attempts += 1
-            trial_product -= multiply_by_power_of_billion(y, index_of_word)
             debug_assert[assert_mode="none"](
                 correction_attempts <= 2, "Too many correction attempts"
             )
+            var add_carry = UInt64(0)
+            for i in range(n):
+                var total = (
+                    UInt64(r_ptr[unsafe_offset=index_of_word + i])
+                    + UInt64(y_ptr[unsafe_offset=i])
+                    + add_carry
+                )
+                if total >= BASE:
+                    r_ptr[unsafe_offset=index_of_word + i] = UInt32(
+                        total - BASE
+                    )
+                    add_carry = 1
+                else:
+                    r_ptr[unsafe_offset=index_of_word + i] = UInt32(total)
+                    add_carry = 0
+            top_value += add_carry
+        r_ptr[unsafe_offset=top] = UInt32(top_value - carry)
 
-        # Store the quotient word
         result.words[index_of_word] = quotient
-        # By construction, trial_product <= remainder
-        subtract_no_check_inplace(remainder, trial_product)
-        index_of_word -= 1
 
     result.remove_leading_empty_words()
     return result^
@@ -2613,38 +2547,36 @@ def floor_divide_by_uint128(x: BigUInt, y: UInt128) -> BigUInt:
         "Division by zero.",
     )
 
-    var carry = UInt256(0)
-    var y_uint255 = UInt256(y)
-    var result: BigUInt
-    if len(x.words) % 4 == 1:
-        carry = UInt256(x.words[len(x.words) - 1])
-        result = BigUInt(unsafe_uninit_length=len(x.words) - 1)
-    elif len(x.words) % 4 == 2:
-        carry = UInt256(
-            (
-                x.words.unsafe_ptr()
-                .unsafe_load[width=2](len(x.words) - 2)
-                .cast[DType.uint64]()
-                * SIMD[DType.uint64, 2](1, 1_000_000_000)
-            ).reduce_add()
-        )
-        result = BigUInt(unsafe_uninit_length=len(x.words) - 2)
-    elif len(x.words) % 4 == 3:
-        carry = UInt256(
-            (
-                x.words.unsafe_ptr()
-                .unsafe_load[width=4](len(x.words) - 3)
-                .cast[DType.uint128]()
-                * SIMD[DType.uint128, 4](
-                    1, 1_000_000_000, 1_000_000_000_000_000_000, 0
-                )
-            ).reduce_add()
-        )
-        result = BigUInt(unsafe_uninit_length=len(x.words) - 3)
-    else:
-        result = BigUInt(unsafe_uninit_length=len(x.words))
+    comptime BILLION = UInt256(1_000_000_000)
 
-    for i in range(len(result.words) - 1, -1, -4):
+    var y_uint255 = UInt256(y)
+    var n_words = len(x.words)
+    var lead_words = n_words % 4
+    var result = BigUInt(unsafe_uninit_length=n_words)
+    var carry = UInt256(0)
+
+    # The dividend is consumed four words at a time, so a word count that is
+    # not a multiple of four leaves a short leading group.
+    #
+    # That group has a quotient of its own, and the previous version of this
+    # function threw it away: it kept only `lead % y` as the carry and sized
+    # the result at `n - lead_words` words. Two things went wrong. A quotient
+    # that needed the dropped words came back too small - `y` of three words
+    # against `x` of seven silently lost the top word, a factor of 10^9. And
+    # when the dividend *was* the leading group, at three words or fewer, the
+    # result was left with no words at all, which faults the first operation
+    # that reads `words[len(words) - 1]`.
+    if lead_words != 0:
+        var lead = UInt256(0)
+        for k in range(n_words - 1, n_words - lead_words - 1, -1):
+            lead = lead * BILLION + UInt256(x.words[k])
+        var lead_quotient = lead // y_uint255
+        carry = lead % y_uint255
+        for k in range(n_words - lead_words, n_words):
+            result.words[k] = UInt32(lead_quotient % BILLION)
+            lead_quotient //= BILLION
+
+    for i in range(n_words - lead_words - 1, -1, -4):
         var dividend = (
             carry * UInt256(1_000_000_000_000_000_000_000_000_000_000_000_000)
             + (

--- a/tests/bigint/test_bigint_large_algorithms.mojo
+++ b/tests/bigint/test_bigint_large_algorithms.mojo
@@ -630,6 +630,52 @@ def test_multiply_toom3_with_zero_limbs() raises:
         )
 
 
+def test_multiply_toom3_lopsided_operands() raises:
+    """Toom-3 stays in bounds when one operand is far shorter than the other.
+
+    A three-way split sizes its limbs by the *longer* operand, so a short
+    second operand can have empty high limbs while `4 * m` — where the `w4`
+    coefficient is recomposed — runs past the end of the result buffer. With
+    `len_a = 513` and `len_b = 129` words, `4 * m` is 684 against a 642-word
+    result. `w4` is zero in exactly those cases, so nothing is *computed*
+    wrongly and a value comparison cannot see it; what catches it is the
+    precondition `debug_assert` in `_add_at_offset_inplace()`, which the suite
+    runs with `-D ASSERT=all`.
+
+    The digit counts below sit either side of `CUTOFF_KARATSUBA` and
+    `CUTOFF_TOOM3` in words, and each pair is checked in both orders so the
+    short operand is exercised as both multiplicand and multiplier.
+    """
+    var long_digits = [4950, 5800, 7400, 9700, 14800]
+    var short_ratios = [4, 3, 2]
+
+    for i in range(len(long_digits)):
+        var na = long_digits[i]
+        var a = BigInt(_bz_digit_run(na, 20260824 + 41 * i))
+        for j in range(len(short_ratios)):
+            var nb = na // short_ratios[j]
+            var b = BigInt(_bz_digit_run(nb, 60504030 + 7 * i + j))
+            var case_label = (
+                String("a=")
+                + String(na)
+                + " digits, b="
+                + String(nb)
+                + " digits"
+            )
+            var forward = a * b
+            var reversed = b * a
+            testing.assert_equal(
+                String(forward),
+                String(reversed),
+                "a * b != b * a for " + case_label,
+            )
+            testing.assert_equal(
+                String(forward),
+                String(_blockwise_product(a, b, 800)),
+                "lopsided product differs from reference for " + case_label,
+            )
+
+
 def test_multiply_toom3_algebraic_identities() raises:
     """Distributivity and the multiply/divide round trip above the cutoff.
 

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -237,6 +237,49 @@ def test_biguint_truncate_divide_random_numbers_against_python() raises:
     # print("BigUInt truncate division tests passed!")
 
 
+def test_biguint_divide_across_the_dispatch_boundaries_against_python() raises:
+    """Cross-checks `//` against Python across every size the dispatch splits on.
+
+    `floor_divide()` picks a different routine for a divisor of one word, two
+    words, three-or-four words, and anything larger, and the three-or-four-word
+    routine additionally behaves differently for each residue of the dividend
+    word count mod four. The two random cross-checks in this file use 2 214
+    digits over 810 and 200 000 over 14 000 — both far above the
+    Burnikel-Ziegler cutoff, so neither ever reaches the small-divisor paths.
+    That is how a three-word divisor could lose a factor of 10^9 for over a
+    year without a red test.
+
+    This walks the divisor from 1 to 40 digits and the dividend from the
+    divisor's length up to 90 digits, which crosses every boundary in the
+    dispatch, and compares against Python at each step.
+    """
+    _set_max_str_digits(500000)
+
+    for divisor_digits in range(1, 41):
+        for dividend_digits in range(divisor_digits, 91, 7):
+            var number_b = _bz_digit_run(divisor_digits, 7 * divisor_digits + 3)
+            var number_a = _bz_digit_run(
+                dividend_digits, 13 * dividend_digits + divisor_digits
+            )
+            var case_label = (
+                String("a=")
+                + String(dividend_digits)
+                + " digits, b="
+                + String(divisor_digits)
+                + " digits"
+            )
+            assert_equal(
+                lhs=String(BigUInt(number_a) // BigUInt(number_b)),
+                rhs=String(Python.int(number_a) // Python.int(number_b)),
+                msg="floor division differs from Python for " + case_label,
+            )
+            assert_equal(
+                lhs=String(BigUInt(number_a) % BigUInt(number_b)),
+                rhs=String(Python.int(number_a) % Python.int(number_b)),
+                msg="modulo differs from Python for " + case_label,
+            )
+
+
 def test_biguint_truncate_divide_huge_random_numbers_against_python() raises:
     # Some two hundred thousand digits over a divisor of some fourteen
     # thousand. The smaller random cases above already clear
@@ -283,6 +326,69 @@ def _bz_digit_run(count: Int, seed: Int) -> String:
         x = (x * 1103515245 + 12345 + j) % 2147483647
         out += String(x % 10)
     return out^
+
+
+def test_biguint_divide_short_operands_of_every_word_count() raises:
+    """`//` and `%` are correct for every small dividend/divisor word count.
+
+    `floor_divide()` routes any divisor of three or four words to
+    `floor_divide_by_uint128()`, which consumes the dividend four words at a
+    time. A dividend whose word count is not a multiple of four leaves a short
+    leading group, and that group's own quotient used to be discarded: a
+    seven-word dividend over a three-word divisor came back a factor of 10^9
+    too small, and a three-word dividend - where the leading group *is* the
+    whole number - produced a `BigUInt` with no words at all, which faults the
+    next operation that reads `words[len(words) - 1]`.
+
+    Neither shape is exotic: `23334504672441144935 // 1854056525350022197`
+    crashed. The sweep below walks every dividend length from one to nine
+    words against every divisor length from one to five, which covers all four
+    residues of the group size, and pins each result with `q * b + r == a`
+    and `0 <= r < b`.
+    """
+    for divisor_words in range(1, 6):
+        for dividend_words in range(1, 10):
+            if dividend_words < divisor_words:
+                continue
+            var b = BigUInt(
+                _bz_digit_run(9 * divisor_words, 30 * divisor_words + 7)
+            )
+            var a = BigUInt(
+                _bz_digit_run(
+                    9 * dividend_words, 91 * dividend_words + divisor_words
+                )
+            )
+            var case_label = (
+                String("a=")
+                + String(dividend_words)
+                + " words, b="
+                + String(divisor_words)
+                + " words"
+            )
+            var q = a // b
+            var r = a % b
+            assert_equal(
+                String(q * b + r), String(a), "q*b+r != a for " + case_label
+            )
+            assert_true(r < b, "remainder not below divisor for " + case_label)
+            assert_true(
+                len(q.words) > 0, "quotient has no words for " + case_label
+            )
+
+    # The exact pair that crashed, and one that came back 10^9 too small.
+    assert_equal(
+        String(
+            BigUInt("23334504672441144935") // BigUInt("1854056525350022197")
+        ),
+        "12",
+    )
+    assert_equal(
+        String(
+            BigUInt("807907260199438794337606998415891117067948916721663647060")
+            // BigUInt("2822897927280927212")
+        ),
+        "286197829681228157267625044899046282569",
+    )
 
 
 def test_biguint_divide_bz_block_padding_sizes() raises:


### PR DESCRIPTION
This PR improves core integer arithmetic performance (multiplication + division) and adds targeted regression coverage for previously-missed edge cases, while updating project docs/changelog to reflect the new kernels and retuned cutoffs.