### PR TITLE
[core][decimal] Optimize `pi()` calculation with binary tail and reciprocal root

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 `from_integral_scalar()` / `from_float_scalar()` naming used by the other
 numeric types, `BigInt10` is no longer referenced by the rest of the library,
 and `BigDecimal.pi()` gets four orders of magnitude faster — 100 000 digits in
-55 ms, and ahead of pure-Python mpmath from 500 digits up. Multiplication is
+50 ms, and ahead of pure-Python mpmath from 500 digits up. Multiplication is
 2-3x faster for both `BigInt` and `BigUInt`, which puts `BigInt` ahead of
 CPython's `int` on every large operation. Burnikel-Ziegler division loses a
 padding choice that cost it its own asymptotics on some sizes, which speeds up
@@ -80,8 +80,9 @@ of its requested precision is fixed.
    kernel was down to about 0.85 cycles per word pair — there was nothing left
    to win per pair, only in the number of pairs. It now packs both operands
    into base-2^64 limbs before the column loop, which quarters the pairs, and
-   writes each result limb straight back out as two 32-bit words. Operands
-   below 32 words skip the packing, which would cost more than it saves.
+   writes each result limb straight back out as two 32-bit words. Products of
+   fewer than 1024 word pairs skip the packing, which would cost more than it
+   saves.
 
    A column of 64-bit products does not fit in 128 bits. Rather than carry a
    three-word accumulator, each product is split at the word boundary and the
@@ -93,13 +94,47 @@ of its requested precision is fixed.
    128 -> 256, Toom-3 512 -> 768). A 100 000-digit `BigInt` product goes from
    3.4 ms to 2.3 ms.
 
-1. **`sqrt()` and `sqrt_reciprocal()` are 1.6x faster at high precision.** The
-   Newton step was the textbook `r * (3 - x * r^2) / 2`, whose second multiply
-   is half-width by full-width. Written around the residual instead — `r + r *
+   The gate is on `len_a * len_b` rather than on either operand, because
+   packing is linear in `len_a + len_b` while the loop it feeds is quadratic.
+   Gating on the shorter operand alone sent lopsided products back to the
+   32-bit kernel for no reason: 31x250 words is 1.8x faster packed, and was
+   slower than 64x250 before. Balanced products, and `pi()` with them, are
+   unaffected.
+
+1. **`pi()` finishes in binary and converts once, and 100 000 digits drop to
+   50 ms.** The pipeline used to leave base 2^32 as soon as the series
+   division was done: the quotient was converted to base 10^9, and the square
+   root and both final multiplications then ran there. That put three of the
+   most expensive stages in the base where a multiplication costs about 2.8x
+   what it costs in base 2^32, for no gain — the same single conversion was
+   needed either way.
+
+   `π = 426880 * √10005 * (q/t)` is now evaluated as
+   `426880 * 10005 / √10005 * (q/t)`, so the irrational factor enters as a
+   *reciprocal* square root — which Newton reaches without a division — and
+   `426880 * 10005 = 4270934400` still fits in a word. The new
+   `BigInt.exponential.reciprocal_isqrt_fixed()` returns `2^f / sqrt(x)` as a
+   binary fixed-point integer, everything is combined in `BigInt`, and the
+   conversion to base 10^9 happens once, on the finished value.
+
+   The three moved stages go from 7.0, 6.4 and 9.8 ms to 2, 2 and 9 ms at
+   100 000 digits. `pi(100000)` 58.2 -> 50.2 ms, `pi(10000)` 1.74 -> 1.59 ms,
+   `pi(1000)` 82 -> 71 us. Digits are unchanged: exact against MPFR at every
+   precision from 1 to 100 000 digits.
+
+1. **`sqrt_reciprocal()` is 1.6x faster at high precision.** The Newton step
+   was the textbook `r * (3 - x * r^2) / 2`, whose second multiply is
+   half-width by full-width. Written around the residual instead — `r + r *
    (1 - x * r^2) / 2`, algebraically the same thing — the correction is around
    `10^(-p/2)`, and a `BigDecimal` keeps those leading zeros in the scale
    rather than in the coefficient. The multiply is then half-width by
    half-width. `sqrt_reciprocal(10005, 100000)` goes from 10.4 ms to 6.6 ms.
+
+   `fast_isqrt()`, which the exact `BigDecimal.sqrt()` uses, now takes the
+   same form, but gains only about 6% (`sqrt(10005, 50000)` 19.3 ms to
+   18.2 ms). Its Newton loop is not where its time goes: the exact-integer
+   refinement that follows costs 7.7x the whole reciprocal iteration, because
+   it divides and squares at full width in base 10^9.
 
    Together with the item above, `pi(100000)` goes from 78 ms to 55 ms and
    `pi(10000)` from 2.2 ms to 1.7 ms.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -101,40 +101,40 @@ of its requested precision is fixed.
    slower than 64x250 before. Balanced products, and `pi()` with them, are
    unaffected.
 
-1. **`pi()` finishes in binary and converts once, and 100 000 digits drop to
-   50 ms.** The pipeline used to leave base 2^32 as soon as the series
-   division was done: the quotient was converted to base 10^9, and the square
-   root and both final multiplications then ran there. That put three of the
-   most expensive stages in the base where a multiplication costs about 2.8x
-   what it costs in base 2^32, for no gain — the same single conversion was
-   needed either way.
+1. **`pi()` finishes in binary and converts once, and 100 000 digits drop to 50
+   ms.** The pipeline used to leave base 2^32 as soon as the series division was
+   done: the quotient was converted to base 10^9, and the square root and both
+   final multiplications then ran there. That put three of the most expensive
+   stages in the base where a multiplication costs about 2.8x what it costs in
+   base 2^32, for no gain — the same single conversion was needed either way.
 
    `π = 426880 * √10005 * (q/t)` is now evaluated as
    `426880 * 10005 / √10005 * (q/t)`, so the irrational factor enters as a
    *reciprocal* square root — which Newton reaches without a division — and
    `426880 * 10005 = 4270934400` still fits in a word. The new
-   `BigInt.exponential.reciprocal_sqrt_fixed_point()` returns `2^f / sqrt(x)` as a
-   binary fixed-point integer, everything is combined in `BigInt`, and the
+   `BigInt.exponential.reciprocal_sqrt_fixed_point()` returns `2^f / sqrt(x)` as
+   a binary fixed-point integer, everything is combined in `BigInt`, and the
    conversion to base 10^9 happens once, on the finished value.
 
-   The three moved stages go from 7.0, 6.4 and 9.8 ms to 2, 2 and 9 ms at
-   100 000 digits. `pi(100000)` 58.2 -> 50.2 ms, `pi(10000)` 1.74 -> 1.59 ms,
+   The three moved stages go from 7.0, 6.4 and 9.8 ms to 2, 2 and 9 ms at 100
+   000 digits. `pi(100000)` 58.2 -> 50.2 ms, `pi(10000)` 1.74 -> 1.59 ms,
    `pi(1000)` 82 -> 71 us. Digits are unchanged: exact against MPFR at every
    precision from 1 to 100 000 digits.
 
-1. **`sqrt_via_reciprocal_iteration()` is 1.6x faster at high precision.** The Newton step
-   was the textbook `r * (3 - x * r^2) / 2`, whose second multiply is
-   half-width by full-width. Written around the residual instead — `r + r *
-   (1 - x * r^2) / 2`, algebraically the same thing — the correction is around
-   `10^(-p/2)`, and a `BigDecimal` keeps those leading zeros in the scale
+1. **`sqrt_via_reciprocal_iteration()` is 1.6x faster at high precision.** The
+   Newton step was the textbook `r * (3 - x * r^2) / 2`, whose second multiply
+   is half-width by full-width. Written around the residual instead —
+   `r + r * (1 - x * r^2) / 2`, algebraically the same thing — the correction is
+   around `10^(-p/2)`, and a `BigDecimal` keeps those leading zeros in the scale
    rather than in the coefficient. The multiply is then half-width by
-   half-width. `sqrt_via_reciprocal_iteration(10005, 100000)` goes from 10.4 ms to 6.6 ms.
+   half-width. `sqrt_via_reciprocal_iteration(10005, 100000)` goes from 10.4 ms
+   to 6.6 ms.
 
-   `fast_isqrt()`, which the exact `BigDecimal.sqrt()` uses, now takes the
-   same form, but gains only about 6% (`sqrt(10005, 50000)` 19.3 ms to
+   `isqrt_via_reciprocal_seed()`, which the exact `BigDecimal.sqrt()` uses, now
+   takes the same form, but gains only about 6% (`sqrt(10005, 50000)` 19.3 ms to
    18.2 ms). Its Newton loop is not where its time goes: the exact-integer
-   refinement that follows costs 7.7x the whole reciprocal iteration, because
-   it divides and squares at full width in base 10^9.
+   refinement that follows costs 7.7x the whole reciprocal iteration, because it
+   divides and squares at full width in base 10^9.
 
    Together with the item above, `pi(100000)` goes from 78 ms to 55 ms and
    `pi(10000)` from 2.2 ms to 1.7 ms.
@@ -153,9 +153,9 @@ of its requested precision is fixed.
    for bit by computing an exact integer square root and testing for a perfect
    square; both cost full-size divisions and neither means anything for a fixed
    non-square constant used as an intermediate. `pi()` now uses the
-   division-free `sqrt_via_reciprocal_iteration()`, which was the largest single line item in
-   `pi()` — ahead of the binary splitting itself. `pi(5000)` goes from 3.26 ms
-   to 1.98 ms and `pi(100000)` from 295 ms to 211 ms.
+   division-free `sqrt_via_reciprocal_iteration()`, which was the largest single
+   line item in `pi()` — ahead of the binary splitting itself. `pi(5000)` goes
+   from 3.26 ms to 1.98 ms and `pi(100000)` from 295 ms to 211 ms.
 1. **`pi()` divides in binary and converts once.** The last step of the
    Chudnovsky evaluation used to build a `BigDecimal` out of each of `q` and
    `t` and divide those, which meant two base-2^32 to base-10^9 conversions —
@@ -287,16 +287,17 @@ of its requested precision is fixed.
    *normalized* dividend, which the normalization has usually lengthened, so
    the guard fired more or less at random. It now tests the normalized length,
    as `BigInt`'s copy of the algorithm always has.
-1. **`sqrt_via_reciprocal_iteration()` returned fewer correct digits than asked for**, from
-   two independent causes. A reciprocal-sqrt iteration only doubles the correct
-   digits, so `n` iterations reach `seed * 2^n` — and the schedule halved down
-   to 20, crediting the seed with more digits than it carries. The seed itself
-   was `x ** -0.5`, which for some inputs is accurate to only about ten digits;
-   it is now `1 / sqrt(x)`, which is correctly rounded. Together these left
-   `sqrt_via_reciprocal_iteration(1234.5678, 1500)` correct to 1248 of 1500 digits, with the
-   full digit count returned and nothing raised. `fast_isqrt()` shared both
-   bugs and was hiding them behind full-size corrective divisions, so
-   `sqrt_exact()` is about 30% faster as well.
+1. **`sqrt_via_reciprocal_iteration()` returned fewer correct digits than asked
+   for**, from two independent causes. A reciprocal-sqrt iteration only doubles
+   the correct digits, so `n` iterations reach `seed * 2^n` — and the schedule
+   halved down to 20, crediting the seed with more digits than it carries. The
+   seed itself was `x ** -0.5`, which for some inputs is accurate to only about
+   ten digits; it is now `1 / sqrt(x)`, which is correctly rounded. Together
+   these left `sqrt_via_reciprocal_iteration(1234.5678, 1500)` correct to 1248
+   of 1500 digits, with the full digit count returned and nothing raised.
+   `isqrt_via_reciprocal_seed()` shared both bugs and was hiding them behind
+   full-size corrective divisions, so `sqrt_exact()` is about 30% faster as
+   well.
 
 ### 🗑️ Deprecated in Unreleased
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -113,7 +113,7 @@ of its requested precision is fixed.
    `426880 * 10005 / √10005 * (q/t)`, so the irrational factor enters as a
    *reciprocal* square root — which Newton reaches without a division — and
    `426880 * 10005 = 4270934400` still fits in a word. The new
-   `BigInt.exponential.reciprocal_isqrt_fixed()` returns `2^f / sqrt(x)` as a
+   `BigInt.exponential.reciprocal_sqrt_fixed_point()` returns `2^f / sqrt(x)` as a
    binary fixed-point integer, everything is combined in `BigInt`, and the
    conversion to base 10^9 happens once, on the finished value.
 
@@ -122,13 +122,13 @@ of its requested precision is fixed.
    `pi(1000)` 82 -> 71 us. Digits are unchanged: exact against MPFR at every
    precision from 1 to 100 000 digits.
 
-1. **`sqrt_reciprocal()` is 1.6x faster at high precision.** The Newton step
+1. **`sqrt_via_reciprocal_iteration()` is 1.6x faster at high precision.** The Newton step
    was the textbook `r * (3 - x * r^2) / 2`, whose second multiply is
    half-width by full-width. Written around the residual instead — `r + r *
    (1 - x * r^2) / 2`, algebraically the same thing — the correction is around
    `10^(-p/2)`, and a `BigDecimal` keeps those leading zeros in the scale
    rather than in the coefficient. The multiply is then half-width by
-   half-width. `sqrt_reciprocal(10005, 100000)` goes from 10.4 ms to 6.6 ms.
+   half-width. `sqrt_via_reciprocal_iteration(10005, 100000)` goes from 10.4 ms to 6.6 ms.
 
    `fast_isqrt()`, which the exact `BigDecimal.sqrt()` uses, now takes the
    same form, but gains only about 6% (`sqrt(10005, 50000)` 19.3 ms to
@@ -153,7 +153,7 @@ of its requested precision is fixed.
    for bit by computing an exact integer square root and testing for a perfect
    square; both cost full-size divisions and neither means anything for a fixed
    non-square constant used as an intermediate. `pi()` now uses the
-   division-free `sqrt_reciprocal()`, which was the largest single line item in
+   division-free `sqrt_via_reciprocal_iteration()`, which was the largest single line item in
    `pi()` — ahead of the binary splitting itself. `pi(5000)` goes from 3.26 ms
    to 1.98 ms and `pi(100000)` from 295 ms to 211 ms.
 1. **`pi()` divides in binary and converts once.** The last step of the
@@ -287,13 +287,13 @@ of its requested precision is fixed.
    *normalized* dividend, which the normalization has usually lengthened, so
    the guard fired more or less at random. It now tests the normalized length,
    as `BigInt`'s copy of the algorithm always has.
-1. **`sqrt_reciprocal()` returned fewer correct digits than asked for**, from
+1. **`sqrt_via_reciprocal_iteration()` returned fewer correct digits than asked for**, from
    two independent causes. A reciprocal-sqrt iteration only doubles the correct
    digits, so `n` iterations reach `seed * 2^n` — and the schedule halved down
    to 20, crediting the seed with more digits than it carries. The seed itself
    was `x ** -0.5`, which for some inputs is accurate to only about ten digits;
    it is now `1 / sqrt(x)`, which is correctly rounded. Together these left
-   `sqrt_reciprocal(1234.5678, 1500)` correct to 1248 of 1500 digits, with the
+   `sqrt_via_reciprocal_iteration(1234.5678, 1500)` correct to 1248 of 1500 digits, with the
    full digit count returned and nothing raised. `fast_isqrt()` shared both
    bugs and was hiding them behind full-size corrective divisions, so
    `sqrt_exact()` is about 30% faster as well.

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -154,7 +154,7 @@ the split itself - because `pi()` called the public `sqrt()`, which is
 by computing an exact integer square root and then testing whether the input is
 a perfect square; both cost full-size divisions, and neither means anything for
 a fixed non-square constant used as an intermediate. `pi()` now calls
-`sqrt_reciprocal()`, whose Newton iteration is division-free.
+`sqrt_via_reciprocal_iteration()`, whose Newton iteration is division-free.
 
 Against mpmath 1.4.1 on its pure-Python backend, best of N for both sides on
 the same machine, comparing against its `to_str` timing since decimo returns
@@ -198,7 +198,7 @@ Where the time goes, after the rest of the 2026-08-24 work took it to 78 ms:
 | ---------------------------------- | ---- | ---- |
 | binary splitting, below the root   | 24.5 | 2^32 |
 | base 2^32 -> 10^9                  | 12.5 | both |
-| `sqrt_reciprocal(10005)`           | 11.1 | 10^9 |
+| `sqrt_via_reciprocal_iteration(10005)`           | 11.1 | 10^9 |
 | root join, 3 full-width multiplies |  9.7 | 2^32 |
 | final division                     |  9.6 | 2^32 |
 | final multiplies and round         |  6.0 | 10^9 |
@@ -217,7 +217,7 @@ one word. 58.2 → 50.2 ms.
 
 ### The exact `sqrt()` spends 87% of its time after Newton has finished
 
-`sqrt(10005, 50000)` takes 18.3 ms; `sqrt_reciprocal(10005, 50000)` takes
+`sqrt(10005, 50000)` takes 18.3 ms; `sqrt_via_reciprocal_iteration(10005, 50000)` takes
 2.36 ms and agrees to every digit checked. The difference is `sqrt_exact()`'s
 exact-integer tail: rescale `c`, one `c.floor_divide(n)` refinement step, and
 the `n * n == c` perfect-square test. Instrumenting the refinement loop shows
@@ -225,7 +225,7 @@ it runs **once**, so this is not a convergence problem - it is one full-width
 division plus one full-width square, both in base 10^9.
 
 That is why rearranging `fast_isqrt()`'s Newton step around the residual, which
-was worth 1.6x in `sqrt_reciprocal()`, is worth only 6% here. The exactness
+was worth 1.6x in `sqrt_via_reciprocal_iteration()`, is worth only 6% here. The exactness
 guarantee costs a divide and a square at full width, and the fix is to stop
 paying for them in base 10^9 (T-Sq2, same argument as T-PI4).
 
@@ -342,7 +342,7 @@ adversarial inputs are the only thing that finds this class of bug.
 
 ### A Newton schedule reaches `seed * 2^n`, and nothing caps it
 
-Two bugs in `sqrt_reciprocal()` and `fast_isqrt()`, caught while measuring the
+Two bugs in `sqrt_via_reciprocal_iteration()` and `fast_isqrt()`, caught while measuring the
 above, both of which returned the full requested digit count with a wrong tail
 and raised nothing.
 
@@ -352,7 +352,7 @@ The iteration `r <- r * (3 - x * r^2) / 2` doubles the correct digits. It does
 their schedule by halving from the target down to 20, which credits the seed
 with 20 digits; and both seeded with `x ** -0.5`, which goes through `exp`/`log`
 and is accurate to about ten digits for some inputs while being exact for
-others. Instrumented, `sqrt_reciprocal(1234.5678, 1500)`:
+others. Instrumented, `sqrt_via_reciprocal_iteration(1234.5678, 1500)`:
 
 | iteration precision | 34 | 58 | 106 | 201 | 392 | 773 | 1535 |
 | ------------------- | -- | -- | --- | --- | --- | --- | ---- |
@@ -363,7 +363,7 @@ iteration was nominally running at. The schedule now halves down to
 `_F64_SEED_DIGITS`, and the seed is `1 / sqrt(x)`, which is correctly rounded.
 
 The reason this survived so long is that both dials have to be wrong *and* the
-schedule has to land badly. `sqrt_reciprocal(10005, 1000)` and
+schedule has to land badly. `sqrt_via_reciprocal_iteration(10005, 1000)` and
 `(10005, 2000)` were correct in full; `(10005, 1500)` was correct in full but
 `(1234.5678, 1500)` was not, because `1.0005 ** -0.5` happens to be exact and
 `12.345678 ** -0.5` is not. Any spot check picks a survivor. The test sweeps

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -194,15 +194,15 @@ the same few levels again; only an FFT changes the exponent everywhere.
 
 Where the time goes, after the rest of the 2026-08-24 work took it to 78 ms:
 
-| Stage                              | ms   | Base |
-| ---------------------------------- | ---- | ---- |
-| binary splitting, below the root   | 24.5 | 2^32 |
-| base 2^32 -> 10^9                  | 12.5 | both |
-| `sqrt_via_reciprocal_iteration(10005)`           | 11.1 | 10^9 |
-| root join, 3 full-width multiplies |  9.7 | 2^32 |
-| final division                     |  9.6 | 2^32 |
-| final multiplies and round         |  6.0 | 10^9 |
-| `5^s` and the scaling multiply     |  4.9 | 2^32 |
+| Stage                                  | ms   | Base |
+| -------------------------------------- | ---- | ---- |
+| binary splitting, below the root       | 24.5 | 2^32 |
+| base 2^32 -> 10^9                      | 12.5 | both |
+| `sqrt_via_reciprocal_iteration(10005)` | 11.1 | 10^9 |
+| root join, 3 full-width multiplies     | 9.7  | 2^32 |
+| final division                         | 9.6  | 2^32 |
+| final multiplies and round             | 6.0  | 10^9 |
+| `5^s` and the scaling multiply         | 4.9  | 2^32 |
 
 17 ms still runs in base 10^9, where the same multiply costs more than it does
 in base 2^32 (6.0 ms against 3.4 at 100 000 digits). Neither stage has to be
@@ -217,17 +217,19 @@ one word. 58.2 → 50.2 ms.
 
 ### The exact `sqrt()` spends 87% of its time after Newton has finished
 
-`sqrt(10005, 50000)` takes 18.3 ms; `sqrt_via_reciprocal_iteration(10005, 50000)` takes
-2.36 ms and agrees to every digit checked. The difference is `sqrt_exact()`'s
-exact-integer tail: rescale `c`, one `c.floor_divide(n)` refinement step, and
-the `n * n == c` perfect-square test. Instrumenting the refinement loop shows
-it runs **once**, so this is not a convergence problem - it is one full-width
-division plus one full-width square, both in base 10^9.
+`sqrt(10005, 50000)` takes 18.3 ms;
+`sqrt_via_reciprocal_iteration(10005, 50000)` takes 2.36 ms and agrees to every
+digit checked. The difference is `sqrt_exact()`'s exact-integer tail: rescale
+`c`, one `c.floor_divide(n)` refinement step, and the `n * n == c`
+perfect-square test. Instrumenting the refinement loop shows it runs **once**,
+so this is not a convergence problem - it is one full-width division plus one
+full-width square, both in base 10^9.
 
-That is why rearranging `fast_isqrt()`'s Newton step around the residual, which
-was worth 1.6x in `sqrt_via_reciprocal_iteration()`, is worth only 6% here. The exactness
-guarantee costs a divide and a square at full width, and the fix is to stop
-paying for them in base 10^9 (T-Sq2, same argument as T-PI4).
+That is why rearranging `isqrt_via_reciprocal_seed()`'s Newton step around the
+residual, which was worth 1.6x in `sqrt_via_reciprocal_iteration()`, is worth
+only 6% here. The exactness guarantee costs a divide and a square at full width,
+and the fix is to stop paying for them in base 10^9 (T-Sq2, same argument as
+T-PI4).
 
 ### GMP is on FFT from ~32 000 digits, and that is most of the gap
 
@@ -342,9 +344,9 @@ adversarial inputs are the only thing that finds this class of bug.
 
 ### A Newton schedule reaches `seed * 2^n`, and nothing caps it
 
-Two bugs in `sqrt_via_reciprocal_iteration()` and `fast_isqrt()`, caught while measuring the
-above, both of which returned the full requested digit count with a wrong tail
-and raised nothing.
+Two bugs in `sqrt_via_reciprocal_iteration()` and `isqrt_via_reciprocal_seed()`,
+caught while measuring the above, both of which returned the full requested
+digit count with a wrong tail and raised nothing.
 
 The iteration `r <- r * (3 - x * r^2) / 2` doubles the correct digits. It does
 *not* get pulled up to whatever precision the arithmetic inside it runs at, so

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -182,11 +182,12 @@ division it feeds.
 
 ### Toom-3 helps the multiply much more than it helps `pi()`
 
-Toom-3 on `BigInt` is 1.15x Karatsuba at 400 words, 1.26x at 5 000 and 1.51x
-at 22 000, but on its own `pi(100000)` only went 152 -> 142 ms. The tree shape explains
-it: doubling the term count multiplies the split's cost by 3.06, so the top
-level is only 35% of the total and each level below adds 65% of the one above.
-Toom-3 reaches the top three or four levels; the rest is Karatsuba as before.
+Toom-3 on `BigInt` is 1.15x Karatsuba at 400 words, 1.26x at 5 000 and 1.51x at
+22 000, but on its own `pi(100000)` only went 152 -> 142 ms. The tree shape
+explains it: doubling the term count multiplies the split's cost by 3.06, so the
+top level is only 35% of the total and each level below adds 65% of the one
+above. Toom-3 reaches the top three or four levels; the rest is Karatsuba as
+before.
 
 So a faster multiply only pays across a *wide* size range. Toom-4 would move
 the same few levels again; only an FFT changes the exponent everywhere.
@@ -206,6 +207,53 @@ Where the time goes, after the rest of the 2026-08-24 work took it to 78 ms:
 17 ms still runs in base 10^9, where the same multiply costs more than it does
 in base 2^32 (6.0 ms against 3.4 at 100 000 digits). Neither stage has to be
 decimal. See `plans/bigdecimal_enhancement.md` T-PI4.
+
+**Update (T-PI4, done).** The square root and the final multiplies moved to
+`BigInt`; only the one conversion still runs in base 10^9. What made it work
+was writing `π = 426880 * √10005 * (q/t)` as `426880 * 10005 / √10005 * (q/t)`
+
+- as a *reciprocal* root it needs no division, and `426880 * 10005` is still
+one word. 58.2 → 50.2 ms.
+
+### The exact `sqrt()` spends 87% of its time after Newton has finished
+
+`sqrt(10005, 50000)` takes 18.3 ms; `sqrt_reciprocal(10005, 50000)` takes
+2.36 ms and agrees to every digit checked. The difference is `sqrt_exact()`'s
+exact-integer tail: rescale `c`, one `c.floor_divide(n)` refinement step, and
+the `n * n == c` perfect-square test. Instrumenting the refinement loop shows
+it runs **once**, so this is not a convergence problem - it is one full-width
+division plus one full-width square, both in base 10^9.
+
+That is why rearranging `fast_isqrt()`'s Newton step around the residual, which
+was worth 1.6x in `sqrt_reciprocal()`, is worth only 6% here. The exactness
+guarantee costs a divide and a square at full width, and the fix is to stop
+paying for them in base 10^9 (T-Sq2, same argument as T-PI4).
+
+### GMP is on FFT from ~32 000 digits, and that is most of the gap
+
+`mpz_mul` normalised to Toom-3's exponent, `t / n^1.465` with `n` in 64-bit
+limbs, is flat until it suddenly isn't:
+
+| digits  | limbs | mul    | t/n^1.465 |
+| ------- | ----- | ------ | --------- |
+| 20 000  | 1 039 | 147 us | 5.58      |
+| 30 000  | 1 558 | 263    | 5.53      |
+| 40 000  | 2 077 | 220    | 3.03      |
+| 100 000 | 5 191 | 412    | 1.49      |
+| 180 000 | 9 343 | 742    | 1.13      |
+
+40 000 digits is faster in *absolute* terms than 30 000, so Schonhage-Strassen
+takes over between them, at roughly 1 600-2 000 limbs.
+
+Extrapolating the flat part to 100 000 digits gives ~1 550 us for a GMP that
+had stayed on Toom. It actually takes 412, so FFT is worth 3.7x there; our
+2 500 us against that 1 550 is 1.6x, and that 1.6x is base case, glue and
+assembly.
+
+Of the 6.1x multiply gap at 100 000 digits, then, 3.7x is algorithm and 1.6x
+is code. NTT is not a >=10^6-digit concern - it is the largest single lever at
+the sizes we already benchmark, and it makes Toom-4 (which by the tree-shape
+argument above would be worth a couple of percent on `pi`) not worth doing.
 
 ### Burnikel-Ziegler padding has to survive every halving
 

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -84,31 +84,31 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 ms — 2.7× MPFR 4.2.2 + GMP 6.3, which does the same job in 20.7 ms. Everything
 that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 
-| Date     | PR   | Item                                                                     |
-| -------- | ---- | ------------------------------------------------------------------------ |
-| 20260823 | #269 | Chudnovsky `P`/`Q`/`T` recurrence — O(1) leaves, root denominator is one |
-|          |      | term's worth instead of the product of every term's                      |
-| 20260823 | #269 | Binary splitting moved from `BigDecimal` to `BigInt`                     |
-| 20260823 | #270 | `sqrt_via_reciprocal_iteration()` instead of the exact `sqrt()` (which costs two       |
-|          |      | full-size divisions to reproduce CPython's perfect-square test)          |
-| 20260823 | #270 | Divide once in binary, convert only the quotient; `10^s` as `5^s << s`   |
-| 20260823 | #270 | Leaves packed from `UInt128` — was half the split's time at p=1000       |
-| 20260823 | #271 | B-Z divisor padding fixed; a 100 000-digit divide 81 ms → 18 ms          |
-| 20260824 | #273 | Toom-3 on `BigInt` (`bigint_enhancement.md` T-M1); 152 → 142 ms          |
-| 20260824 | #273 | Product-scanning `BigUInt` schoolbook, replacing deferred-carry (T-9b);  |
-|          |      | 2.2× at 256 words, and it supersedes `multiply_slices_deferred_carry`    |
-| 20260824 | #273 | `BigUInt` cutoffs re-tuned: Karatsuba 64 → 256, Toom-3 256 → 768;        |
-|          |      | a 100 000-digit `BigUInt` multiply 10.5 → 6.0 ms                         |
-| 20260824 | #274 | Product-scanning `BigUInt` schoolbook mul, windowed schoolbook div,      |
-|          |      | dead `right.p` at the root of the split. Total: 142 → 78 ms              |
-| 20260824 | #275 | `sqrt_via_reciprocal_iteration()` Newton step rearranged around the residual (T-Sq1)   |
-|          |      | 10.4 → 6.6 ms at p=100000                                                |
-| 20260824 | #275 | 64-bit limbs inside the `BigInt` schoolbook base case                    |
-|          |      | (`bigint_enhancement.md` T-M4), plus cutoffs re-tuned. Total: 78 → 55 ms |
-| 20260824 | #276 | `fast_isqrt()` Newton step rearranged around the residual too (T-Sq1);   |
-|          |      | only 6% — `sqrt(10005, 50000)` 19.3 → 18.2 ms. See T-Sq2                 |
-| 20260824 | #276 | Binary-only `pi()` tail via `reciprocal_sqrt_fixed_point()` (T-PI4);          |
-|          |      | sqrt and final multiplies leave base 10^9. Total: 58.2 → 50.2 ms         |
+| Date     | PR   | Item                                                                                  |
+| -------- | ---- | ------------------------------------------------------------------------------------- |
+| 20260823 | #269 | Chudnovsky `P`/`Q`/`T` recurrence — O(1) leaves, root denominator is one              |
+|          |      | term's worth instead of the product of every term's                                   |
+| 20260823 | #269 | Binary splitting moved from `BigDecimal` to `BigInt`                                  |
+| 20260823 | #270 | `sqrt_via_reciprocal_iteration()` instead of the exact `sqrt()` (which costs two      |
+|          |      | full-size divisions to reproduce CPython's perfect-square test)                       |
+| 20260823 | #270 | Divide once in binary, convert only the quotient; `10^s` as `5^s << s`                |
+| 20260823 | #270 | Leaves packed from `UInt128` — was half the split's time at p=1000                    |
+| 20260823 | #271 | B-Z divisor padding fixed; a 100 000-digit divide 81 ms → 18 ms                       |
+| 20260824 | #273 | Toom-3 on `BigInt` (`bigint_enhancement.md` T-M1); 152 → 142 ms                       |
+| 20260824 | #273 | Product-scanning `BigUInt` schoolbook, replacing deferred-carry (T-9b);               |
+|          |      | 2.2× at 256 words, and it supersedes `multiply_slices_deferred_carry`                 |
+| 20260824 | #273 | `BigUInt` cutoffs re-tuned: Karatsuba 64 → 256, Toom-3 256 → 768;                     |
+|          |      | a 100 000-digit `BigUInt` multiply 10.5 → 6.0 ms                                      |
+| 20260824 | #274 | Product-scanning `BigUInt` schoolbook mul, windowed schoolbook div,                   |
+|          |      | dead `right.p` at the root of the split. Total: 142 → 78 ms                           |
+| 20260824 | #275 | `sqrt_via_reciprocal_iteration()` Newton step rearranged around the residual (T-Sq1)  |
+|          |      | 10.4 → 6.6 ms at p=100000                                                             |
+| 20260824 | #275 | 64-bit limbs inside the `BigInt` schoolbook base case                                 |
+|          |      | (`bigint_enhancement.md` T-M4), plus cutoffs re-tuned. Total: 78 → 55 ms              |
+| 20260824 | #276 | `isqrt_via_reciprocal_seed()` Newton step rearranged around the residual too (T-Sq1); |
+|          |      | only 6% — `sqrt(10005, 50000)` 19.3 → 18.2 ms. See T-Sq2                              |
+| 20260824 | #276 | Binary-only `pi()` tail via `reciprocal_sqrt_fixed_point()` (T-PI4);                  |
+|          |      | sqrt and final multiplies leave base 10^9. Total: 58.2 → 50.2 ms                      |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -613,20 +613,19 @@ P3 — Divide all precisions (5× py → target ≤2×)
 
 P4 — sqrt at p=100 (2.1× py → target ≤1.0×)
 
-- **T-S1: Small-coefficient short-circuit before `fast_isqrt`.**
+- **T-S1: Small-coefficient short-circuit before `isqrt_via_reciprocal_seed`.**
   **INVALID — already handled, and the premise is false (20260611).**
   `sqrt_exact` already short-circuits the reciprocal-Newton dance:
-  `if len(c.words) <= 20: n = biguint_exponential.sqrt(c)` (direct
-  integer Newton) else `fast_isqrt`. Two problems with the task as
-  written: (1) at p=100 the coefficient is rescaled so `isqrt(c)` has
-  `prec` (101) digits, making `c` ~202 digits (~23 words) — it never
-  fits UInt128, so a "UInt128 isqrt" cannot apply. (2) The claim that
-  the float64 setup + precision doubling is "wasted" at this size is
-  empirically false: raising the direct-Newton threshold to 30 words so
-  p=100 takes the direct path **regressed** sqrt@p100 from 8,370 →
-  15,125 ns (1.8× → 3.8× py). `fast_isqrt` is the faster choice at ~23
-  words; the existing threshold of 20 is well-tuned. sqrt@p1000 is
-  already 0.7× py.
+  `if len(c.words) <= 20: n = biguint_exponential.sqrt(c)` (direct integer
+  Newton) else `isqrt_via_reciprocal_seed`. Two problems with the task as
+  written: (1) at p=100 the coefficient is rescaled so `isqrt(c)` has `prec`
+  (101) digits, making `c` ~202 digits (~23 words) — it never fits UInt128, so a
+  "UInt128 isqrt" cannot apply. (2) The claim that the float64 setup + precision
+  doubling is "wasted" at this size is empirically false: raising the
+  direct-Newton threshold to 30 words so p=100 takes the direct path
+  **regressed** sqrt@p100 from 8,370 → 15,125 ns (1.8× → 3.8× py).
+  `isqrt_via_reciprocal_seed` is the faster choice at ~23 words; the existing
+  threshold of 20 is well-tuned. sqrt@p1000 is already 0.7× py.
 
 P5 — ln far-from-1 (4.6×–9.2× py → target ≤2×)
 
@@ -829,16 +828,16 @@ P7 — `round` (2× py → target ≤1.0×)
 **T-PI4 — keep the `pi()` pipeline binary, convert once. DONE 20260824.**
 Stage breakdown at p=100000, before and after:
 
-| Stage                              | before   | after    | Base |
-| ---------------------------------- | -------- | -------- | ---- |
-| binary splitting, below the root   | 16.8     | 16       | 2^32 |
-| base 2^32 → 10^9                   | 9.8      | 9        | both |
-| `sqrt_via_reciprocal_iteration(10005)`           | 7.0      | 2        | 2^32 |
-| final division                     | 6.6      | 6        | 2^32 |
-| root join, 3 full-width multiplies | 6.5      | 6        | 2^32 |
-| final multiplies and round         | 6.4      | 2        | 2^32 |
-| `5^s` and the scaling multiply     | 3.3      | 3        | 2^32 |
-| **total**                          | **58.2** | **50.2** |      |
+| Stage                                  | before   | after    | Base |
+| -------------------------------------- | -------- | -------- | ---- |
+| binary splitting, below the root       | 16.8     | 16       | 2^32 |
+| base 2^32 → 10^9                       | 9.8      | 9        | both |
+| `sqrt_via_reciprocal_iteration(10005)` | 7.0      | 2        | 2^32 |
+| final division                         | 6.6      | 6        | 2^32 |
+| root join, 3 full-width multiplies     | 6.5      | 6        | 2^32 |
+| final multiplies and round             | 6.4      | 2        | 2^32 |
+| `5^s` and the scaling multiply         | 3.3      | 3        | 2^32 |
+| **total**                              | **58.2** | **50.2** |      |
 
 The square root and both final multiplications used to run in base 10^9, where
 a multiplication costs about 2.8× what it costs in base 2^32 (6.4 ms vs 2.3 at
@@ -937,50 +936,50 @@ binary splitting). All implementable in base-10^9.
 Open items in priority order (target: dm/py ≤ 1.5× across the board,
 some ops < 1.0×):
 
-| #      | Issue                                      | Effort | Priority | Target gain                                     |
-| ------ | ------------------------------------------ | ------ | -------- | ----------------------------------------------- |
-| T-API1 | `precision` arg on `add`/`sub`/`multiply`  | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3  |
-| T-R2   | `round_to_precision_inplace` audit         | S      | **DONE** | code-quality; ~0% on divide bench (noise)       |
-| T-A1   | `debug_assert .format` sweep across        | S      | **DONE** | sweep complete (20260606);                      |
-|        |                                            |        |          | no .format asserts remain                       |
-|        | BigDecimal                                 |        |          |                                                 |
-| T-A2   | `multiply_by_power_of_ten` audit           | M      | **DONE** | inplace + multiple-of-9 fast path in use;       |
-|        | + inplace variant                          |        |          | minor residual in non-inplace add/sub           |
-| T-A3   | Hot-path-first switch in `add`/`sub`       | S      | **DONE** | subtract −37%@p1000, −24%@p100;                 |
-|        |                                            |        |          | add −13%@p1000; add@p100 noise                  |
-| T-A4   | `@no_inline` raise helpers in              | S      | **DONE** | `_shorten_path` `@no_inline`;                   |
-|        | BigDecimal/BigUInt                         |        |          | shrinks every inlined raise site                |
-| T-A5   | `is_zero`/`is_integer` branch audit        | S      | **DONE** | kept; removal = 3x regression on zero           |
-| T-M1   | Small-coefficient mul fast path            | M      | **NO**   | UInt128 path 130 vs 46 ns (base-10⁹)            |
-| T-M2   | Single-pass rounding in `multiply`         | S      | **DONE** | already single-pass; 90→80 ns                   |
-| T-D1   | Short-divisor fast path in `divide`        | M      | **DONE** | already via BigUInt dispatch                    |
-| T-D2   | Trailing-zero strip allocation in divide   | S      | **DONE** | inplace strip; −16–21% exact-divide             |
-| T-D3   | Reciprocal-Newton divide (legacy Task 2)   | XL     | **WAIT** | div only 2.1–3.1× mul →                         |
-|        |                                            |        |          | recip-Newton ~5× mul (slower); gated on NTT     |
-| T-S1   | Small-coef short-circuit in `sqrt` p=100   | S      | **NO**   | already short-circuits                          |
-| T-L1   | atanh reformulation for ln (T3f)           | M      | **DONE** | already a hybrid; near-1 0.9–1.8× py            |
-| T-L2   | Process-wide ln(10) cache recipe           | S      | **DONE** | `MathCache` (ln2/ln1.25/ln10) + recipe exist;   |
-|        |                                            |        |          | auto-cache blocked on Mojo                      |
-| T-L3   | AGM ln for p ≥ 1000 (T3g)                  | XL     | **WAIT** | gated on NTT (heavy per-iter sqrt);             |
-|        |                                            |        |          | far-from-1 ln now addressed by T-3e             |
-| T-IO1  | `from_string` digit batching               | M      | **DONE** | batching already present;                       |
-|        |                                            |        |          | slice removed, 1.4×→1.2×                        |
-| T-IO2  | `to_string` right-aligned InlineArray      | M      | **DONE** | hybrid exact-size direct-write;                 |
-|        |                                            |        |          | long 2.5–2.9×→0.8×                              |
-| T-R1   | `round` `.format` sweep                    | S      | **NO**   | no `.format` asserts in round; great            |
-| T-7b   | Reciprocal-Newton nth root                 | M      | **WAIT** | break-even at current mul speed                 |
-|        |                                            |        |          | (div ~2.7× mul); root already 0.2× py           |
-| T-PI4  | Binary-only `pi()` pipeline, convert once  | M      | **DONE** | 58.2 → 50.2 ms; sqrt + final mul left base 10^9 |
-| T-Sq1  | Newton step around the residual in sqrt    | S      | **DONE** | 1.6× in `sqrt_via_reciprocal_iteration`; only 6% in           |
-|        |                                            |        |          | `fast_isqrt`, whose time is elsewhere           |
-| T-Sq2  | Exact `sqrt()` refinement out of base 10^9 | M      | **OPEN** | exact path is 7.7× `sqrt_via_reciprocal_iteration`; one       |
-|        |                                            |        |          | full-width divide + square, both base 10^9      |
-| T-9b   | Product-scanning `BigUInt` schoolbook      | M      | **DONE** | 2.2× at 256 words; deferred-carry removed       |
-| T-9c   | Re-tune `BigUInt` mul cutoffs              | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms       |
-| T-D5   | Windowed fused mul-sub in schoolbook div   | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000  |
-| T-5    | NTT multiplication                         | XL     | **NEXT** | largest lever: 3.7× of the GMP mul gap is FFT   |
-| T-9    | deferred-carry schoolbook mul              | M      | **DONE** | deferred-carry (product-scanning);              |
-|        |                                            |        |          | Definitely worth bringing it to `BigInt` too    |
-| T-3e   | Faster ln constant series                  | L      | **DONE** | exact-reciprocal divide; ln(2) 9–21×,           |
-|        |                                            |        |          | ln(1.25) 3–4× at p≥1000                         |
-| T-U1   | Use pointers rather than list indexing     | M      | **DONE** | kept 2-buffer divide (+4-8% >=256w)             |
+| #      | Issue                                      | Effort | Priority | Target gain                                             |
+| ------ | ------------------------------------------ | ------ | -------- | ------------------------------------------------------- |
+| T-API1 | `precision` arg on `add`/`sub`/`multiply`  | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3          |
+| T-R2   | `round_to_precision_inplace` audit         | S      | **DONE** | code-quality; ~0% on divide bench (noise)               |
+| T-A1   | `debug_assert .format` sweep across        | S      | **DONE** | sweep complete (20260606);                              |
+|        |                                            |        |          | no .format asserts remain                               |
+|        | BigDecimal                                 |        |          |                                                         |
+| T-A2   | `multiply_by_power_of_ten` audit           | M      | **DONE** | inplace + multiple-of-9 fast path in use;               |
+|        | + inplace variant                          |        |          | minor residual in non-inplace add/sub                   |
+| T-A3   | Hot-path-first switch in `add`/`sub`       | S      | **DONE** | subtract −37%@p1000, −24%@p100;                         |
+|        |                                            |        |          | add −13%@p1000; add@p100 noise                          |
+| T-A4   | `@no_inline` raise helpers in              | S      | **DONE** | `_shorten_path` `@no_inline`;                           |
+|        | BigDecimal/BigUInt                         |        |          | shrinks every inlined raise site                        |
+| T-A5   | `is_zero`/`is_integer` branch audit        | S      | **DONE** | kept; removal = 3x regression on zero                   |
+| T-M1   | Small-coefficient mul fast path            | M      | **NO**   | UInt128 path 130 vs 46 ns (base-10⁹)                    |
+| T-M2   | Single-pass rounding in `multiply`         | S      | **DONE** | already single-pass; 90→80 ns                           |
+| T-D1   | Short-divisor fast path in `divide`        | M      | **DONE** | already via BigUInt dispatch                            |
+| T-D2   | Trailing-zero strip allocation in divide   | S      | **DONE** | inplace strip; −16–21% exact-divide                     |
+| T-D3   | Reciprocal-Newton divide (legacy Task 2)   | XL     | **WAIT** | div only 2.1–3.1× mul →                                 |
+|        |                                            |        |          | recip-Newton ~5× mul (slower); gated on NTT             |
+| T-S1   | Small-coef short-circuit in `sqrt` p=100   | S      | **NO**   | already short-circuits                                  |
+| T-L1   | atanh reformulation for ln (T3f)           | M      | **DONE** | already a hybrid; near-1 0.9–1.8× py                    |
+| T-L2   | Process-wide ln(10) cache recipe           | S      | **DONE** | `MathCache` (ln2/ln1.25/ln10) + recipe exist;           |
+|        |                                            |        |          | auto-cache blocked on Mojo                              |
+| T-L3   | AGM ln for p ≥ 1000 (T3g)                  | XL     | **WAIT** | gated on NTT (heavy per-iter sqrt);                     |
+|        |                                            |        |          | far-from-1 ln now addressed by T-3e                     |
+| T-IO1  | `from_string` digit batching               | M      | **DONE** | batching already present;                               |
+|        |                                            |        |          | slice removed, 1.4×→1.2×                                |
+| T-IO2  | `to_string` right-aligned InlineArray      | M      | **DONE** | hybrid exact-size direct-write;                         |
+|        |                                            |        |          | long 2.5–2.9×→0.8×                                      |
+| T-R1   | `round` `.format` sweep                    | S      | **NO**   | no `.format` asserts in round; great                    |
+| T-7b   | Reciprocal-Newton nth root                 | M      | **WAIT** | break-even at current mul speed                         |
+|        |                                            |        |          | (div ~2.7× mul); root already 0.2× py                   |
+| T-PI4  | Binary-only `pi()` pipeline, convert once  | M      | **DONE** | 58.2 → 50.2 ms; sqrt + final mul left base 10^9         |
+| T-Sq1  | Newton step around the residual in sqrt    | S      | **DONE** | 1.6× in `sqrt_via_reciprocal_iteration`; only 6% in     |
+|        |                                            |        |          | `isqrt_via_reciprocal_seed`, whose time is elsewhere    |
+| T-Sq2  | Exact `sqrt()` refinement out of base 10^9 | M      | **OPEN** | exact path is 7.7× `sqrt_via_reciprocal_iteration`; one |
+|        |                                            |        |          | full-width divide + square, both base 10^9              |
+| T-9b   | Product-scanning `BigUInt` schoolbook      | M      | **DONE** | 2.2× at 256 words; deferred-carry removed               |
+| T-9c   | Re-tune `BigUInt` mul cutoffs              | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms               |
+| T-D5   | Windowed fused mul-sub in schoolbook div   | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000          |
+| T-5    | NTT multiplication                         | XL     | **NEXT** | largest lever: 3.7× of the GMP mul gap is FFT           |
+| T-9    | deferred-carry schoolbook mul              | M      | **DONE** | deferred-carry (product-scanning);                      |
+|        |                                            |        |          | Definitely worth bringing it to `BigInt` too            |
+| T-3e   | Faster ln constant series                  | L      | **DONE** | exact-reciprocal divide; ln(2) 9–21×,                   |
+|        |                                            |        |          | ln(1.25) 3–4× at p≥1000                                 |
+| T-U1   | Use pointers rather than list indexing     | M      | **DONE** | kept 2-buffer divide (+4-8% >=256w)                     |

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -105,6 +105,10 @@ that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 |          |      | 10.4 → 6.6 ms at p=100000                                                |
 | 20260824 | #275 | 64-bit limbs inside the `BigInt` schoolbook base case                    |
 |          |      | (`bigint_enhancement.md` T-M4), plus cutoffs re-tuned. Total: 78 → 55 ms |
+| 20260824 | #276 | `fast_isqrt()` Newton step rearranged around the residual too (T-Sq1);   |
+|          |      | only 6% — `sqrt(10005, 50000)` 19.3 → 18.2 ms. See T-Sq2                 |
+| 20260824 | #276 | Binary-only `pi()` tail via `reciprocal_isqrt_fixed()` (T-PI4);          |
+|          |      | sqrt and final multiplies leave base 10^9. Total: 58.2 → 50.2 ms         |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -706,15 +710,28 @@ P5 — ln far-from-1 (4.6×–9.2× py → target ≤2×)
   largely addressed by T-3e, which removed the dominant constant-series
   cost.)
 
-- **T-5: NTT multiplication. Assessed during the P4 sweep — valid but
-  out of scope for an incremental change (20260618).** NTT is the single
-  biggest long-term item and the enabler for T-D3 / T-L3 / T-7b. It is
-  beneficial only for very large operands (≳1024 words ≈ 9000+ digits),
-  i.e. the p≥10000 tail. Implementing a correct base-10⁹ NTT (prime
-  selection, forward/inverse transforms, CRT recombination, carry
-  handling) is a multi-session XL effort with substantial correctness
-  risk and is not a safe single-pass edit; it remains tracked in §5.3 as
-  dedicated future work rather than something to land inline.
+- **T-5: NTT multiplication. The largest remaining lever, and it pays at
+  the sizes we already benchmark (re-assessed 20260824).** NTT is the
+  enabler for T-D3 / T-L3 / T-7b. GMP's own FFT threshold measures at
+  ~1 600 limbs (≈32 000 digits) and is worth 3.7× to it at 100 000
+  digits — see `internal/internal_notes.md`. That kills the earlier
+  reading that NTT only matters in some ≳10⁶-digit tail, and it also
+  kills Toom-4, whose window would sit between our 768-word Toom-3
+  cutoff and the NTT threshold and which the `pi` tree shape makes worth
+  a couple of percent at best.
+
+  Build it on `BigInt` (base 2^32), not base 10⁹: NTT wants binary
+  coefficients, and this is the same argument as T-PI4. Split the words
+  into 16-bit coefficients. The design choice to settle first is the
+  prime, and it is architecture-bound — the Goldilocks prime
+  `2^64 − 2^32 + 1` needs no CRT and reduces in a few adds, but NEON has
+  no 64×64 multiply, so it runs scalar on arm64; two 31-bit NTT-friendly
+  primes plus CRT double the transform count but vectorise 4-wide via
+  `umull`. Benchmark both before committing.
+
+  Still a multi-session XL effort with substantial correctness risk, and
+  not a safe single-pass edit; tracked in §5.3 as dedicated future
+  work.
 
 P6 — `from_string` / `to_string` (1.2–1.3× py → target ≤1.0×)
 
@@ -809,29 +826,40 @@ P7 — `round` (2× py → target ≤1.0×)
   rounding-dominated fast paths (e.g. small-coefficient `add` /
   `subtract` / `multiply` with `precision > 0`).
 
-**T-PI4 — keep the `pi()` pipeline binary, convert once. OPEN.**
-Stage breakdown at p=100000, end of 2026-08-24 (56 ms total):
+**T-PI4 — keep the `pi()` pipeline binary, convert once. DONE 20260824.**
+Stage breakdown at p=100000, before and after:
 
-| Stage                              | ms   | Base |
-| ---------------------------------- | ---- | ---- |
-| binary splitting, below the root   | 16.8 | 2^32 |
-| base 2^32 → 10^9                   |  9.8 | both |
-| `sqrt_reciprocal(10005)`           |  7.0 | 10^9 |
-| final division                     |  6.6 | 2^32 |
-| root join, 3 full-width multiplies |  6.5 | 2^32 |
-| final multiplies and round         |  6.4 | 10^9 |
-| `5^s` and the scaling multiply     |  3.3 | 2^32 |
+| Stage                              | before   | after    | Base |
+| ---------------------------------- | -------- | -------- | ---- |
+| binary splitting, below the root   | 16.8     | 16       | 2^32 |
+| base 2^32 → 10^9                   | 9.8      | 9        | both |
+| `sqrt_reciprocal(10005)`           | 7.0      | 2        | 2^32 |
+| final division                     | 6.6      | 6        | 2^32 |
+| root join, 3 full-width multiplies | 6.5      | 6        | 2^32 |
+| final multiplies and round         | 6.4      | 2        | 2^32 |
+| `5^s` and the scaling multiply     | 3.3      | 3        | 2^32 |
+| **total**                          | **58.2** | **50.2** |      |
 
-The two base-10^9 stages are now 13.4 ms of the 56, and `BigInt` multiply has
-pulled 2.8× ahead of `BigUInt` multiply (2.3 ms vs 6.4 at 100 000 digits)
-because the 64-bit packing of T-M4 has no base-10^9 analogue. A fixed-point
-reciprocal square root on `BigInt`, with the final multiply following it and a
-single conversion at the end, is worth roughly 8 ms — up from the 5 ms it was
-worth this morning, because the gap between the two bases has widened.
+The square root and both final multiplications used to run in base 10^9, where
+a multiplication costs about 2.8× what it costs in base 2^32 (6.4 ms vs 2.3 at
+100 000 digits) because the 64-bit packing of T-M4 has no base-10^9 analogue.
+Moving them cost nothing in conversions: there was one before and there is one
+now, it just happens on the finished value instead of on the quotient.
 
-Below that the multiplication exponent itself has to come down (T-5, NTT).
-For scale, MPFR 4.2.2 + GMP 6.3 does the same 100 000 digits in 20.7 ms
-(18.6 compute + 2.1 to-string), and mpmath on gmpy2 in ~16 ms.
+The enabler is `bigint.exponential.reciprocal_isqrt_fixed()`, which returns
+`2^f / sqrt(x)` as a binary fixed-point integer. Writing the formula as
+`426880 * 10005 / √10005 * (q/t)` is what lets the irrational factor enter as
+a reciprocal — Newton reaches it with no division at all — and
+`426880 * 10005 = 4270934400` still fits in a word.
+
+`pi(1000)` 82 → 71 µs, `pi(10000)` 1.74 → 1.59 ms, `pi(100000)` 58.2 → 50.2 ms,
+digit-exact against MPFR at every precision tested from 1 to 100 000.
+
+What is left is one conversion (9 ms, irreducible while `BigDecimal` is base
+10^9) and the splitting itself. Below that the multiplication exponent has to
+come down (T-5, NTT). For scale, MPFR 4.2.2 + GMP 6.3 does the same 100 000
+digits in 20.7 ms (18.6 compute + 2.1 to-string), and mpmath on gmpy2 in
+~16 ms.
 
 ### 5.3 Long-term tasks not on the active roadmap
 
@@ -909,47 +937,50 @@ binary splitting). All implementable in base-10^9.
 Open items in priority order (target: dm/py ≤ 1.5× across the board,
 some ops < 1.0×):
 
-| #      | Issue                                     | Effort | Priority | Target gain                                    |
-| ------ | ----------------------------------------- | ------ | -------- | ---------------------------------------------- |
-| T-API1 | `precision` arg on `add`/`sub`/`multiply` | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3 |
-| T-R2   | `round_to_precision_inplace` audit        | S      | **DONE** | code-quality; ~0% on divide bench (noise)      |
-| T-A1   | `debug_assert .format` sweep across       | S      | **DONE** | sweep complete (20260606);                     |
-|        |                                           |        |          | no .format asserts remain                      |
-|        | BigDecimal                                |        |          |                                                |
-| T-A2   | `multiply_by_power_of_ten` audit          | M      | **DONE** | inplace + multiple-of-9 fast path in use;      |
-|        | + inplace variant                         |        |          | minor residual in non-inplace add/sub          |
-| T-A3   | Hot-path-first switch in `add`/`sub`      | S      | **DONE** | subtract −37%@p1000, −24%@p100;                |
-|        |                                           |        |          | add −13%@p1000; add@p100 noise                 |
-| T-A4   | `@no_inline` raise helpers in             | S      | **DONE** | `_shorten_path` `@no_inline`;                  |
-|        | BigDecimal/BigUInt                        |        |          | shrinks every inlined raise site               |
-| T-A5   | `is_zero`/`is_integer` branch audit       | S      | **DONE** | kept; removal = 3x regression on zero          |
-| T-M1   | Small-coefficient mul fast path           | M      | **NO**   | UInt128 path 130 vs 46 ns (base-10⁹)           |
-| T-M2   | Single-pass rounding in `multiply`        | S      | **DONE** | already single-pass; 90→80 ns                  |
-| T-D1   | Short-divisor fast path in `divide`       | M      | **DONE** | already via BigUInt dispatch                   |
-| T-D2   | Trailing-zero strip allocation in divide  | S      | **DONE** | inplace strip; −16–21% exact-divide            |
-| T-D3   | Reciprocal-Newton divide (legacy Task 2)  | XL     | **WAIT** | div only 2.1–3.1× mul →                        |
-|        |                                           |        |          | recip-Newton ~5× mul (slower); gated on NTT    |
-| T-S1   | Small-coef short-circuit in `sqrt` p=100  | S      | **NO**   | already short-circuits                         |
-| T-L1   | atanh reformulation for ln (T3f)          | M      | **DONE** | already a hybrid; near-1 0.9–1.8× py           |
-| T-L2   | Process-wide ln(10) cache recipe          | S      | **DONE** | `MathCache` (ln2/ln1.25/ln10) + recipe exist;  |
-|        |                                           |        |          | auto-cache blocked on Mojo                     |
-| T-L3   | AGM ln for p ≥ 1000 (T3g)                 | XL     | **WAIT** | gated on NTT (heavy per-iter sqrt);            |
-|        |                                           |        |          | far-from-1 ln now addressed by T-3e            |
-| T-IO1  | `from_string` digit batching              | M      | **DONE** | batching already present;                      |
-|        |                                           |        |          | slice removed, 1.4×→1.2×                       |
-| T-IO2  | `to_string` right-aligned InlineArray     | M      | **DONE** | hybrid exact-size direct-write;                |
-|        |                                           |        |          | long 2.5–2.9×→0.8×                             |
-| T-R1   | `round` `.format` sweep                   | S      | **NO**   | no `.format` asserts in round; great           |
-| T-7b   | Reciprocal-Newton nth root                | M      | **WAIT** | break-even at current mul speed                |
-|        |                                           |        |          | (div ~2.7× mul); root already 0.2× py          |
-| T-PI4  | Binary-only `pi()` pipeline, convert once | M      | **OPEN** | now the biggest item left: ~8 ms of the 55 ms  |
-| T-Sq1  | Newton step around the residual in sqrt   | S      | **DONE** | 1.6× at p=100000; correction mul halves        |
-| T-9b   | Product-scanning `BigUInt` schoolbook     | M      | **DONE** | 2.2× at 256 words; deferred-carry removed      |
-| T-9c   | Re-tune `BigUInt` mul cutoffs             | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms      |
-| T-D5   | Windowed fused mul-sub in schoolbook div  | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000 |
-| T-5    | NTT multiplication                        | XL     | **WAIT** | valid; multi-session XL, tracked in §5.3       |
-| T-9    | deferred-carry schoolbook mul             | M      | **DONE** | deferred-carry (product-scanning);             |
-|        |                                           |        |          | Definitely worth bringing it to `BigInt` too   |
-| T-3e   | Faster ln constant series                 | L      | **DONE** | exact-reciprocal divide; ln(2) 9–21×,          |
-|        |                                           |        |          | ln(1.25) 3–4× at p≥1000                        |
-| T-U1   | Use pointers rather than list indexing    | M      | **DONE** | kept 2-buffer divide (+4-8% >=256w)            |
+| #      | Issue                                      | Effort | Priority | Target gain                                     |
+| ------ | ------------------------------------------ | ------ | -------- | ----------------------------------------------- |
+| T-API1 | `precision` arg on `add`/`sub`/`multiply`  | S      | **DONE** | exact-then-round; foundation for T-API2/T-API3  |
+| T-R2   | `round_to_precision_inplace` audit         | S      | **DONE** | code-quality; ~0% on divide bench (noise)       |
+| T-A1   | `debug_assert .format` sweep across        | S      | **DONE** | sweep complete (20260606);                      |
+|        |                                            |        |          | no .format asserts remain                       |
+|        | BigDecimal                                 |        |          |                                                 |
+| T-A2   | `multiply_by_power_of_ten` audit           | M      | **DONE** | inplace + multiple-of-9 fast path in use;       |
+|        | + inplace variant                          |        |          | minor residual in non-inplace add/sub           |
+| T-A3   | Hot-path-first switch in `add`/`sub`       | S      | **DONE** | subtract −37%@p1000, −24%@p100;                 |
+|        |                                            |        |          | add −13%@p1000; add@p100 noise                  |
+| T-A4   | `@no_inline` raise helpers in              | S      | **DONE** | `_shorten_path` `@no_inline`;                   |
+|        | BigDecimal/BigUInt                         |        |          | shrinks every inlined raise site                |
+| T-A5   | `is_zero`/`is_integer` branch audit        | S      | **DONE** | kept; removal = 3x regression on zero           |
+| T-M1   | Small-coefficient mul fast path            | M      | **NO**   | UInt128 path 130 vs 46 ns (base-10⁹)            |
+| T-M2   | Single-pass rounding in `multiply`         | S      | **DONE** | already single-pass; 90→80 ns                   |
+| T-D1   | Short-divisor fast path in `divide`        | M      | **DONE** | already via BigUInt dispatch                    |
+| T-D2   | Trailing-zero strip allocation in divide   | S      | **DONE** | inplace strip; −16–21% exact-divide             |
+| T-D3   | Reciprocal-Newton divide (legacy Task 2)   | XL     | **WAIT** | div only 2.1–3.1× mul →                         |
+|        |                                            |        |          | recip-Newton ~5× mul (slower); gated on NTT     |
+| T-S1   | Small-coef short-circuit in `sqrt` p=100   | S      | **NO**   | already short-circuits                          |
+| T-L1   | atanh reformulation for ln (T3f)           | M      | **DONE** | already a hybrid; near-1 0.9–1.8× py            |
+| T-L2   | Process-wide ln(10) cache recipe           | S      | **DONE** | `MathCache` (ln2/ln1.25/ln10) + recipe exist;   |
+|        |                                            |        |          | auto-cache blocked on Mojo                      |
+| T-L3   | AGM ln for p ≥ 1000 (T3g)                  | XL     | **WAIT** | gated on NTT (heavy per-iter sqrt);             |
+|        |                                            |        |          | far-from-1 ln now addressed by T-3e             |
+| T-IO1  | `from_string` digit batching               | M      | **DONE** | batching already present;                       |
+|        |                                            |        |          | slice removed, 1.4×→1.2×                        |
+| T-IO2  | `to_string` right-aligned InlineArray      | M      | **DONE** | hybrid exact-size direct-write;                 |
+|        |                                            |        |          | long 2.5–2.9×→0.8×                              |
+| T-R1   | `round` `.format` sweep                    | S      | **NO**   | no `.format` asserts in round; great            |
+| T-7b   | Reciprocal-Newton nth root                 | M      | **WAIT** | break-even at current mul speed                 |
+|        |                                            |        |          | (div ~2.7× mul); root already 0.2× py           |
+| T-PI4  | Binary-only `pi()` pipeline, convert once  | M      | **DONE** | 58.2 → 50.2 ms; sqrt + final mul left base 10^9 |
+| T-Sq1  | Newton step around the residual in sqrt    | S      | **DONE** | 1.6× in `sqrt_reciprocal`; only 6% in           |
+|        |                                            |        |          | `fast_isqrt`, whose time is elsewhere           |
+| T-Sq2  | Exact `sqrt()` refinement out of base 10^9 | M      | **OPEN** | exact path is 7.7× `sqrt_reciprocal`; one       |
+|        |                                            |        |          | full-width divide + square, both base 10^9      |
+| T-9b   | Product-scanning `BigUInt` schoolbook      | M      | **DONE** | 2.2× at 256 words; deferred-carry removed       |
+| T-9c   | Re-tune `BigUInt` mul cutoffs              | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms       |
+| T-D5   | Windowed fused mul-sub in schoolbook div   | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000  |
+| T-5    | NTT multiplication                         | XL     | **NEXT** | largest lever: 3.7× of the GMP mul gap is FFT   |
+| T-9    | deferred-carry schoolbook mul              | M      | **DONE** | deferred-carry (product-scanning);              |
+|        |                                            |        |          | Definitely worth bringing it to `BigInt` too    |
+| T-3e   | Faster ln constant series                  | L      | **DONE** | exact-reciprocal divide; ln(2) 9–21×,           |
+|        |                                            |        |          | ln(1.25) 3–4× at p≥1000                         |
+| T-U1   | Use pointers rather than list indexing     | M      | **DONE** | kept 2-buffer divide (+4-8% >=256w)             |

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -89,7 +89,7 @@ that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 | 20260823 | #269 | Chudnovsky `P`/`Q`/`T` recurrence — O(1) leaves, root denominator is one |
 |          |      | term's worth instead of the product of every term's                      |
 | 20260823 | #269 | Binary splitting moved from `BigDecimal` to `BigInt`                     |
-| 20260823 | #270 | `sqrt_reciprocal()` instead of the exact `sqrt()` (which costs two       |
+| 20260823 | #270 | `sqrt_via_reciprocal_iteration()` instead of the exact `sqrt()` (which costs two       |
 |          |      | full-size divisions to reproduce CPython's perfect-square test)          |
 | 20260823 | #270 | Divide once in binary, convert only the quotient; `10^s` as `5^s << s`   |
 | 20260823 | #270 | Leaves packed from `UInt128` — was half the split's time at p=1000       |
@@ -101,13 +101,13 @@ that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 |          |      | a 100 000-digit `BigUInt` multiply 10.5 → 6.0 ms                         |
 | 20260824 | #274 | Product-scanning `BigUInt` schoolbook mul, windowed schoolbook div,      |
 |          |      | dead `right.p` at the root of the split. Total: 142 → 78 ms              |
-| 20260824 | #275 | `sqrt_reciprocal()` Newton step rearranged around the residual (T-Sq1)   |
+| 20260824 | #275 | `sqrt_via_reciprocal_iteration()` Newton step rearranged around the residual (T-Sq1)   |
 |          |      | 10.4 → 6.6 ms at p=100000                                                |
 | 20260824 | #275 | 64-bit limbs inside the `BigInt` schoolbook base case                    |
 |          |      | (`bigint_enhancement.md` T-M4), plus cutoffs re-tuned. Total: 78 → 55 ms |
 | 20260824 | #276 | `fast_isqrt()` Newton step rearranged around the residual too (T-Sq1);   |
 |          |      | only 6% — `sqrt(10005, 50000)` 19.3 → 18.2 ms. See T-Sq2                 |
-| 20260824 | #276 | Binary-only `pi()` tail via `reciprocal_isqrt_fixed()` (T-PI4);          |
+| 20260824 | #276 | Binary-only `pi()` tail via `reciprocal_sqrt_fixed_point()` (T-PI4);          |
 |          |      | sqrt and final multiplies leave base 10^9. Total: 58.2 → 50.2 ms         |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
@@ -255,7 +255,7 @@ because the lesson generalises to the variable-length case unchanged.
    $2\sqrt{3.322p}$ multiplies. **2.6× py at p=1000.**
 
 5. **Repeated-sqrt range reduction for ln REGRESSES** by 100×.
-   `sqrt_reciprocal` per call costs more than the Taylor terms it
+   `sqrt_via_reciprocal_iteration` per call costs more than the Taylor terms it
    saves. Use `atanh` reformulation (T3f) instead.
 
 6. **Wasted quotient words dominate asymmetric division.** The T1 fix
@@ -833,7 +833,7 @@ Stage breakdown at p=100000, before and after:
 | ---------------------------------- | -------- | -------- | ---- |
 | binary splitting, below the root   | 16.8     | 16       | 2^32 |
 | base 2^32 → 10^9                   | 9.8      | 9        | both |
-| `sqrt_reciprocal(10005)`           | 7.0      | 2        | 2^32 |
+| `sqrt_via_reciprocal_iteration(10005)`           | 7.0      | 2        | 2^32 |
 | final division                     | 6.6      | 6        | 2^32 |
 | root join, 3 full-width multiplies | 6.5      | 6        | 2^32 |
 | final multiplies and round         | 6.4      | 2        | 2^32 |
@@ -846,7 +846,7 @@ a multiplication costs about 2.8× what it costs in base 2^32 (6.4 ms vs 2.3 at
 Moving them cost nothing in conversions: there was one before and there is one
 now, it just happens on the finished value instead of on the quotient.
 
-The enabler is `bigint.exponential.reciprocal_isqrt_fixed()`, which returns
+The enabler is `bigint.exponential.reciprocal_sqrt_fixed_point()`, which returns
 `2^f / sqrt(x)` as a binary fixed-point integer. Writing the formula as
 `426880 * 10005 / √10005 * (q/t)` is what lets the irrational factor enter as
 a reciprocal — Newton reaches it with no division at all — and
@@ -971,9 +971,9 @@ some ops < 1.0×):
 | T-7b   | Reciprocal-Newton nth root                 | M      | **WAIT** | break-even at current mul speed                 |
 |        |                                            |        |          | (div ~2.7× mul); root already 0.2× py           |
 | T-PI4  | Binary-only `pi()` pipeline, convert once  | M      | **DONE** | 58.2 → 50.2 ms; sqrt + final mul left base 10^9 |
-| T-Sq1  | Newton step around the residual in sqrt    | S      | **DONE** | 1.6× in `sqrt_reciprocal`; only 6% in           |
+| T-Sq1  | Newton step around the residual in sqrt    | S      | **DONE** | 1.6× in `sqrt_via_reciprocal_iteration`; only 6% in           |
 |        |                                            |        |          | `fast_isqrt`, whose time is elsewhere           |
-| T-Sq2  | Exact `sqrt()` refinement out of base 10^9 | M      | **OPEN** | exact path is 7.7× `sqrt_reciprocal`; one       |
+| T-Sq2  | Exact `sqrt()` refinement out of base 10^9 | M      | **OPEN** | exact path is 7.7× `sqrt_via_reciprocal_iteration`; one       |
 |        |                                            |        |          | full-width divide + square, both base 10^9      |
 | T-9b   | Product-scanning `BigUInt` schoolbook      | M      | **DONE** | 2.2× at 256 words; deferred-carry removed       |
 | T-9c   | Re-tune `BigUInt` mul cutoffs              | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms       |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -283,8 +283,10 @@ word boundary into two `UInt128` accumulators avoids that: each half is below
 | 182   | 6 630           | 3 400         |
 
 A 100 000-digit multiply went 3.44 → 2.30 ms, and `pi(100000)` 78 → 55 ms.
-GMP does the same multiply in 0.39 ms, so it is still 5.9× ahead — it is on
-FFT at this size and we are not (T-5).
+GMP does the same multiply in 0.39 ms, so it is still 5.9× ahead. Measuring
+its exponent across sizes splits that gap: GMP moves to FFT at ~1 600 limbs
+(≈32 000 digits), which is worth 3.7× to it at 100 000 digits, leaving only
+1.6× for base case, glue and assembly. See `internal/internal_notes.md`.
 
 Watch out for Mojo's ASAP destruction here: the packed operands are only
 touched through raw pointers, so without an explicit `_ = limbs_a^` the
@@ -385,4 +387,5 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-A1  | add/sub dispatch reorder                         | OPEN                                  |
 | T-SH1 | Pre-size the shift result buffer                 | OPEN                                  |
 | T-W1  | Base-2^64 limbs throughout                       | PARTLY — T-M4 does it in the kernel   |
+| T-E1  | `reciprocal_isqrt_fixed()` binary recip. sqrt    | DONE 2026-08-24 — enables T-PI4       |
 | T-D4  | Reciprocal-Newton divide                         | DEFERRED — needs NTT, not Toom-3      |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -387,5 +387,5 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-A1  | add/sub dispatch reorder                         | OPEN                                  |
 | T-SH1 | Pre-size the shift result buffer                 | OPEN                                  |
 | T-W1  | Base-2^64 limbs throughout                       | PARTLY — T-M4 does it in the kernel   |
-| T-E1  | `reciprocal_isqrt_fixed()` binary recip. sqrt    | DONE 2026-08-24 — enables T-PI4       |
+| T-E1  | `reciprocal_sqrt_fixed_point()` binary recip. sqrt    | DONE 2026-08-24 — enables T-PI4       |
 | T-D4  | Reciprocal-Newton divide                         | DEFERRED — needs NTT, not Toom-3      |

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -22,7 +22,8 @@ from decimo.errors import ValueError
 from decimo.bigint.bigint import BigInt
 from decimo.biguint.biguint import BigUInt
 from decimo.rounding_mode import RoundingMode
-import decimo.bigdecimal.exponential as bigdecimal_exponential
+import decimo.bigint.arithmetics as bigint_arithmetics
+import decimo.bigint.exponential as bigint_exponential
 import decimo.bigdecimal.trigonometric as bigdecimal_trigonometric
 
 comptime PI_1024 = BigDecimal(
@@ -307,9 +308,6 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     # 16 terms where 11 will do.
     var iterations = (working_precision + 13) // 14 + 3
 
-    var bdec_10005 = BigDecimal.from_raw_components(UInt32(10005))
-    var bdec_426880 = BigDecimal.from_raw_components(UInt32(426880))
-
     # Binary splitting to compute the series sum as a single rational number.
     #
     # The two halves are joined here rather than through
@@ -363,23 +361,34 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
 
     var scaled = (numerator * BigInt(5).power(scale_digits)) << scale_digits
     var quotient = scaled.truncate_divide(denominator)
-    var sum_series = BigDecimal(
-        quotient.to_biguint(), scale_digits, quotient.sign
-    )
 
-    # Final formula: π = 426880 * √10005 * (q / t)
+    # Final formula: π = 426880 * √10005 * (q / t).
     #
-    # `sqrt_reciprocal()` rather than the public `sqrt()`: the latter is
-    # `sqrt_exact()`, which reproduces CPython's `Decimal.sqrt()` bit for bit
-    # by computing an exact `isqrt` and testing whether the input is a perfect
-    # square. Both of those cost full-size divisions, and neither means
-    # anything for a fixed non-square integer used as an intermediate. The
-    # division-free Newton iteration gives the same digits here for a fraction
-    # of the work - it was the single largest line item in `pi()`, ahead of the
-    # binary splitting itself.
-    var result = bdec_426880.multiply(
-        bigdecimal_exponential.sqrt_reciprocal(bdec_10005, working_precision)
-    ).multiply(sum_series)
+    # Written as `426880 * 10005 / √10005` so that the irrational factor enters
+    # as a *reciprocal* square root, which Newton computes without a single
+    # division. `426880 * 10005 = 4270934400`, which still fits in a word.
+    #
+    # All three factors are combined in `BigInt` and converted to base 10^9
+    # exactly once, at the end. The obvious alternative - build a `BigDecimal`
+    # from `quotient` and multiply it by `sqrt_reciprocal()` - converts here
+    # instead of at the end, and then does the square root and both final
+    # multiplications in base 10^9, where the same multiplication costs about
+    # 2.8x what it does in base 2^32. Same number of conversions, three
+    # expensive stages moved to the cheaper base.
+    #
+    # `quotient` takes the word factor first: `(quotient * r) >> frac_bits`
+    # would truncate before the multiplication and turn one unit in the last
+    # place into 4.3 billion of them.
+    var frac_bits = (scale_digits + 32) * 10 // 3  # 10/3 > log2(10)
+    var reciprocal_root = bigint_exponential.reciprocal_isqrt_fixed(
+        UInt64(10005), frac_bits
+    )
+    var magnitude = (
+        (bigint_arithmetics.absolute(quotient) * BigInt(4270934400))
+        * reciprocal_root
+    ) >> frac_bits
+
+    var result = BigDecimal(magnitude.to_biguint(), scale_digits, quotient.sign)
 
     result.round_to_precision_inplace(
         precision,

--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -370,23 +370,23 @@ def pi_chudnovsky_binary_split(precision: Int) raises -> BigDecimal:
     #
     # All three factors are combined in `BigInt` and converted to base 10^9
     # exactly once, at the end. The obvious alternative - build a `BigDecimal`
-    # from `quotient` and multiply it by `sqrt_reciprocal()` - converts here
+    # from `quotient` and multiply it by `sqrt_via_reciprocal_iteration()` - converts here
     # instead of at the end, and then does the square root and both final
     # multiplications in base 10^9, where the same multiplication costs about
     # 2.8x what it does in base 2^32. Same number of conversions, three
     # expensive stages moved to the cheaper base.
     #
-    # `quotient` takes the word factor first: `(quotient * r) >> frac_bits`
+    # `quotient` takes the word factor first: `(quotient * r) >> fractional_bits`
     # would truncate before the multiplication and turn one unit in the last
     # place into 4.3 billion of them.
-    var frac_bits = (scale_digits + 32) * 10 // 3  # 10/3 > log2(10)
-    var reciprocal_root = bigint_exponential.reciprocal_isqrt_fixed(
-        UInt64(10005), frac_bits
+    var fractional_bits = (scale_digits + 32) * 10 // 3  # 10/3 > log2(10)
+    var reciprocal_root = bigint_exponential.reciprocal_sqrt_fixed_point(
+        UInt64(10005), fractional_bits
     )
     var magnitude = (
         (bigint_arithmetics.absolute(quotient) * BigInt(4270934400))
         * reciprocal_root
-    ) >> frac_bits
+    ) >> fractional_bits
 
     var result = BigDecimal(magnitude.to_biguint(), scale_digits, quotient.sign)
 

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -45,7 +45,7 @@ the schedule.
 # - integer_root(x: BigDecimal, n: BigDecimal, precision: Int) -> BigDecimal
 # - is_integer_reciprocal_and_return(n: BigDecimal) -> Tuple[Bool, BigDecimal]
 # - is_odd_reciprocal(n: BigDecimal) -> Bool
-# - fast_isqrt(c: BigUInt, working_digits: Int) -> BigUInt
+# - isqrt_via_reciprocal_seed(c: BigUInt, working_digits: Int) -> BigUInt
 # - sqrt(x: BigDecimal, precision: Int) -> BigDecimal  [public API]
 # - sqrt_exact(x: BigDecimal, precision: Int) -> BigDecimal  [CPython-style]
 # - sqrt_via_reciprocal_iteration(x: BigDecimal, precision: Int) -> BigDecimal
@@ -1011,9 +1011,10 @@ def _rational_root_decomposition(
 #
 # In Decimo v0.6.0, `sqrt` is re-implemented as `sqrt_exact`, using the
 # CPython _pydecimal.py algorithm for bit-perfect results matching Python's
-# Decimal.sqrt() output. For large numbers (>20 words), `fast_isqrt` uses
-# reciprocal sqrt with precision doubling for a fast initial approximation,
-# then exact integer Newton iterations to converge to isqrt(c).
+# Decimal.sqrt() output. For large numbers (>20 words),
+# `isqrt_via_reciprocal_seed` uses reciprocal sqrt with precision doubling for
+# a fast initial approximation, then exact integer Newton iterations to
+# converge to isqrt(c).
 #
 # Function hierarchy:
 # - sqrt()
@@ -1027,7 +1028,7 @@ def _rational_root_decomposition(
 #       arctan, ln) where exact perfect-square detection is unnecessary.
 #       It returns the root itself, not the reciprocal - the reciprocal is
 #       `bigint.exponential.reciprocal_sqrt_fixed_point()`.
-# - fast_isqrt()
+# - isqrt_via_reciprocal_seed()
 #       Hybrid isqrt: reciprocal sqrt approximation + exact integer Newton
 #       refinement. Used by sqrt_exact() for large numbers.
 # - sqrt_decimal_approach()
@@ -1066,9 +1067,15 @@ def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return sqrt_exact(x, precision)
 
 
-def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
-    """Compute isqrt(c) using reciprocal sqrt with precision doubling for speed,
-    then verify/correct with exact integer Newton iterations.
+def isqrt_via_reciprocal_seed(
+    c: BigUInt, working_digits: Int
+) raises -> BigUInt:
+    """Returns `isqrt(c)`, seeded by a reciprocal square root approximation.
+
+    The seed is what makes this faster than a plain integer Newton: reaching
+    `sqrt(c)` through `1 / sqrt(c)` needs no division, so the approximation is
+    cheap, and the exact refinement that follows it then costs one or two
+    divisions instead of a full convergence.
 
     This is a hybrid approach:
     1. Use reciprocal sqrt Newton (division-free, precision doubling) to get
@@ -1345,7 +1352,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
     if len(c.words) <= 20:
         n = biguint_exponential.sqrt(c)
     else:
-        n = fast_isqrt(c, prec + 10)
+        n = isqrt_via_reciprocal_seed(c, prec + 10)
 
     # Check for exact perfect square
     exact = exact and (n * n == c)
@@ -1472,7 +1479,7 @@ def sqrt_via_reciprocal_iteration(
 
     var x_norm_exp = x_norm.adjusted()
     var x_norm_f64 = mantissa * Float64(10.0) ** Float64(x_norm_exp)
-    # `1 / sqrt(v)`, not `v ** -0.5`. See the note in `fast_isqrt()`: the power
+    # `1 / sqrt(v)`, not `v ** -0.5`. See the note in `isqrt_via_reciprocal_seed()`: the power
     # operator is accurate to only about ten digits for some inputs, which the
     # doubling schedule then carries all the way to the top.
     var r_f64 = Float64(1.0) / math.sqrt(x_norm_f64)  # 1/sqrt(x_norm)

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -48,7 +48,8 @@ the schedule.
 # - fast_isqrt(c: BigUInt, working_digits: Int) -> BigUInt
 # - sqrt(x: BigDecimal, precision: Int) -> BigDecimal  [public API]
 # - sqrt_exact(x: BigDecimal, precision: Int) -> BigDecimal  [CPython-style]
-# - sqrt_reciprocal(x: BigDecimal, precision: Int) -> BigDecimal  [fast, for internal use]
+# - sqrt_via_reciprocal_iteration(x: BigDecimal, precision: Int) -> BigDecimal
+#       [returns sqrt(x); fast, for internal use]
 # - sqrt_decimal_approach(x: BigDecimal, precision: Int) -> BigDecimal  [legacy]
 # - sqrt_newton(x: BigDecimal, precision: Int) -> BigDecimal  [legacy]
 # - exp(x: BigDecimal, precision: Int) -> BigDecimal
@@ -1015,25 +1016,31 @@ def _rational_root_decomposition(
 # then exact integer Newton iterations to converge to isqrt(c).
 #
 # Function hierarchy:
-# - sqrt()                : Public API, delegates to sqrt_exact().
-# - sqrt_exact()          : CPython-style exact integer algorithm. Produces
-#                           results identical to Python's Decimal.sqrt().
-# - sqrt_reciprocal()     : Fast reciprocal sqrt iteration. For use as an
-#                           intermediate function by other functions (e.g.,
-#                           arctan, ln) where exact perfect square detection
-#                           is unnecessary.
-# - fast_isqrt()          : Hybrid isqrt: reciprocal sqrt approximation +
-#                           exact integer Newton refinement. Used by
-#                           sqrt_exact() for large numbers.
-# - sqrt_decimal_approach() : Legacy implementation (v0.3.0).
-# - sqrt_newton()           : Legacy implementation (v0.5.0).
+# - sqrt()
+#       Public API, delegates to sqrt_exact().
+# - sqrt_exact()
+#       CPython-style exact integer algorithm. Produces results identical to
+#       Python's Decimal.sqrt().
+# - sqrt_via_reciprocal_iteration()
+#       Returns sqrt(x), reached through the division-free Newton iteration
+#       for 1/sqrt(x). For use as an intermediate by other functions (e.g.
+#       arctan, ln) where exact perfect-square detection is unnecessary.
+#       It returns the root itself, not the reciprocal - the reciprocal is
+#       `bigint.exponential.reciprocal_sqrt_fixed_point()`.
+# - fast_isqrt()
+#       Hybrid isqrt: reciprocal sqrt approximation + exact integer Newton
+#       refinement. Used by sqrt_exact() for large numbers.
+# - sqrt_decimal_approach()
+#       Legacy implementation (v0.3.0).
+# - sqrt_newton()
+#       Legacy implementation (v0.5.0).
 # ===----------------------------------------------------------------------=== #
 
 
 # TODO:
 # When global config for pad_zeros_to_precision is implemented,
 # Pass the config to sqrt() and use it to control whether to
-# call `sqrt_exact()` (pad zeros) or `sqrt_reciprocal()` (no padding)
+# call `sqrt_exact()` (pad zeros) or `sqrt_via_reciprocal_iteration()` (no padding)
 def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the square root of a BigDecimal number.
 
@@ -1043,7 +1050,7 @@ def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     Use this function when the result is returned directly to users.
     For intermediate computations inside other functions (e.g., arctan, ln),
-    prefer `sqrt_reciprocal()` for better performance.
+    prefer `sqrt_via_reciprocal_iteration()` for better performance.
 
     Args:
         x: The number to calculate the square root of.
@@ -1141,7 +1148,7 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
     # --- Newton iterations: r_{k+1} = r_k + r_k * (1 - c_norm * r_k^2) / 2 ---
     #
     # Rearranged around the residual for exactly the reason spelled out in
-    # `sqrt_reciprocal()`: `e = 1 - c_norm * r^2` is around `10^(-ip/2)`, and a
+    # `sqrt_via_reciprocal_iteration()`: `e = 1 - c_norm * r^2` is around `10^(-ip/2)`, and a
     # `BigDecimal` holds those leading zeros in the scale rather than the
     # coefficient, so the correction multiply is half-width by half-width where
     # `r * (3 - c_norm * r^2)` was half-width by full-width.
@@ -1257,7 +1264,7 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
 
     This function produces results identical to Python's `Decimal.sqrt()`.
     For better performance in intermediate computations where exact perfect
-    square detection is not needed, use `sqrt_reciprocal()` instead.
+    square detection is not needed, use `sqrt_via_reciprocal_iteration()` instead.
 
     Args:
         x: The number to calculate the square root of.
@@ -1377,9 +1384,16 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
     return result^
 
 
-def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
-    """Calculate the square root of a BigDecimal number using reciprocal square
-    root iteration.
+def sqrt_via_reciprocal_iteration(
+    x: BigDecimal, precision: Int
+) raises -> BigDecimal:
+    """Returns `sqrt(x)`, computed through a reciprocal square root iteration.
+
+    The return value is the square root itself, not its reciprocal; the
+    reciprocal only appears inside, because the Newton iteration for
+    `1 / sqrt(x)` needs no division where the one for `sqrt(x)` does. For the
+    reciprocal as a return value, see
+    `bigint.exponential.reciprocal_sqrt_fixed_point()`.
 
     Uses reciprocal square root Newton iteration with precision doubling:
         r_{k+1} = r_k + r_k * (1 - x * r_k^2) / 2   (computes 1/sqrt(x))
@@ -1411,7 +1425,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
     if x.sign:
         raise ValueError(
             message="Cannot compute square root of a negative number.",
-            function="sqrt_reciprocal()",
+            function="sqrt_via_reciprocal_iteration()",
         )
 
     if x.coefficient.is_zero():
@@ -1474,7 +1488,7 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # _F64_SEED_DIGITS * 2^n` and the `n` doublings below reach the top. A
     # higher stopping point silently returns fewer correct digits than asked
     # for: with the halving stopped at 20 the seed was credited with 20 digits
-    # it does not have, and `sqrt_reciprocal(10005, 5009)` came back correct to
+    # it does not have, and `sqrt_via_reciprocal_iteration(10005, 5009)` came back correct to
     # only 4244 digits.
     var prec_schedule = List[Int]()
     var p = working_precision

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -1135,10 +1135,16 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
         prec_schedule.append(p)
         p = (p + 1) // 2
 
-    # Constant 3
-    var three = BigDecimal(BigUInt(raw_words=[3]), 0, False)
+    # Constant 1
+    var one = BigDecimal(BigUInt(raw_words=[1]), 0, False)
 
-    # --- Reciprocal sqrt Newton iterations ---
+    # --- Newton iterations: r_{k+1} = r_k + r_k * (1 - c_norm * r_k^2) / 2 ---
+    #
+    # Rearranged around the residual for exactly the reason spelled out in
+    # `sqrt_reciprocal()`: `e = 1 - c_norm * r^2` is around `10^(-ip/2)`, and a
+    # `BigDecimal` holds those leading zeros in the scale rather than the
+    # coefficient, so the correction multiply is half-width by half-width where
+    # `r * (3 - c_norm * r^2)` was half-width by full-width.
     for i in range(len(prec_schedule) - 1, -1, -1):
         var ip = prec_schedule[i] + 10
 
@@ -1158,17 +1164,27 @@ def fast_isqrt(c: BigUInt, working_digits: Int) raises -> BigUInt:
             fill_zeros_to_precision=False,
         )
 
-        var correction = three.subtract(r_sq)
+        # e = 1 - c_norm * r^2, the Newton residual. Signed, and tiny.
+        var residual = one.subtract(r_sq)
 
-        bigdecimal_arithmetics.multiply_inplace(r, correction)
+        # r * e / 2
+        bigdecimal_arithmetics.multiply_inplace(residual, r)
+        residual.round_to_precision_inplace(
+            precision=ip,
+            rounding_mode=RoundingMode.half_up(),
+            remove_extra_digit_due_to_rounding=True,
+            fill_zeros_to_precision=False,
+        )
+        residual = residual.true_divide_inexact_by_uint32(UInt32(2), ip)
+
+        # r + r * e / 2
+        r = r.add(residual)
         r.round_to_precision_inplace(
             precision=ip,
             rounding_mode=RoundingMode.half_up(),
             remove_extra_digit_due_to_rounding=True,
             fill_zeros_to_precision=False,
         )
-
-        r = r.true_divide_inexact_by_uint32(UInt32(2), ip)
 
     # --- Compute sqrt(c) = c_norm * r * 10^(norm_shift/2) ---
     var result_bd = c_norm.multiply(r)
@@ -1366,8 +1382,12 @@ def sqrt_reciprocal(x: BigDecimal, precision: Int) raises -> BigDecimal:
     root iteration.
 
     Uses reciprocal square root Newton iteration with precision doubling:
-        r_{k+1} = r_k * (3 - x * r_k^2) / 2   (computes 1/sqrt(x))
+        r_{k+1} = r_k + r_k * (1 - x * r_k^2) / 2   (computes 1/sqrt(x))
     Then sqrt(x) = x * r.
+
+    That is the textbook `r * (3 - x * r^2) / 2` rearranged around the
+    residual, which makes the correction multiply half-width by half-width
+    instead of half-width by full-width. See the note on the loop itself.
 
     This avoids division entirely — each Newton iteration uses only
     multiplication, subtraction, and trivial divide-by-2. Combined with

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -545,9 +545,9 @@ def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
         # This is to ensure convergence of the Taylor series.
         # print("Using identity for arctan with |x| <= 2")
         # print(bdec_1 + x * x)
-        # Use sqrt_reciprocal for speed — exact perfect square detection is
+        # Use sqrt_via_reciprocal_iteration for speed — exact perfect square detection is
         # unnecessary since this is an intermediate computation.
-        var sqrt_term = bigdecimal_exponential.sqrt_reciprocal(
+        var sqrt_term = bigdecimal_exponential.sqrt_via_reciprocal_iteration(
             bdec_1.add(x.multiply(x)), working_precision
         )
         var x_divided = x.true_divide(

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -57,10 +57,11 @@ comptime CUTOFF_KARATSUBA: Int = 256
 # and interpolation step. The extra additions, the two exact divisions and
 # the five sub-results only pay for themselves once the operands are large.
 #
-# The crossover is soft rather than sharp, and it moved up with the Karatsuba
-# cutoff for the same reason. Measured on Apple Silicon arm64 with the tuned
-# base case, 512 is the best of 384 / 512 / 768 / 1024 across 512 to 11 000
-# words. Adjust if benchmarking on another target shows a better value.
+# The crossover is soft rather than sharp, and it moves up every time the base
+# case gets faster. Measured on Apple Silicon arm64 after the base case was
+# packed into 64-bit limbs, 768 is the best of 384 / 512 / 768 / 1024 across
+# 512 to 11 000 words; before the packing it was 512. Adjust if benchmarking
+# on another target shows a better value.
 comptime CUTOFF_TOOM3: Int = 768
 """The minimum number of words above which Toom-3 multiplication is used."""
 
@@ -177,8 +178,11 @@ def _subtract_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
 def _multiply_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     """Multiplies two unsigned magnitudes, dispatching to the best algorithm.
 
-    Uses Karatsuba O(n^1.585) for large operands, schoolbook O(n*m) for small.
-    Both algorithms use UInt64 for intermediate products.
+    Toom-3 O(n^1.465) above `CUTOFF_TOOM3`, Karatsuba O(n^1.585) above
+    `CUTOFF_KARATSUBA`, product-scanning schoolbook O(n*m) below it. The
+    schoolbook base case accumulates in `UInt128` over packed 64-bit limbs,
+    or in `UInt64` over 32-bit words when the operands are too small to repay
+    the packing - see `_multiply_magnitudes_schoolbook()`.
 
     Args:
         a: First magnitude (little-endian UInt32 words).
@@ -263,13 +267,19 @@ def _multiply_magnitude_by_word(
     return result^
 
 
-comptime CUTOFF_PACK_64: Int = 32
-"""Operand size at which the schoolbook kernel switches to 64-bit limbs.
+comptime CUTOFF_PACK_64_AREA: Int = 32 * 32
+"""Word-pair count at which the schoolbook kernel switches to 64-bit limbs.
 
 Packing costs three linear passes and two heap allocations either side of a
 quadratic loop. That is a rounding error at the Karatsuba cutoff but it is
 about 120 ns of fixed cost, which swamps a multiplication of a handful of
-words. Measured crossover is just under 30 words.
+words. Measured crossover is just under 30 words square.
+
+The gate is on `len_a * len_b`, the work the quadratic loop actually does,
+rather than on either operand alone. Packing is linear in `len_a + len_b`, so
+a lopsided product such as 31x250 words is worth packing even though one side
+is below the square crossover: it does 7 750 word pairs, and the 32-bit kernel
+needs all of them where the packed one needs 2 048.
 """
 
 
@@ -280,7 +290,7 @@ def _multiply_magnitudes_comba32(
 
     The small-operand half of `_multiply_magnitudes_schoolbook()`. Allocates
     nothing but the result, which is what makes it the better choice below
-    `CUTOFF_PACK_64`.
+    `CUTOFF_PACK_64_AREA`.
 
     Args:
         a: First magnitude, non-empty.
@@ -392,7 +402,7 @@ def _multiply_magnitudes_schoolbook(
         var zero: List[UInt32] = [UInt32(0)]
         return zero^
 
-    if len_a < CUTOFF_PACK_64 or len_b < CUTOFF_PACK_64:
+    if len_a * len_b < CUTOFF_PACK_64_AREA:
         return _multiply_magnitudes_comba32(a, b)
 
     comptime LOW_HALF = UInt128(0xFFFF_FFFF_FFFF_FFFF)
@@ -2077,7 +2087,8 @@ def absolute(x: BigInt) -> BigInt:
 def multiply(x1: BigInt, x2: BigInt) -> BigInt:
     """Returns the product of two BigInt numbers.
 
-    Uses schoolbook multiplication O(n*m) with UInt64 intermediate products.
+    Dispatches on operand size through `_multiply_magnitudes()`: Toom-3,
+    Karatsuba, or a product-scanning schoolbook base case.
 
     Args:
         x1: The first operand (multiplicand).

--- a/src/decimo/bigint/exponential.mojo
+++ b/src/decimo/bigint/exponential.mojo
@@ -478,7 +478,7 @@ def _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
 
 
 comptime _NEWTON_GUARD_BITS: Int = 4
-"""Bits of slack per Newton step in `reciprocal_isqrt_fixed()`.
+"""Bits of slack per Newton step in `reciprocal_sqrt_fixed_point()`.
 
 Each step truncates twice - once in the shift that forms the correction, once
 in the shift that rescales `r` - so the doubling of correct bits falls a little
@@ -503,15 +503,20 @@ def isqrt(x: BigInt) raises -> BigInt:
     return sqrt(x)
 
 
-def reciprocal_isqrt_fixed(x: UInt64, frac_bits: Int) raises -> BigInt:
-    """Returns `2^frac_bits / sqrt(x)` as a binary fixed-point integer.
+def reciprocal_sqrt_fixed_point(
+    x: UInt64, fractional_bits: Int
+) raises -> BigInt:
+    """Returns `2^fractional_bits / sqrt(x)` as a binary fixed-point integer.
 
-    The result `r` satisfies `r ~= 2^frac_bits / sqrt(x)` to within a few units
-    in the last place, so it carries about `frac_bits - bit_length(x) / 2`
-    correct significant bits. It is the binary counterpart of
-    `bigdecimal.exponential.sqrt_reciprocal()`, and exists because a
-    `BigDecimal` holds its coefficient in base 10^9, where the same
-    multiplication costs about 2.8x what it does in base 2^32.
+    The result `r` satisfies `r ~= 2^fractional_bits / sqrt(x)` to within a few
+    units in the last place, so it carries about
+    `fractional_bits - bit_length(x) / 2` correct significant bits. Note that
+    this returns the *reciprocal* of the root, where
+    `bigdecimal.exponential.sqrt_via_reciprocal_iteration()` merely reaches
+    the root through one and returns the root.
+
+    It exists because a `BigDecimal` holds its coefficient in base 10^9, where
+    the same multiplication costs about 2.8x what it does in base 2^32.
 
     The iteration is Newton's for the reciprocal square root, written around
     the residual so that no step ever multiplies at the full target width:
@@ -531,24 +536,24 @@ def reciprocal_isqrt_fixed(x: UInt64, frac_bits: Int) raises -> BigInt:
 
     Args:
         x: The value to take the reciprocal square root of. Must be non-zero.
-        frac_bits: The number of fractional bits in the result. Must be
+        fractional_bits: The number of fractional bits in the result. Must be
             non-negative.
 
     Returns:
-        `2^frac_bits / sqrt(x)`, truncated to an integer.
+        `2^fractional_bits / sqrt(x)`, truncated to an integer.
 
     Raises:
-        ValueError: If `x` is zero or `frac_bits` is negative.
+        ValueError: If `x` is zero or `fractional_bits` is negative.
     """
     if x == 0:
         raise ValueError(
             message="Cannot compute the reciprocal square root of zero.",
-            function="reciprocal_isqrt_fixed()",
+            function="reciprocal_sqrt_fixed_point()",
         )
-    if frac_bits < 0:
+    if fractional_bits < 0:
         raise ValueError(
             message="Number of fractional bits must be non-negative.",
-            function="reciprocal_isqrt_fixed()",
+            function="reciprocal_sqrt_fixed_point()",
         )
 
     # Bit length of `x`, and half of it rounded up: `r` is about
@@ -570,15 +575,15 @@ def reciprocal_isqrt_fixed(x: UInt64, frac_bits: Int) raises -> BigInt:
         Int(Float64(2.0) ** Float64(seed_scale) / math.sqrt(Float64(x)))
     )
 
-    if frac_bits <= seed_credit:
-        return seed >> (seed_scale - frac_bits)
+    if fractional_bits <= seed_credit:
+        return seed >> (seed_scale - fractional_bits)
 
     # Newton doubles the correct significant bits, so a step lands at
     # `g = 2f - half_bits - 2 * _NEWTON_GUARD_BITS`; inverting that gives the
     # scale each step has to start from. Building the schedule downwards from
     # the target is what keeps the final step at half the target width.
     var schedule = List[Int]()
-    var f = frac_bits
+    var f = fractional_bits
     while f > seed_credit:
         schedule.append(f)
         f = (f + half_bits) // 2 + _NEWTON_GUARD_BITS

--- a/src/decimo/bigint/exponential.mojo
+++ b/src/decimo/bigint/exponential.mojo
@@ -477,6 +477,16 @@ def _sqrt_precision_doubling_fast(x: BigInt) raises -> BigInt:
     return BigInt(raw_words=a_words^, sign=False)
 
 
+comptime _NEWTON_GUARD_BITS: Int = 4
+"""Bits of slack per Newton step in `reciprocal_isqrt_fixed()`.
+
+Each step truncates twice - once in the shift that forms the correction, once
+in the shift that rescales `r` - so the doubling of correct bits falls a little
+short of exact. Four bits per step covers that with room to spare, and costs
+four bits of width on operands tens of thousands of bits wide.
+"""
+
+
 def isqrt(x: BigInt) raises -> BigInt:
     """Calculates the integer square root of a BigInt.
     Equivalent to `sqrt()`.
@@ -491,3 +501,102 @@ def isqrt(x: BigInt) raises -> BigInt:
         ValueError: If x is negative.
     """
     return sqrt(x)
+
+
+def reciprocal_isqrt_fixed(x: UInt64, frac_bits: Int) raises -> BigInt:
+    """Returns `2^frac_bits / sqrt(x)` as a binary fixed-point integer.
+
+    The result `r` satisfies `r ~= 2^frac_bits / sqrt(x)` to within a few units
+    in the last place, so it carries about `frac_bits - bit_length(x) / 2`
+    correct significant bits. It is the binary counterpart of
+    `bigdecimal.exponential.sqrt_reciprocal()`, and exists because a
+    `BigDecimal` holds its coefficient in base 10^9, where the same
+    multiplication costs about 2.8x what it does in base 2^32.
+
+    The iteration is Newton's for the reciprocal square root, written around
+    the residual so that no step ever multiplies at the full target width:
+
+        e     = 2^(2f) - x * r^2                 (r at scale 2^f)
+        r_new = (r << (g - f)) + (r * e) >> (3f + 1 - g)
+
+    `r` and `e` are both about `f` bits, so a step from scale `f` to scale
+    `g <= 2f` costs two multiplications of `f`-bit operands. Halving the scale
+    on the way down means the last step - the only one at half the target
+    width - dominates, and the whole function costs about 1.1 multiplications
+    at the target width.
+
+    `x` is a machine word rather than a `BigInt` because the only caller needs
+    `1 / sqrt(10005)`. Generalising means normalising `x` to an even power of
+    two before seeding, and nothing else here changes.
+
+    Args:
+        x: The value to take the reciprocal square root of. Must be non-zero.
+        frac_bits: The number of fractional bits in the result. Must be
+            non-negative.
+
+    Returns:
+        `2^frac_bits / sqrt(x)`, truncated to an integer.
+
+    Raises:
+        ValueError: If `x` is zero or `frac_bits` is negative.
+    """
+    if x == 0:
+        raise ValueError(
+            message="Cannot compute the reciprocal square root of zero.",
+            function="reciprocal_isqrt_fixed()",
+        )
+    if frac_bits < 0:
+        raise ValueError(
+            message="Number of fractional bits must be non-negative.",
+            function="reciprocal_isqrt_fixed()",
+        )
+
+    # Bit length of `x`, and half of it rounded up: `r` is about
+    # `2^(scale - half_bits)`, so `half_bits` is the gap between the scale of
+    # `r` and the number of significant bits it actually carries.
+    var bits = 0
+    var probe = x
+    while probe != 0:
+        probe >>= 1
+        bits += 1
+    var half_bits = (bits + 1) // 2
+
+    # Seed from `Float64`, placed so the value lands near 2^48 whatever `x` is.
+    # One `sqrt` and one divide leave it good to about 51 bits; 44 is the
+    # conservative credit the schedule below is built on.
+    var seed_scale = 48 + half_bits
+    var seed_credit = 44 + half_bits
+    var seed = BigInt(
+        Int(Float64(2.0) ** Float64(seed_scale) / math.sqrt(Float64(x)))
+    )
+
+    if frac_bits <= seed_credit:
+        return seed >> (seed_scale - frac_bits)
+
+    # Newton doubles the correct significant bits, so a step lands at
+    # `g = 2f - half_bits - 2 * _NEWTON_GUARD_BITS`; inverting that gives the
+    # scale each step has to start from. Building the schedule downwards from
+    # the target is what keeps the final step at half the target width.
+    var schedule = List[Int]()
+    var f = frac_bits
+    while f > seed_credit:
+        schedule.append(f)
+        f = (f + half_bits) // 2 + _NEWTON_GUARD_BITS
+
+    var r = seed >> (seed_scale - f)
+    var current = f
+    # Built from the words rather than through `Int(x)`, which wraps to a
+    # negative value for `x >= 2^63`.
+    var bx = BigInt(raw_words=_uint64_to_words(x), sign=False)
+
+    for i in range(len(schedule) - 1, -1, -1):
+        var target = schedule[i]
+        # The subtraction is a near-total cancellation, exact in integers:
+        # `x * r^2` agrees with `2^(2f)` to within about `f` bits.
+        var residual = (BigInt.one() << (2 * current)) - bx * (r * r)
+        r = (r << (target - current)) + (
+            (r * residual) >> (3 * current + 1 - target)
+        )
+        current = target
+
+    return r^

--- a/tests/bigdecimal/test_bigdecimal_exponential.mojo
+++ b/tests/bigdecimal/test_bigdecimal_exponential.mojo
@@ -188,8 +188,8 @@ def test_ln_invalid_inputs() raises:
     )
 
 
-def test_sqrt_reciprocal_matches_sqrt_exact() raises:
-    """Test that `sqrt_reciprocal()` delivers every digit it is asked for.
+def test_sqrt_via_reciprocal_iteration_matches_sqrt_exact() raises:
+    """Test that `sqrt_via_reciprocal_iteration()` delivers every digit it is asked for.
 
     `sqrt_exact()` is the oracle here: it reproduces CPython's
     `Decimal.sqrt()`, which the tests above check directly.
@@ -201,8 +201,8 @@ def test_sqrt_reciprocal_matches_sqrt_exact() raises:
     and both are invisible to a spot check: one shows up only at precisions
     where the halving schedule lands with little slack (1500 and 3000 here, but
     not 1000 or 2000), and the other only for inputs whose `Float64` seed is
-    poor - `sqrt_reciprocal(1234.5678, 1500)` was correct to 1248 of 1500
-    digits while `sqrt_reciprocal(10005, 1500)` was correct in full, because
+    poor - `sqrt_via_reciprocal_iteration(1234.5678, 1500)` was correct to 1248 of 1500
+    digits while `sqrt_via_reciprocal_iteration(10005, 1500)` was correct in full, because
     `12.345678 ** -0.5` is accurate to ten digits and `1.0005 ** -0.5` is
     exact. Neither raises, and both return the full requested digit count.
     """
@@ -215,7 +215,9 @@ def test_sqrt_reciprocal_matches_sqrt_exact() raises:
             var prec = precisions[j]
             var got = List[Byte](
                 String(
-                    bigdecimal_exponential.sqrt_reciprocal(x, prec)
+                    bigdecimal_exponential.sqrt_via_reciprocal_iteration(
+                        x, prec
+                    )
                 ).as_bytes()
             )
             var want = List[Byte](
@@ -234,7 +236,7 @@ def test_sqrt_reciprocal_matches_sqrt_exact() raises:
             # half-even), so only the last digit is allowed to differ.
             testing.assert_true(
                 agree >= len(want) - 1,
-                String("sqrt_reciprocal(")
+                String("sqrt_via_reciprocal_iteration(")
                 + inputs[i]
                 + String(", ")
                 + String(prec)

--- a/tests/bigint/test_bigint_large_algorithms.mojo
+++ b/tests/bigint/test_bigint_large_algorithms.mojo
@@ -3,8 +3,13 @@ Characterization tests for the large-operand code paths of BigInt.
 
 These exercise the algorithms that only engage above the size cutoffs in
 `bigint/arithmetics.mojo`, and which no other test in the suite reaches:
-  - Karatsuba multiplication (len_max > CUTOFF_KARATSUBA = 48 words)
+  - packed base-2^64 schoolbook (len_a * len_b >= CUTOFF_PACK_64_AREA = 1024)
+  - Karatsuba multiplication (len_max > CUTOFF_KARATSUBA = 256 words)
+  - Toom-3 multiplication (len_max > CUTOFF_TOOM3 = 768 words)
   - Burnikel-Ziegler division (len_b > CUTOFF_BURNIKEL_ZIEGLER = 64 words)
+
+Keep the sizes here in step with those constants. A cutoff that moves up past
+a fixture leaves the test passing while covering a path it no longer reaches.
 
 Expected values were computed with Python's arbitrary-precision integers.
 Operand bit widths are chosen to straddle each cutoff, including cases just
@@ -16,12 +21,20 @@ from decimo.bigint.bigint import BigInt
 
 
 # ===----------------------------------------------------------------=== #
-# Karatsuba multiplication (> 48 words = > 1536 bits)
+# Karatsuba multiplication (> 256 words = > 8192 bits)
 # ===----------------------------------------------------------------=== #
 
 
-def test_multiply_at_karatsuba_boundary() raises:
-    """Products straddling the Karatsuba cutoff (1536 bits = 48 words)."""
+def test_multiply_schoolbook_fixed_vectors() raises:
+    """Fixed 48-word products, checked against Python's `int`.
+
+    48 words is below `CUTOFF_KARATSUBA` and above `CUTOFF_PACK_64_AREA`, so
+    these run on the packed base-2^64 schoolbook kernel. They were written
+    when 48 was the Karatsuba cutoff and are kept as fixed vectors: every
+    other multiplication test in this file checks one decimo path against
+    another, and these are the only ones that check against an outside
+    oracle.
+    """
     testing.assert_equal(
         String(
             BigInt(
@@ -571,16 +584,47 @@ def _blockwise_product(a: BigInt, b: BigInt, block_bits: Int) raises -> BigInt:
     return total^
 
 
+def test_multiply_at_karatsuba_boundary() raises:
+    """Products straddling the Karatsuba cutoff (256 words, ~2 470 digits).
+
+    Dispatch is on `max(len_a, len_b)`, so pairing unequal sizes also covers a
+    Karatsuba operand multiplied by a schoolbook-sized one, where the halves
+    of the split are lopsided. The reference multiplies in 800-bit blocks
+    (25 words, area 625), which stays on the unpacked schoolbook kernel, so
+    the two sides share no code above the cutoff.
+    """
+    var sizes = [2400, 2460, 2480, 2600, 3000]
+
+    for i in range(len(sizes)):
+        for j in range(len(sizes)):
+            var a = BigInt(_bz_digit_run(sizes[i], 51000 + 29 * i + j))
+            var b = BigInt(_bz_digit_run(sizes[j], 82000 + 11 * i + j))
+            var case_label = (
+                String("a=")
+                + String(sizes[i])
+                + " digits, b="
+                + String(sizes[j])
+                + " digits"
+            )
+            testing.assert_equal(
+                String(a * b),
+                String(_blockwise_product(a, b, 800)),
+                "Karatsuba product differs from reference for " + case_label,
+            )
+
+
 def test_multiply_toom3_against_blockwise_reference() raises:
     """Toom-3 products match a block-by-block schoolbook recomposition.
 
-    The digit counts straddle `CUTOFF_TOOM3` (384 words, about 3 700 decimal
+    The digit counts straddle `CUTOFF_TOOM3` (768 words, about 7 400 decimal
     digits), including sizes just below and just above it, and pair operands
-    of unequal length so the three-way split lands on ragged limbs. The
-    reference multiplies in 800-bit blocks, which never leaves the schoolbook
+    of unequal length so the three-way split lands on ragged limbs. Dispatch
+    is on `max(len_a, len_b)`, so the mixed pairs also cover a Toom-3 operand
+    multiplied by a Karatsuba-sized one. The reference multiplies in 800-bit
+    blocks (25 words, area 625), which never leaves the unpacked schoolbook
     path, so the two sides share no code above the cutoff.
     """
-    var sizes = [3600, 3700, 3750, 4200, 6000, 9000]
+    var sizes = [6000, 7300, 7400, 7600, 9000]
 
     for i in range(len(sizes)):
         for j in range(len(sizes)):
@@ -703,17 +747,17 @@ def test_multiply_toom3_algebraic_identities() raises:
 def test_multiply_across_the_64_bit_packing_boundary() raises:
     """The packed and unpacked schoolbook kernels agree, at every parity.
 
-    Below `CUTOFF_PACK_64` (32 words) the base case runs over 32-bit words;
-    above it, operands are packed into base-2^64 limbs and the result is
-    unpacked again. An operand with an odd word count leaves the top limb
-    half empty, and the product then carries up to two zero words the packed
-    kernel has to strip, so both parities are covered on both sides of the
-    gate and in every combination.
+    Below `CUTOFF_PACK_64_AREA` (`len_a * len_b < 1024`) the base case runs
+    over 32-bit words; at or above it, operands are packed into base-2^64
+    limbs and the result is unpacked again. An operand with an odd word count
+    leaves the top limb half empty, and the product then carries up to two
+    zero words the packed kernel has to strip, so both parities are covered on
+    both sides of the gate and in every combination.
 
     9 decimal digits is a shade under one 32-bit word, so this walks the word
     counts one at a time through the boundary rather than jumping over it.
-    The reference multiplies in 200-bit blocks, which stays under the gate
-    whatever the operands do.
+    The reference multiplies in 200-bit blocks (7 words, area 49), which stays
+    under the gate whatever the operands do.
     """
     var digit_counts = [180, 189, 198, 270, 279, 288, 297, 306, 360, 450]
 
@@ -738,6 +782,36 @@ def test_multiply_across_the_64_bit_packing_boundary() raises:
                 "-" + String(_blockwise_product(a, b, 200)),
                 "packed product sign is wrong for " + case_label,
             )
+
+
+def test_multiply_lopsided_across_the_packing_boundary() raises:
+    """One short operand against a long one, either side of the area gate.
+
+    The gate is on `len_a * len_b`, not on either operand alone, so a product
+    such as 5x250 words packs while 4x250 does not - the short side crosses
+    the boundary while the long side never moves. That also drives the packed
+    kernel at `n_a = 3` packed limbs, where the column bounds `i_low` and
+    `i_high` are at their tightest and the two-wide unroll runs at most one
+    full pass. The small digit counts below straddle the gate against a fixed
+    250-word operand.
+    """
+    var short_digits = [20, 30, 40, 50, 70, 120, 250, 400]
+    var long_digits = 2400
+
+    for i in range(len(short_digits)):
+        var a = BigInt(_bz_digit_run(short_digits[i], 90210 + 17 * i))
+        var b = BigInt(_bz_digit_run(long_digits, 31337 + i))
+        var case_label = String(short_digits[i]) + " digits x 2400 digits"
+        testing.assert_equal(
+            String(a * b),
+            String(_blockwise_product(a, b, 200)),
+            "lopsided product differs from reference for " + case_label,
+        )
+        testing.assert_equal(
+            String(b * a),
+            String(_blockwise_product(a, b, 200)),
+            "lopsided product is not commutative for " + case_label,
+        )
 
 
 def main() raises:

--- a/tests/bigint/test_bigint_sqrt_divmod.mojo
+++ b/tests/bigint/test_bigint_sqrt_divmod.mojo
@@ -5,6 +5,7 @@ with positive, negative, mixed-sign, and consistency checks.
 
 from std import testing
 from decimo.bigint.bigint import BigInt
+import decimo.bigint.exponential as bigint_exponential
 
 
 # ===----------------------------------------------------------------------=== #
@@ -151,6 +152,108 @@ def test_divmod_by_zero_raises() raises:
     except:
         raised = True
     testing.assert_true(raised, "divmod by zero should raise")
+
+
+# ===----------------------------------------------------------------------=== #
+# Test: reciprocal_isqrt_fixed
+# ===----------------------------------------------------------------------=== #
+
+
+def _assert_reciprocal_isqrt(x: UInt64, frac_bits: Int, tolerance: Int) raises:
+    """Brackets `r` against the exact `floor(2^frac_bits / sqrt(x))`.
+
+    `r` is the exact value when `r^2 * x <= 2^(2f) < (r + 1)^2 * x`. Widening
+    that by `tolerance` on each side gives a check that needs no reference
+    value and no reference implementation: it asserts exactly the contract the
+    function documents, and it is not satisfied by any wrong answer.
+    """
+    var r = bigint_exponential.reciprocal_isqrt_fixed(x, frac_bits)
+    var bx = BigInt(String(x))
+    var square = BigInt.one() << (2 * frac_bits)
+    var label = " for x=" + String(x) + ", frac_bits=" + String(frac_bits)
+
+    var low = r - BigInt(tolerance)
+    if low.sign:
+        low = BigInt.zero()
+    testing.assert_true(
+        low * low * bx <= square,
+        "reciprocal_isqrt_fixed() is more than "
+        + String(tolerance)
+        + " ulp high"
+        + label,
+    )
+
+    var high = r + BigInt(tolerance + 1)
+    testing.assert_true(
+        high * high * bx > square,
+        "reciprocal_isqrt_fixed() is more than "
+        + String(tolerance)
+        + " ulp low"
+        + label,
+    )
+
+
+def test_reciprocal_isqrt_fixed_brackets_the_exact_value() raises:
+    """`2^f / sqrt(x)` is within a few ulp of the true value, at every size.
+
+    The word-sized `x` values span the whole `UInt64` range, including both
+    perfect squares (exact answers, where an off-by-one is easiest to make)
+    and values above `2^53`, which no longer round-trip through the `Float64`
+    seed. The `frac_bits` values cross the point where the Newton schedule
+    starts running at all (`frac_bits <= 44 + bits(x) / 2` returns the seed
+    directly) and then several doublings past it.
+    """
+    var xs = [
+        UInt64(1),
+        UInt64(2),
+        UInt64(3),
+        UInt64(4),
+        UInt64(10005),
+        UInt64(999999937),
+        UInt64(1) << 40,
+        UInt64(9223372036854775807),
+        UInt64(0) - UInt64(1),
+    ]
+    var frac_bits = [0, 1, 30, 64, 128, 200, 256, 501, 1000, 3000]
+
+    for i in range(len(xs)):
+        for j in range(len(frac_bits)):
+            _assert_reciprocal_isqrt(xs[i], frac_bits[j], 4)
+
+
+def test_reciprocal_isqrt_fixed_exact_powers_of_four() raises:
+    """`x = 4^k` makes `2^f / sqrt(x)` an exact power of two."""
+    testing.assert_equal(
+        String(bigint_exponential.reciprocal_isqrt_fixed(UInt64(1), 64)),
+        String(BigInt.one() << 64),
+    )
+    testing.assert_equal(
+        String(bigint_exponential.reciprocal_isqrt_fixed(UInt64(4), 300)),
+        String(BigInt.one() << 299),
+    )
+    testing.assert_equal(
+        String(
+            bigint_exponential.reciprocal_isqrt_fixed(UInt64(1) << 40, 1000)
+        ),
+        String(BigInt.one() << 980),
+    )
+
+
+def test_reciprocal_isqrt_fixed_rejects_bad_arguments() raises:
+    """Zero and a negative width raise rather than returning nonsense."""
+    var raised = False
+    try:
+        _ = bigint_exponential.reciprocal_isqrt_fixed(UInt64(0), 64)
+    except:
+        raised = True
+    testing.assert_true(raised, "x = 0 should raise")
+
+    raised = False
+    try:
+        _ = bigint_exponential.reciprocal_isqrt_fixed(UInt64(10005), -1)
+    except:
+        raised = True
+    testing.assert_true(raised, "negative frac_bits should raise")
 
 
 def main() raises:

--- a/tests/bigint/test_bigint_sqrt_divmod.mojo
+++ b/tests/bigint/test_bigint_sqrt_divmod.mojo
@@ -155,29 +155,33 @@ def test_divmod_by_zero_raises() raises:
 
 
 # ===----------------------------------------------------------------------=== #
-# Test: reciprocal_isqrt_fixed
+# Test: reciprocal_sqrt_fixed_point
 # ===----------------------------------------------------------------------=== #
 
 
-def _assert_reciprocal_isqrt(x: UInt64, frac_bits: Int, tolerance: Int) raises:
-    """Brackets `r` against the exact `floor(2^frac_bits / sqrt(x))`.
+def _assert_reciprocal_sqrt_fixed_point(
+    x: UInt64, fractional_bits: Int, tolerance: Int
+) raises:
+    """Brackets `r` against the exact `floor(2^fractional_bits / sqrt(x))`.
 
     `r` is the exact value when `r^2 * x <= 2^(2f) < (r + 1)^2 * x`. Widening
     that by `tolerance` on each side gives a check that needs no reference
     value and no reference implementation: it asserts exactly the contract the
     function documents, and it is not satisfied by any wrong answer.
     """
-    var r = bigint_exponential.reciprocal_isqrt_fixed(x, frac_bits)
+    var r = bigint_exponential.reciprocal_sqrt_fixed_point(x, fractional_bits)
     var bx = BigInt(String(x))
-    var square = BigInt.one() << (2 * frac_bits)
-    var label = " for x=" + String(x) + ", frac_bits=" + String(frac_bits)
+    var square = BigInt.one() << (2 * fractional_bits)
+    var label = (
+        " for x=" + String(x) + ", fractional_bits=" + String(fractional_bits)
+    )
 
     var low = r - BigInt(tolerance)
     if low.sign:
         low = BigInt.zero()
     testing.assert_true(
         low * low * bx <= square,
-        "reciprocal_isqrt_fixed() is more than "
+        "reciprocal_sqrt_fixed_point() is more than "
         + String(tolerance)
         + " ulp high"
         + label,
@@ -186,21 +190,21 @@ def _assert_reciprocal_isqrt(x: UInt64, frac_bits: Int, tolerance: Int) raises:
     var high = r + BigInt(tolerance + 1)
     testing.assert_true(
         high * high * bx > square,
-        "reciprocal_isqrt_fixed() is more than "
+        "reciprocal_sqrt_fixed_point() is more than "
         + String(tolerance)
         + " ulp low"
         + label,
     )
 
 
-def test_reciprocal_isqrt_fixed_brackets_the_exact_value() raises:
+def test_reciprocal_sqrt_fixed_point_brackets_the_exact_value() raises:
     """`2^f / sqrt(x)` is within a few ulp of the true value, at every size.
 
     The word-sized `x` values span the whole `UInt64` range, including both
     perfect squares (exact answers, where an off-by-one is easiest to make)
     and values above `2^53`, which no longer round-trip through the `Float64`
-    seed. The `frac_bits` values cross the point where the Newton schedule
-    starts running at all (`frac_bits <= 44 + bits(x) / 2` returns the seed
+    seed. The `fractional_bits` values cross the point where the Newton schedule
+    starts running at all (`fractional_bits <= 44 + bits(x) / 2` returns the seed
     directly) and then several doublings past it.
     """
     var xs = [
@@ -214,46 +218,48 @@ def test_reciprocal_isqrt_fixed_brackets_the_exact_value() raises:
         UInt64(9223372036854775807),
         UInt64(0) - UInt64(1),
     ]
-    var frac_bits = [0, 1, 30, 64, 128, 200, 256, 501, 1000, 3000]
+    var fractional_bits = [0, 1, 30, 64, 128, 200, 256, 501, 1000, 3000]
 
     for i in range(len(xs)):
-        for j in range(len(frac_bits)):
-            _assert_reciprocal_isqrt(xs[i], frac_bits[j], 4)
+        for j in range(len(fractional_bits)):
+            _assert_reciprocal_sqrt_fixed_point(xs[i], fractional_bits[j], 4)
 
 
-def test_reciprocal_isqrt_fixed_exact_powers_of_four() raises:
+def test_reciprocal_sqrt_fixed_point_exact_powers_of_four() raises:
     """`x = 4^k` makes `2^f / sqrt(x)` an exact power of two."""
     testing.assert_equal(
-        String(bigint_exponential.reciprocal_isqrt_fixed(UInt64(1), 64)),
+        String(bigint_exponential.reciprocal_sqrt_fixed_point(UInt64(1), 64)),
         String(BigInt.one() << 64),
     )
     testing.assert_equal(
-        String(bigint_exponential.reciprocal_isqrt_fixed(UInt64(4), 300)),
+        String(bigint_exponential.reciprocal_sqrt_fixed_point(UInt64(4), 300)),
         String(BigInt.one() << 299),
     )
     testing.assert_equal(
         String(
-            bigint_exponential.reciprocal_isqrt_fixed(UInt64(1) << 40, 1000)
+            bigint_exponential.reciprocal_sqrt_fixed_point(
+                UInt64(1) << 40, 1000
+            )
         ),
         String(BigInt.one() << 980),
     )
 
 
-def test_reciprocal_isqrt_fixed_rejects_bad_arguments() raises:
+def test_reciprocal_sqrt_fixed_point_rejects_bad_arguments() raises:
     """Zero and a negative width raise rather than returning nonsense."""
     var raised = False
     try:
-        _ = bigint_exponential.reciprocal_isqrt_fixed(UInt64(0), 64)
+        _ = bigint_exponential.reciprocal_sqrt_fixed_point(UInt64(0), 64)
     except:
         raised = True
     testing.assert_true(raised, "x = 0 should raise")
 
     raised = False
     try:
-        _ = bigint_exponential.reciprocal_isqrt_fixed(UInt64(10005), -1)
+        _ = bigint_exponential.reciprocal_sqrt_fixed_point(UInt64(10005), -1)
     except:
         raised = True
-    testing.assert_true(raised, "negative frac_bits should raise")
+    testing.assert_true(raised, "negative fractional_bits should raise")
 
 
 def main() raises:


### PR DESCRIPTION
`pi()` left base 2^32 right after the series division, running the square root and both final multiplies in base 10^9 where a multiply costs 2.8x more. Writing `426880*sqrt(10005)` as `4270934400/sqrt(10005)` (still one word) lets the irrational factor enter as a reciprocal root, which Newton reaches without any division. New `BigInt.reciprocal_sqrt_fixed_point()`，one base conversion, now at the end.