### PR TITLE
[core][decimal] Pack the multiply base case into 64-bit limbs + rewrite the Newton `sqrt` step

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,13 +7,13 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 `Rational` grows a full set of conversions and joins the
 `from_integral_scalar()` / `from_float_scalar()` naming used by the other
 numeric types, `BigInt10` is no longer referenced by the rest of the library,
-and `BigDecimal.pi()` gets four orders of magnitude faster — it now runs ahead
-of pure-Python mpmath from 500 digits up. Multiplication is 2-3x faster for
-both `BigInt` and `BigUInt`, which puts `BigInt` ahead of CPython's `int` on
-every large operation. Burnikel-Ziegler division loses a padding choice that
-cost it its own asymptotics on some sizes, which speeds up every division in
-the library. A Newton iteration that silently returned short of its requested
-precision is fixed.
+and `BigDecimal.pi()` gets four orders of magnitude faster — 100 000 digits in
+55 ms, and ahead of pure-Python mpmath from 500 digits up. Multiplication is
+2-3x faster for both `BigInt` and `BigUInt`, which puts `BigInt` ahead of
+CPython's `int` on every large operation. Burnikel-Ziegler division loses a
+padding choice that cost it its own asymptotics on some sizes, which speeds up
+every division in the library. A Newton iteration that silently returned short
+of its requested precision is fixed.
 
 ### ⭐️ New in Unreleased
 
@@ -74,6 +74,35 @@ precision is fixed.
    100 000 digits, decimo against CPython 3.14: multiply 3.4 ms vs 9.4,
    floor division 9.2 ms vs 19.4, `to_string` 13.1 ms vs 18.6, `from_string`
    5.1 ms vs 9.3.
+
+1. **The `BigInt` multiply base case works in 64-bit limbs, and `pi(100000)`
+   drops to 55 ms.** After the product-scanning rewrite above, the schoolbook
+   kernel was down to about 0.85 cycles per word pair — there was nothing left
+   to win per pair, only in the number of pairs. It now packs both operands
+   into base-2^64 limbs before the column loop, which quarters the pairs, and
+   writes each result limb straight back out as two 32-bit words. Operands
+   below 32 words skip the packing, which would cost more than it saves.
+
+   A column of 64-bit products does not fit in 128 bits. Rather than carry a
+   three-word accumulator, each product is split at the word boundary and the
+   halves go into two separate `UInt128` accumulators: neither can overflow
+   until a column is `2^64` limbs long, and on arm64 the split is free because
+   `mul` and `umulh` already produce the halves in different registers.
+
+   1.9x at the Karatsuba cutoff, which moved the cutoffs up again (Karatsuba
+   128 -> 256, Toom-3 512 -> 768). A 100 000-digit `BigInt` product goes from
+   3.4 ms to 2.3 ms.
+
+1. **`sqrt()` and `sqrt_reciprocal()` are 1.6x faster at high precision.** The
+   Newton step was the textbook `r * (3 - x * r^2) / 2`, whose second multiply
+   is half-width by full-width. Written around the residual instead — `r + r *
+   (1 - x * r^2) / 2`, algebraically the same thing — the correction is around
+   `10^(-p/2)`, and a `BigDecimal` keeps those leading zeros in the scale
+   rather than in the coefficient. The multiply is then half-width by
+   half-width. `sqrt_reciprocal(10005, 100000)` goes from 10.4 ms to 6.6 ms.
+
+   Together with the item above, `pi(100000)` goes from 78 ms to 55 ms and
+   `pi(10000)` from 2.2 ms to 1.7 ms.
 
 1. **`BigDecimal.pi()` is three to four orders of magnitude faster.** The
    Chudnovsky binary splitting now uses the `P`/`Q`/`T` recurrence: each leaf

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -80,26 +80,31 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 
 ### 2.3b Constants — `pi()` (PR #269–#273)
 
-`pi(10000)` 13.7 s → 2.2 ms; `pi(100000)`, out of practical reach before, now
-78 ms. Everything that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
+`pi(10000)` 13.7 s → 1.7 ms; `pi(100000)`, out of practical reach before, now 55
+ms — 2.7× MPFR 4.2.2 + GMP 6.3, which does the same job in 20.7 ms. Everything
+that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 
-| Date     | PR       | Item                                                                      |
-| -------- | -------- | ------------------------------------------------------------------------- |
-| 20260823 | #269     | Chudnovsky `P`/`Q`/`T` recurrence — O(1) leaves, root denominator is one   |
-|          |          | term's worth instead of the product of every term's                       |
-| 20260823 | #269     | Binary splitting moved from `BigDecimal` to `BigInt`                       |
-| 20260823 | #270     | `sqrt_reciprocal()` instead of the exact `sqrt()` (which costs two         |
-|          |          | full-size divisions to reproduce CPython's perfect-square test)            |
-| 20260823 | #270     | Divide once in binary, convert only the quotient; `10^s` as `5^s << s`     |
-| 20260823 | #270     | Leaves packed from `UInt128` — was half the split's time at p=1000         |
-| 20260823 | #271     | B-Z divisor padding fixed; a 100 000-digit divide 81 ms → 18 ms     |
-| 20260824 | #273     | Toom-3 on `BigInt` (`bigint_enhancement.md` T-M1); 152 → 142 ms            |
-| 20260824 | #273     | Product-scanning `BigUInt` schoolbook, replacing deferred-carry (T-9b);    |
-|          |          | 2.2× at 256 words, and it supersedes `multiply_slices_deferred_carry`      |
-| 20260824 | #273     | `BigUInt` cutoffs re-tuned: Karatsuba 64 → 256, Toom-3 256 → 768;          |
-|          |          | a 100 000-digit `BigUInt` multiply 10.5 → 6.0 ms                           |
-| 20260824 | #274     | Product-scanning `BigUInt` schoolbook mul, windowed schoolbook div,        |
-|          |          | dead `right.p` at the root of the split. Total: 142 → 78 ms                |
+| Date     | PR   | Item                                                                     |
+| -------- | ---- | ------------------------------------------------------------------------ |
+| 20260823 | #269 | Chudnovsky `P`/`Q`/`T` recurrence — O(1) leaves, root denominator is one |
+|          |      | term's worth instead of the product of every term's                      |
+| 20260823 | #269 | Binary splitting moved from `BigDecimal` to `BigInt`                     |
+| 20260823 | #270 | `sqrt_reciprocal()` instead of the exact `sqrt()` (which costs two       |
+|          |      | full-size divisions to reproduce CPython's perfect-square test)          |
+| 20260823 | #270 | Divide once in binary, convert only the quotient; `10^s` as `5^s << s`   |
+| 20260823 | #270 | Leaves packed from `UInt128` — was half the split's time at p=1000       |
+| 20260823 | #271 | B-Z divisor padding fixed; a 100 000-digit divide 81 ms → 18 ms          |
+| 20260824 | #273 | Toom-3 on `BigInt` (`bigint_enhancement.md` T-M1); 152 → 142 ms          |
+| 20260824 | #273 | Product-scanning `BigUInt` schoolbook, replacing deferred-carry (T-9b);  |
+|          |      | 2.2× at 256 words, and it supersedes `multiply_slices_deferred_carry`    |
+| 20260824 | #273 | `BigUInt` cutoffs re-tuned: Karatsuba 64 → 256, Toom-3 256 → 768;        |
+|          |      | a 100 000-digit `BigUInt` multiply 10.5 → 6.0 ms                         |
+| 20260824 | #274 | Product-scanning `BigUInt` schoolbook mul, windowed schoolbook div,      |
+|          |      | dead `right.p` at the root of the split. Total: 142 → 78 ms              |
+| 20260824 | #275 | `sqrt_reciprocal()` Newton step rearranged around the residual (T-Sq1)   |
+|          |      | 10.4 → 6.6 ms at p=100000                                                |
+| 20260824 | #275 | 64-bit limbs inside the `BigInt` schoolbook base case                    |
+|          |      | (`bigint_enhancement.md` T-M4), plus cutoffs re-tuned. Total: 78 → 55 ms |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -805,26 +810,28 @@ P7 — `round` (2× py → target ≤1.0×)
   `subtract` / `multiply` with `precision > 0`).
 
 **T-PI4 — keep the `pi()` pipeline binary, convert once. OPEN.**
-Stage breakdown at p=100000, after the 2026-08-24 work (78 ms total):
+Stage breakdown at p=100000, end of 2026-08-24 (56 ms total):
 
 | Stage                              | ms   | Base |
 | ---------------------------------- | ---- | ---- |
-| binary splitting, below the root   | 24.5 | 2^32 |
-| base 2^32 → 10^9                   | 12.5 | both |
-| `sqrt_reciprocal(10005)`           | 11.1 | 10^9 |
-| final division                     |  9.6 | 2^32 |
-| root join, 3 full-width multiplies |  9.7 | 2^32 |
-| final multiplies and round         |  6.0 | 10^9 |
-| `5^s` and the scaling multiply     |  4.9 | 2^32 |
+| binary splitting, below the root   | 16.8 | 2^32 |
+| base 2^32 → 10^9                   |  9.8 | both |
+| `sqrt_reciprocal(10005)`           |  7.0 | 10^9 |
+| final division                     |  6.6 | 2^32 |
+| root join, 3 full-width multiplies |  6.5 | 2^32 |
+| final multiplies and round         |  6.4 | 10^9 |
+| `5^s` and the scaling multiply     |  3.3 | 2^32 |
 
-`sqrt_reciprocal` has no reason to be decimal — a fixed-point reciprocal
-square root on `BigInt` would run against a multiply that is still 1.75× the
-base-10^9 one (3.4 ms vs 6.0 at 100 000 digits) — and the final multiply could
-follow it, leaving a single conversion. Worth roughly 5 ms now, down from the
-17 ms it would have been worth before the kernels were fixed.
+The two base-10^9 stages are now 13.4 ms of the 56, and `BigInt` multiply has
+pulled 2.8× ahead of `BigUInt` multiply (2.3 ms vs 6.4 at 100 000 digits)
+because the 64-bit packing of T-M4 has no base-10^9 analogue. A fixed-point
+reciprocal square root on `BigInt`, with the final multiply following it and a
+single conversion at the end, is worth roughly 8 ms — up from the 5 ms it was
+worth this morning, because the gap between the two bases has widened.
 
 Below that the multiplication exponent itself has to come down (T-5, NTT).
-For scale, mpmath on gmpy2 does the same 100 000 digits in ~16 ms.
+For scale, MPFR 4.2.2 + GMP 6.3 does the same 100 000 digits in 20.7 ms
+(18.6 compute + 2.1 to-string), and mpmath on gmpy2 in ~16 ms.
 
 ### 5.3 Long-term tasks not on the active roadmap
 
@@ -935,7 +942,8 @@ some ops < 1.0×):
 | T-R1   | `round` `.format` sweep                   | S      | **NO**   | no `.format` asserts in round; great           |
 | T-7b   | Reciprocal-Newton nth root                | M      | **WAIT** | break-even at current mul speed                |
 |        |                                           |        |          | (div ~2.7× mul); root already 0.2× py          |
-| T-PI4  | Binary-only `pi()` pipeline, convert once | M      | **OPEN** | ~5 ms of the 82 ms at p=100000                 |
+| T-PI4  | Binary-only `pi()` pipeline, convert once | M      | **OPEN** | now the biggest item left: ~8 ms of the 55 ms  |
+| T-Sq1  | Newton step around the residual in sqrt   | S      | **DONE** | 1.6× at p=100000; correction mul halves        |
 | T-9b   | Product-scanning `BigUInt` schoolbook     | M      | **DONE** | 2.2× at 256 words; deferred-carry removed      |
 | T-9c   | Re-tune `BigUInt` mul cutoffs             | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms      |
 | T-D5   | Windowed fused mul-sub in schoolbook div  | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000 |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -258,7 +258,38 @@ four accumulators, because one serialises on the 128-bit add.
 **T-M3 — re-tune the cutoffs. DONE (2026-08-24).** A quadratic kernel at well
 under a cycle per partial product moves both crossovers a long way up:
 `CUTOFF_KARATSUBA` 48 → 128, `CUTOFF_TOOM3` 384 → 512. At 11 000 words the
-dispatcher went 4 754 → 3 743 µs on the cutoffs alone.
+dispatcher went 4 754 → 3 743 µs on the cutoffs alone. T-M4 moved them again,
+to 256 / 768.
+
+**T-M4 — 64-bit limbs in the base case. DONE (2026-08-24).** T-M2 left the
+kernel at 0.19 ns per word pair, about 0.85 cycles — there was nothing left to
+win per pair, only in the number of pairs. So the base case now packs both
+operands into base-2^64 limbs, quartering the pairs, and writes each result
+limb straight back out as two words. Below `CUTOFF_PACK_64 = 32` words the
+packing costs more than it saves and `_multiply_magnitudes_comba32()` runs
+instead.
+
+A column of 64-bit products overflows 128 bits, and a three-word accumulator
+with a carry chain gives most of the gain back. Splitting each product at the
+word boundary into two `UInt128` accumulators avoids that: each half is below
+`2^64`, so neither overflows until a column is `2^64` limbs long, and on arm64
+`mul`/`umulh` deliver the two halves already separated.
+
+| words | Comba ×4 (T-M2) | packed 64-bit |
+| ----- | --------------- | ------------- |
+| 38    | 387 ns          | 270           |
+| 75    | 1 230           | 676           |
+| 113   | 2 530           | 1 320         |
+| 182   | 6 630           | 3 400         |
+
+A 100 000-digit multiply went 3.44 → 2.30 ms, and `pi(100000)` 78 → 55 ms.
+GMP does the same multiply in 0.39 ms, so it is still 5.9× ahead — it is on
+FFT at this size and we are not (T-5).
+
+Watch out for Mojo's ASAP destruction here: the packed operands are only
+touched through raw pointers, so without an explicit `_ = limbs_a^` the
+compiler destroys them at the point the pointer is taken and the loop reads
+freed memory. That is a silent heap corruption, not a crash at the fault.
 
 ### power (2.1× py) and add (1.5× py)
 
@@ -348,9 +379,10 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-T1  | Lower to_string D&C entry threshold              | OPEN — after T-D1 / T-D2              |
 | T-M1  | Toom-3 multiply above 384 words                  | DONE 2026-08-24                       |
 | T-M2  | Product-scanning (Comba) schoolbook base case    | DONE 2026-08-24 — ~2× at the cutoff   |
-| T-M3  | Re-tune `CUTOFF_KARATSUBA` / `CUTOFF_TOOM3`      | DONE 2026-08-24 — 48→128, 384→512     |
+| T-M3  | Re-tune `CUTOFF_KARATSUBA` / `CUTOFF_TOOM3`      | DONE 2026-08-24 — 48→128→256, →768    |
+| T-M4  | Pack the base case into base-2^64 limbs          | DONE 2026-08-24 — 1.9× at the cutoff  |
 | T-P1  | `square()` plus inplace loop for power           | OPEN                                  |
 | T-A1  | add/sub dispatch reorder                         | OPEN                                  |
 | T-SH1 | Pre-size the shift result buffer                 | OPEN                                  |
-| T-W1  | Base-2^64 limbs                                  | OPEN — unproven, low priority         |
+| T-W1  | Base-2^64 limbs throughout                       | PARTLY — T-M4 does it in the kernel   |
 | T-D4  | Reciprocal-Newton divide                         | DEFERRED — needs NTT, not Toom-3      |

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -431,6 +431,10 @@ def _chudnovsky_split_dropping_p(
     costs one multiplication of two half-width operands, which at 100 000
     digits is around 1.3 ms.
 
+    The same argument then applies to that subtree's own right child, and so
+    on down the right spine, so this recurses into itself rather than into
+    `chudnovsky_split`. The left child still needs its `p`.
+
     Args:
         a: The start index of the splitting range (inclusive).
         b: The end index of the splitting range (exclusive).
@@ -449,9 +453,9 @@ def _chudnovsky_split_dropping_p(
 
     var mid = (a + b) // 2
     var left = chudnovsky_split(a, mid)
-    var right = chudnovsky_split(mid, b)
-    var q = left.q * right.q
-    var t = left.t * right.q + left.p * right.t
+    var right = _chudnovsky_split_dropping_p(mid, b)
+    var q = left.q * right[0]
+    var t = left.t * right[0] + left.p * right[1]
     return (q^, t^)
 
 

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -1462,10 +1462,20 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
         prec_schedule.append(p)
         p = (p + 1) // 2
 
-    # Constant 3
-    var three = BigDecimal(BigUInt(raw_words=[3]), 0, False)
+    # Constant 1
+    var one = BigDecimal(BigUInt(raw_words=[1]), 0, False)
 
-    # --- Newton iterations: r_{k+1} = r_k * (3 - x_norm * r_k^2) / 2 ---
+    # --- Newton iterations: r_{k+1} = r_k + r_k * (1 - x_norm * r_k^2) / 2 ---
+    #
+    # This is the textbook `r * (3 - x * r^2) / 2` rearranged around the
+    # residual `e = 1 - x * r^2`. The two forms are algebraically identical -
+    # `(3 - x r^2) / 2 = 1 + e / 2` - but they cost different amounts. `r`
+    # entering an iteration is accurate to half the target, so `e` is around
+    # `10^(-ip/2)` and a `BigDecimal` keeps those leading zeros in the scale
+    # rather than in the coefficient. The correction multiply is therefore
+    # half-width by half-width, where `r * (3 - x r^2)` was half-width by
+    # full-width. That is one full half-precision multiplication saved per
+    # iteration, about 3 ms of `pi(100000)`.
     for i in range(len(prec_schedule) - 1, -1, -1):
         var ip = prec_schedule[i] + 10  # iteration precision with guard
 
@@ -1487,20 +1497,27 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
             fill_zeros_to_precision=False,
         )
 
-        # 3 - x_norm * r^2 (should be close to 2 when converged)
-        var correction = three.subtract(r_sq)
+        # e = 1 - x_norm * r^2, the Newton residual. Signed, and tiny.
+        var residual = one.subtract(r_sq)
 
-        # r * (3 - x_norm * r^2) (inplace)
-        bigdecimal_arithmetics.multiply_inplace(r, correction)
+        # r * e / 2
+        bigdecimal_arithmetics.multiply_inplace(residual, r)
+        residual.round_to_precision_inplace(
+            precision=ip,
+            rounding_mode=RoundingMode.half_up(),
+            remove_extra_digit_due_to_rounding=True,
+            fill_zeros_to_precision=False,
+        )
+        residual = residual.true_divide_inexact_by_uint32(UInt32(2), ip)
+
+        # r + r * e / 2
+        r = r.add(residual)
         r.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
             fill_zeros_to_precision=False,
         )
-
-        # / 2
-        r = r.true_divide_inexact_by_uint32(UInt32(2), ip)
 
     # --- Final: sqrt(x_norm) = x_norm * r ---
     var result = x_norm.multiply(r)

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -47,7 +47,7 @@ from decimo.errors import ValueError, ZeroDivisionError
 # Comba column runs at well under a cycle per partial product, which pushes
 # the point where Karatsuba's three sub-products and its extra additions and
 # allocations start to pay well past where it used to be.
-comptime CUTOFF_KARATSUBA: Int = 128
+comptime CUTOFF_KARATSUBA: Int = 256
 """The minimum number of words above which Karatsuba multiplication is used."""
 
 # Toom-3 cutoff: operands with this many words or fewer use Karatsuba.
@@ -61,7 +61,7 @@ comptime CUTOFF_KARATSUBA: Int = 128
 # cutoff for the same reason. Measured on Apple Silicon arm64 with the tuned
 # base case, 512 is the best of 384 / 512 / 768 / 1024 across 512 to 11 000
 # words. Adjust if benchmarking on another target shows a better value.
-comptime CUTOFF_TOOM3: Int = 512
+comptime CUTOFF_TOOM3: Int = 768
 """The minimum number of words above which Toom-3 multiplication is used."""
 
 # Burnikel-Ziegler cutoff: divisors with this many words or fewer use
@@ -263,37 +263,34 @@ def _multiply_magnitude_by_word(
     return result^
 
 
-def _multiply_magnitudes_schoolbook(
+comptime CUTOFF_PACK_64: Int = 32
+"""Operand size at which the schoolbook kernel switches to 64-bit limbs.
+
+Packing costs three linear passes and two heap allocations either side of a
+quadratic loop. That is a rounding error at the Karatsuba cutoff but it is
+about 120 ns of fixed cost, which swamps a multiplication of a handful of
+words. Measured crossover is just under 30 words.
+"""
+
+
+def _multiply_magnitudes_comba32(
     a: ImmSpan[UInt32, _], b: ImmSpan[UInt32, _]
 ) -> List[UInt32]:
-    """Product-scanning (Comba) multiplication on magnitude slices.
+    """Product-scanning multiplication over 32-bit words, without packing.
 
-    Walks the result one word at a time, summing the whole column
-    `sum(a[i] * b[k-i])` into a `UInt128` before emitting a word. Each product
-    is below 2^64 and the column has at most `2^64` terms, so the accumulator
-    cannot overflow and no carry has to be propagated back through the result.
-
-    Against the operand-scanning form this replaces, that removes the
-    read-modify-write of the result array on every partial product and the
-    serial carry chain along each row: about 2x at the Karatsuba cutoff. The
-    column is unrolled over four independent accumulators because a single one
-    serialises on the 128-bit add.
-
-    Operates on borrowed views of the operands without copying the input data.
+    The small-operand half of `_multiply_magnitudes_schoolbook()`. Allocates
+    nothing but the result, which is what makes it the better choice below
+    `CUTOFF_PACK_64`.
 
     Args:
-        a: First magnitude.
-        b: Second magnitude.
+        a: First magnitude, non-empty.
+        b: Second magnitude, non-empty.
 
     Returns:
         The product magnitude as a new word list.
     """
     var len_a = len(a)
     var len_b = len(b)
-
-    if len_a == 0 or len_b == 0:
-        var zero: List[UInt32] = [UInt32(0)]
-        return zero^
 
     var result_len = len_a + len_b
     var result = List[UInt32](capacity=result_len)
@@ -303,8 +300,6 @@ def _multiply_magnitudes_schoolbook(
     var bp = b.unsafe_ptr()
     var rp = result._data
 
-    # `carry` is the part of the column sum above 32 bits, which belongs to
-    # the next column. The last column leaves it holding the top word.
     var carry = UInt128(0)
     for k in range(result_len - 1):
         var i_low = 0 if k < len_b else k - len_b + 1
@@ -344,6 +339,150 @@ def _multiply_magnitudes_schoolbook(
         carry = column >> 32
 
     rp[unsafe_offset=result_len - 1] = UInt32(carry & 0xFFFF_FFFF)
+
+    var rlen = result_len
+    while rlen > 1 and result[rlen - 1] == 0:
+        rlen -= 1
+    while len(result) > rlen:
+        result.shrink(len(result) - 1)
+
+    return result^
+
+
+def _multiply_magnitudes_schoolbook(
+    a: ImmSpan[UInt32, _], b: ImmSpan[UInt32, _]
+) -> List[UInt32]:
+    """Product-scanning (Comba) multiplication on magnitude slices.
+
+    Packs the two magnitudes into base-2^64 limbs, walks the result one limb
+    at a time summing the whole column `sum(a[i] * b[k-i])`, and writes each
+    limb straight back out as two 32-bit words.
+
+    The packing is what makes this fast. A 32-bit kernel already runs at under
+    a cycle per word pair, so the only way left to cut the base case is to cut
+    the number of word pairs, and 64-bit limbs quarter it. That is worth about
+    1.9x at the Karatsuba cutoff. Small operands take
+    `_multiply_magnitudes_comba32()` instead, which skips the packing.
+
+    A column of 64-bit products does not fit in 128 bits, and the usual answer
+    - a three-word accumulator with an explicit carry chain - gives most of
+    the gain back. Instead each product is split at the word boundary and the
+    two halves go into separate `UInt128` accumulators: every half is below
+    `2^64`, so neither can overflow until a column is `2^64` limbs long. On
+    arm64 the split is free, since `mul` and `umulh` already deliver the two
+    halves in separate registers. Recombining is one add per column, not one
+    per product.
+
+    The columns are unrolled over two independent accumulator pairs because a
+    single one serialises on the 128-bit add.
+
+    Operates on borrowed views of the operands without copying the input data.
+
+    Args:
+        a: First magnitude.
+        b: Second magnitude.
+
+    Returns:
+        The product magnitude as a new word list.
+    """
+    var len_a = len(a)
+    var len_b = len(b)
+
+    if len_a == 0 or len_b == 0:
+        var zero: List[UInt32] = [UInt32(0)]
+        return zero^
+
+    if len_a < CUTOFF_PACK_64 or len_b < CUTOFF_PACK_64:
+        return _multiply_magnitudes_comba32(a, b)
+
+    comptime LOW_HALF = UInt128(0xFFFF_FFFF_FFFF_FFFF)
+
+    var ap = a.unsafe_ptr()
+    var bp = b.unsafe_ptr()
+
+    # --- Pack both operands into base-2^64 limbs ---
+    var n_a = (len_a + 1) >> 1
+    var n_b = (len_b + 1) >> 1
+
+    var limbs_a = List[UInt64](capacity=n_a)
+    limbs_a.resize(unsafe_uninit_length=n_a)
+    var lap = limbs_a._data
+    for j in range(n_a - 1):
+        lap[unsafe_offset=j] = UInt64(ap[unsafe_offset=2 * j]) | (
+            UInt64(ap[unsafe_offset=2 * j + 1]) << 32
+        )
+    var last_a = UInt64(ap[unsafe_offset=2 * (n_a - 1)])
+    if 2 * n_a - 1 < len_a:
+        last_a |= UInt64(ap[unsafe_offset=2 * n_a - 1]) << 32
+    lap[unsafe_offset=n_a - 1] = last_a
+
+    var limbs_b = List[UInt64](capacity=n_b)
+    limbs_b.resize(unsafe_uninit_length=n_b)
+    var lbp = limbs_b._data
+    for j in range(n_b - 1):
+        lbp[unsafe_offset=j] = UInt64(bp[unsafe_offset=2 * j]) | (
+            UInt64(bp[unsafe_offset=2 * j + 1]) << 32
+        )
+    var last_b = UInt64(bp[unsafe_offset=2 * (n_b - 1)])
+    if 2 * n_b - 1 < len_b:
+        last_b |= UInt64(bp[unsafe_offset=2 * n_b - 1]) << 32
+    lbp[unsafe_offset=n_b - 1] = last_b
+
+    # --- Product scanning over the packed limbs ---
+    # `2 * (n_a + n_b)` is at most two words longer than `len_a + len_b`, and
+    # any such word is zero, so stripping below removes it.
+    var n_out = n_a + n_b
+    var result_len = n_out << 1
+    var result = List[UInt32](capacity=result_len)
+    result.resize(unsafe_uninit_length=result_len)
+    var rp = result._data
+
+    # `carry` is the part of the column sum above 64 bits, which belongs to
+    # the next column. The last column leaves it holding the top limb.
+    var carry = UInt128(0)
+    for k in range(n_out - 1):
+        var i_low = 0 if k < n_b else k - n_b + 1
+        var i_high = k if k < n_a else n_a - 1
+
+        var low0 = carry
+        var high0 = UInt128(0)
+        var low1 = UInt128(0)
+        var high1 = UInt128(0)
+
+        var i = i_low
+        while i + 1 <= i_high:
+            var product0 = UInt128(lap[unsafe_offset=i]) * UInt128(
+                lbp[unsafe_offset=k - i]
+            )
+            low0 += product0 & LOW_HALF
+            high0 += product0 >> 64
+            var product1 = UInt128(lap[unsafe_offset=i + 1]) * UInt128(
+                lbp[unsafe_offset=k - i - 1]
+            )
+            low1 += product1 & LOW_HALF
+            high1 += product1 >> 64
+            i += 2
+        if i <= i_high:
+            var product = UInt128(lap[unsafe_offset=i]) * UInt128(
+                lbp[unsafe_offset=k - i]
+            )
+            low0 += product & LOW_HALF
+            high0 += product >> 64
+
+        var low = low0 + low1
+        rp[unsafe_offset=2 * k] = UInt32(low & 0xFFFF_FFFF)
+        rp[unsafe_offset=2 * k + 1] = UInt32((low >> 32) & 0xFFFF_FFFF)
+        carry = (high0 + high1) + (low >> 64)
+
+    rp[unsafe_offset=result_len - 2] = UInt32(carry & 0xFFFF_FFFF)
+    rp[unsafe_offset=result_len - 1] = UInt32((carry >> 32) & 0xFFFF_FFFF)
+
+    # The packed operands are only ever touched through the raw pointers taken
+    # above, so their last *use* as values was where those pointers were
+    # taken. Without these the compiler is free to destroy them there, and the
+    # loop above then reads freed memory.
+    _ = limbs_a^
+    _ = limbs_b^
 
     # Strip leading zeros
     var rlen = result_len

--- a/tests/bigint/test_bigint_large_algorithms.mojo
+++ b/tests/bigint/test_bigint_large_algorithms.mojo
@@ -700,5 +700,45 @@ def test_multiply_toom3_algebraic_identities() raises:
     )
 
 
+def test_multiply_across_the_64_bit_packing_boundary() raises:
+    """The packed and unpacked schoolbook kernels agree, at every parity.
+
+    Below `CUTOFF_PACK_64` (32 words) the base case runs over 32-bit words;
+    above it, operands are packed into base-2^64 limbs and the result is
+    unpacked again. An operand with an odd word count leaves the top limb
+    half empty, and the product then carries up to two zero words the packed
+    kernel has to strip, so both parities are covered on both sides of the
+    gate and in every combination.
+
+    9 decimal digits is a shade under one 32-bit word, so this walks the word
+    counts one at a time through the boundary rather than jumping over it.
+    The reference multiplies in 200-bit blocks, which stays under the gate
+    whatever the operands do.
+    """
+    var digit_counts = [180, 189, 198, 270, 279, 288, 297, 306, 360, 450]
+
+    for i in range(len(digit_counts)):
+        for j in range(len(digit_counts)):
+            var a = BigInt(_bz_digit_run(digit_counts[i], 24680 + 13 * i + j))
+            var b = BigInt(_bz_digit_run(digit_counts[j], 13579 + 7 * i + j))
+            var case_label = (
+                String("a=")
+                + String(digit_counts[i])
+                + " digits, b="
+                + String(digit_counts[j])
+                + " digits"
+            )
+            testing.assert_equal(
+                String(a * b),
+                String(_blockwise_product(a, b, 200)),
+                "packed product differs from reference for " + case_label,
+            )
+            testing.assert_equal(
+                String(a * (-b)),
+                "-" + String(_blockwise_product(a, b, 200)),
+                "packed product sign is wrong for " + case_label,
+            )
+
+
 def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR optimizes large-number arithmetic and high-precision decimal calculations.
- Adds packed base-2^64 multiplication and retunes cutoffs.
- Rewrites reciprocal-square-root Newton correction.
- Optimizes Chudnovsky splitting and updates tests and documentation.