### PR TITLE
[core][integer] Take the carry chain off the critical path in add, subtract, and exact division

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,18 @@ fixed.
    1.22x at 10 400 words, `BigUInt` 1.30x and 1.27x at 11 112. `pi(100000)`
    goes from 44.2 ms to 36.1 ms and `pi(10000)` from 1.42 ms to 1.27 ms.
 
+   *Exact division by three, the same way.* Toom-3's interpolation calls it once
+   per node. Building `remainder * BASE + word` and then taking both the
+   quotient and the modulus puts *two* dependent multiply-highs on the
+   loop-carried chain, which cost about nine cycles per word — nine times what
+   the neighbouring word-at-a-time helpers cost. Both bases happen to be
+   `1 mod 3`, so with `BASE = 3T + 1` and `word = 3d + m` the step splits into
+   `quotient = remainder * T + d + (remainder + m >= 3)` and
+   `new remainder = (remainder + m) mod 3`. `d` and `m` depend only on `word`,
+   so the one division left is off the chain. 1.7x in `BigInt`, 2.2x in
+   `BigUInt` — though it is only a few percent of a Toom-3 multiply, at the
+   edge of what the benchmark resolves.
+
    `subtract_simd()` and `add_slices_simd()` are renamed
    `subtract_carry_select()` and `add_slices_carry_select()`, since neither is
    vectorized any more, and `normalize_borrows()` is gone — the kernels resolve

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,12 +8,14 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 `from_integral_scalar()` / `from_float_scalar()` naming used by the other
 numeric types, `BigInt10` is no longer referenced by the rest of the library,
 and `BigDecimal.pi()` gets four orders of magnitude faster — 100 000 digits in
-50 ms, and ahead of pure-Python mpmath from 500 digits up. Multiplication is
+36 ms, and ahead of pure-Python mpmath from 500 digits up. Multiplication is
 2-3x faster for both `BigInt` and `BigUInt`, which puts `BigInt` ahead of
-CPython's `int` on every large operation. Burnikel-Ziegler division loses a
-padding choice that cost it its own asymptotics on some sizes, which speeds up
-every division in the library. A Newton iteration that silently returned short
-of its requested precision is fixed.
+CPython's `int` on every large operation. Addition and subtraction are 2-3x
+faster in turn, which the recursive multiplications and divisions inherit.
+Burnikel-Ziegler division loses a padding choice that cost it its own
+asymptotics on some sizes, which speeds up every division in the library. A
+Newton iteration that silently returned short of its requested precision is
+fixed.
 
 ### ⭐️ New in Unreleased
 
@@ -31,6 +33,39 @@ of its requested precision is fixed.
    `BigInt10.from_bigint()` and `BigInt10.to_bigint()` (PR #269).
 
 ### 🦋 Changed in Unreleased
+
+1. **Addition and subtraction are 2-3x faster, and everything built on them
+   moves with them.** Both types carried word by word in 32-bit steps, and
+   both spent more of the loop on bookkeeping than on the sum.
+
+   *`BigInt`, base 2^32.* The words are little-endian, so a pair of them is
+   already a base-2^64 limb: one 64-bit add does the work of two 32-bit ones,
+   and the carry out is the unsigned overflow of that add, which a comparison
+   recovers without the old shift-and-mask. The loads ask for `alignment=4`, so
+   the two operands and the destination may each start at any word offset —
+   which is what lets the Karatsuba and Toom-3 helpers, whose slices start
+   anywhere, use the same kernel. 0.71 -> 0.25 ns/word.
+
+   *`BigUInt`, base 10^9.* A base-10^9 word carries by comparison against
+   `BASE`, not by overflowing, and the comparison depends on the carry coming
+   in — so the carry sat on the loop-carried dependency chain. Both answers are
+   now computed from the operands alone, off the critical path, and the
+   incoming carry only selects between them; what remains loop-carried is a
+   select. This also replaces a two-pass shape — a vectorized word-wise add
+   over the whole operand, then a normalization sweep over the whole result —
+   with one pass, so the words are touched once, and a carry that dies early
+   stops early instead of walking the rest of the accumulator. 1.75 -> 0.83
+   ns/word at 100 000 words, 1.31 -> 0.87 at 1 000.
+
+   The recursive algorithms are add/sub-heavy at every level of their
+   recursion, so they inherit most of this: `BigInt` multiply 1.26x and divide
+   1.22x at 10 400 words, `BigUInt` 1.30x and 1.27x at 11 112. `pi(100000)`
+   goes from 44.2 ms to 36.1 ms and `pi(10000)` from 1.42 ms to 1.27 ms.
+
+   `subtract_simd()` and `add_slices_simd()` are renamed
+   `subtract_carry_select()` and `add_slices_carry_select()`, since neither is
+   vectorized any more, and `normalize_borrows()` is gone — the kernels resolve
+   borrows as they go.
 
 1. **`BigUInt` schoolbook division is 1.3-2x faster.** Each quotient word used
    to build `q * y` as a fresh `BigUInt`, shift it up by the word position,
@@ -112,7 +147,7 @@ of its requested precision is fixed.
    `426880 * 10005 / √10005 * (q/t)`, so the irrational factor enters as a
    *reciprocal* square root — which Newton reaches without a division — and
    `426880 * 10005 = 4270934400` still fits in a word. The new
-   `BigInt.exponential.reciprocal_sqrt_fixed_point()` returns `2^f / sqrt(x)` as
+   `bigint.exponential.reciprocal_sqrt_fixed_point()` returns `2^f / sqrt(x)` as
    a binary fixed-point integer, everything is combined in `BigInt`, and the
    conversion to base 10^9 happens once, on the finished value.
 

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -310,6 +310,22 @@ differently for each residue of the dividend length mod 4. Two samples cannot
 cross that. `test_biguint_divide_across_the_dispatch_boundaries_against_python`
 now walks divisor 1-40 digits against dividend up to 90.
 
+### Passing one pointer as both source and destination
+
+The exclusivity checker rejects `kernel(p, p, ...)` when the destination
+parameter requires `Origin[mut=True]`: `list.unsafe_ptr()` carries
+`origin_of(list.words)`, and two arguments tied to the same origin, one of them
+mutable, is an aliasing error even when the aliasing is the whole point of an
+in-place loop. `list._data` yields the same address without the origin, so
+`kernel(x._data, x._data, ...)` compiles. Used by every in-place add/sub kernel
+in both types.
+
+Reading a `UInt32` array two words at a time needs
+`ptr.unsafe_bitcast[UInt64]().unsafe_load[alignment=4](i)`. Without the
+explicit alignment the load claims 8-byte alignment, which a slice starting at
+an odd word offset does not have — and the Karatsuba and Toom-3 helpers pass
+exactly those.
+
 ### A missing `return` in `subtract_inplace()`
 
 Found while checking a Copilot review comment on PR #271 (which was itself

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -109,6 +109,10 @@ that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 |          |      | only 6% — `sqrt(10005, 50000)` 19.3 → 18.2 ms. See T-Sq2                              |
 | 20260824 | #276 | Binary-only `pi()` tail via `reciprocal_sqrt_fixed_point()` (T-PI4);                  |
 |          |      | sqrt and final multiplies leave base 10^9. Total: 58.2 → 50.2 ms                      |
+| 20260825 | —    | 64-bit limb pairs in every `BigInt` add/sub loop (`bigint_enhancement.md` T-A2);      |
+|          |      | 0.71 → 0.25 ns/word                                                                   |
+| 20260825 | —    | Carry-select, single-pass `BigUInt` add/sub (T-A3); 1.75 → 0.83 ns/word at            |
+|          |      | 100 000 words. Multiply and divide inherit ~1.3×. Total: 44.2 → 36.1 ms               |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -860,6 +864,34 @@ come down (T-5, NTT). For scale, MPFR 4.2.2 + GMP 6.3 does the same 100 000
 digits in 20.7 ms (18.6 compute + 2.1 to-string), and mpmath on gmpy2 in
 ~16 ms.
 
+**T-A3 — carry-select `BigUInt` add/sub. DONE 20260825.** A base-10^9 word
+carries by comparison against `BASE`, not by overflowing, and the comparison
+depends on the carry coming in — so the carry sat on the loop-carried
+dependency chain. Both answers, for carry-in 0 and for carry-in 1, are now
+computed from the operands alone, off the critical path, and the incoming
+carry only selects between them.
+
+That also collapses the old two-pass shape — a vectorized word-wise add over
+the whole operand, then `normalize_carries_lt_2_bases()` over the whole result
+— into one pass. Two consequences beyond the halved memory traffic: the
+accumulator paths (`add_inplace()`, `add_by_slice_inplace()`, both in-place
+subtracts) now stop as soon as the carry dies instead of walking the rest of a
+much longer `x`, and `normalize_borrows()` has no callers left.
+
+| words   | before | after | |
+| ------- | ------ | ----- | ----------- |
+| 1 000   | 1.31   | 0.87  | ns/word     |
+| 11 112  | 1.21   | 0.84  | ns/word     |
+| 100 000 | 1.75   | 0.83  | ns/word     |
+
+Multiply 6.29 → 4.84 ms and divide 15.5 → 12.2 ms at ~11 000 words. The
+`_simd` names went with the vectorization: `add_slices_carry_select()` and
+`subtract_carry_select()`.
+
+The `BigInt` half of the same task is `bigint_enhancement.md` T-A2, which gets
+to 0.25 ns/word — base 2^32 can pair two words into one 64-bit add, and base
+10^9 cannot.
+
 ### 5.3 Long-term tasks not on the active roadmap
 
 | #   | Task                                                            | Effort |
@@ -977,6 +1009,8 @@ some ops < 1.0×):
 | T-9b   | Product-scanning `BigUInt` schoolbook      | M      | **DONE** | 2.2× at 256 words; deferred-carry removed               |
 | T-9c   | Re-tune `BigUInt` mul cutoffs              | S      | **DONE** | Kara 64→256, Toom3 256→768; 10.5 → 6.0 ms               |
 | T-D5   | Windowed fused mul-sub in schoolbook div   | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000          |
+| T-A2   | 64-bit limb pairs in `BigInt` add/sub      | S      | **DONE** | 0.71 → 0.25 ns/word; mul 1.26×, div 1.22× at 10 400w    |
+| T-A3   | Carry-select single-pass `BigUInt` add/sub | M      | **DONE** | 1.75 → 0.83 ns/word; mul 1.30×, div 1.27×               |
 | T-5    | NTT multiplication                         | XL     | **NEXT** | largest lever: 3.7× of the GMP mul gap is FFT           |
 | T-9    | deferred-carry schoolbook mul              | M      | **DONE** | deferred-carry (product-scanning);                      |
 |        |                                            |        |          | Definitely worth bringing it to `BigInt` too            |

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -113,6 +113,8 @@ that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 |          |      | 0.71 → 0.25 ns/word                                                                   |
 | 20260825 | —    | Carry-select, single-pass `BigUInt` add/sub (T-A3); 1.75 → 0.83 ns/word at            |
 |          |      | 100 000 words. Multiply and divide inherit ~1.3×. Total: 44.2 → 36.1 ms               |
+| 20260825 | —    | `exact_divide_by_3_inplace()` division taken off the carry chain (T-A4);              |
+|          |      | 2.50 → 1.13 ns/word, but only ~2% of a Toom-3 multiply                                |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -1011,6 +1013,7 @@ some ops < 1.0×):
 | T-D5   | Windowed fused mul-sub in schoolbook div   | M      | **DONE** | 2.0× at 100 digits, 1.5× at 300, 1.3× at 1 000          |
 | T-A2   | 64-bit limb pairs in `BigInt` add/sub      | S      | **DONE** | 0.71 → 0.25 ns/word; mul 1.26×, div 1.22× at 10 400w    |
 | T-A3   | Carry-select single-pass `BigUInt` add/sub | M      | **DONE** | 1.75 → 0.83 ns/word; mul 1.30×, div 1.27×               |
+| T-A4   | Exact divide-by-3 off the carry chain      | S      | **DONE** | 2.50 → 1.13 ns/word; ~2% of a Toom-3 multiply           |
 | T-5    | NTT multiplication                         | XL     | **NEXT** | largest lever: 3.7× of the GMP mul gap is FFT           |
 | T-9    | deferred-carry schoolbook mul              | M      | **DONE** | deferred-carry (product-scanning);                      |
 |        |                                            |        |          | Definitely worth bringing it to `BigInt` too            |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -300,10 +300,25 @@ temporary on every multiply. Route the loop through `multiply_inplace` and
 add a dedicated `square()` that exploits symmetry, roughly half the partial
 products. The 2^N shift fast path is already excellent; Rust loses to it.
 
-**T-A1 — add/sub dispatch.** SIMD add is already in place, so the
-small-operand gap is dispatch, not the kernel. Put the same-length
-same-sign case first (Lesson 5) and check for any stray
-`debug_assert .format` (Lesson 4).
+**T-A1 — add/sub dispatch. DONE 2026-08-25.** The same-sign case now comes
+first, and the mixed-sign cases no longer route through `subtract(x1, -x2)` /
+`add(x1, -x2)`: negating an operand copied its whole magnitude before the
+kernel ever ran.
+
+**T-A2 — 64-bit limb pairs in the add/sub kernels. DONE 2026-08-25.** The
+words are little-endian, so a pair of them is already a base-2^64 limb: one
+64-bit add does the work of two 32-bit ones, and the carry out is the unsigned
+overflow of that add, recovered by a comparison instead of a shift-and-mask.
+`_add_word_pairs()` and `_subtract_word_pairs()` load with `alignment=4`, so
+the two operands and the destination may each start at any word offset — which
+is what lets the Karatsuba and Toom-3 helpers, whose slices start anywhere,
+share the kernel. All six loops use it: the two out-of-place magnitude
+operations, the two in-place ones, `_add_slices()` and
+`_add_at_offset_inplace()`.
+
+0.71 → 0.25 ns/word (about 3.2 → 1.1 cycles), flat from 1 000 to 100 000
+words. The recursions are add/sub-heavy at every level and inherit most of it:
+multiply 1.26× and divide 1.22× at 10 400 words, `pi(100000)` 44.2 → 36.1 ms.
 
 ### from_string and shift
 
@@ -384,7 +399,8 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-M3  | Re-tune `CUTOFF_KARATSUBA` / `CUTOFF_TOOM3`      | DONE 2026-08-24 — 48→128→256, →768    |
 | T-M4  | Pack the base case into base-2^64 limbs          | DONE 2026-08-24 — 1.9× at the cutoff  |
 | T-P1  | `square()` plus inplace loop for power           | OPEN                                  |
-| T-A1  | add/sub dispatch reorder                         | OPEN                                  |
+| T-A1  | add/sub dispatch reorder                         | DONE 2026-08-25                       |
+| T-A2  | 64-bit limb pairs in the add/sub kernels         | DONE 2026-08-25 — 2.8× at every size  |
 | T-SH1 | Pre-size the shift result buffer                 | OPEN                                  |
 | T-W1  | Base-2^64 limbs throughout                       | PARTLY — T-M4 does it in the kernel   |
 | T-E1  | `reciprocal_sqrt_fixed_point()` binary recip. sqrt    | DONE 2026-08-24 — enables T-PI4       |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -320,6 +320,28 @@ operations, the two in-place ones, `_add_slices()` and
 words. The recursions are add/sub-heavy at every level and inherit most of it:
 multiply 1.26× and divide 1.22× at 10 400 words, `pi(100000)` 44.2 → 36.1 ms.
 
+**T-A4 — exact divide-by-3 off the carry chain. DONE 2026-08-25.** Found by
+listing every `O(n)` helper's ns/word and looking for the outlier:
+`_exact_divide_by_3_inplace()` was 2.03 against 0.23-0.25 for its neighbours,
+because `//3` and `%3` both lower to multiply-high and both sat on the
+loop-carried chain.
+
+`2^32 = 3T + 1` with `T = 0x5555_5555`, so writing `word = 3d + m`:
+
+    quotient      = remainder * T + d + (remainder + m >= 3)
+    new remainder = (remainder + m) mod 3
+
+`d` and `m` depend only on `word`, so the surviving division is off the chain;
+what stays on it is an add and a reduction of a value below five. 2.03 → 1.17
+ns/word. `BigUInt` uses the same identity — `10^9` is also `1 mod 3` — and goes
+2.50 → 1.13.
+
+Worth having, but small: Toom-3 calls it once per node, so it is about 4% of a
+large multiply and the ~2% it returns is at the edge of the benchmark's noise.
+The remaining carry-select candidates in the codebase are all this size or
+smaller — the carry domain has to be tiny to enumerate, and multiply, division
+and base conversion all carry full-width values.
+
 ### from_string and shift
 
 **T-F1 — from_string base conversion.** The 50–10000-digit band runs an
@@ -401,6 +423,7 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-P1  | `square()` plus inplace loop for power           | OPEN                                  |
 | T-A1  | add/sub dispatch reorder                         | DONE 2026-08-25                       |
 | T-A2  | 64-bit limb pairs in the add/sub kernels         | DONE 2026-08-25 — 2.8× at every size  |
+| T-A4  | Exact divide-by-3 off the carry chain            | DONE 2026-08-25 — 1.7×, but ~2% of mul|
 | T-SH1 | Pre-size the shift result buffer                 | OPEN                                  |
 | T-W1  | Base-2^64 limbs throughout                       | PARTLY — T-M4 does it in the kernel   |
 | T-E1  | `reciprocal_sqrt_fixed_point()` binary recip. sqrt    | DONE 2026-08-24 — enables T-PI4       |

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -77,6 +77,94 @@ comptime CUTOFF_BURNIKEL_ZIEGLER: Int = 64
 # ===----------------------------------------------------------------------=== #
 
 
+@always_inline
+def _add_word_pairs[
+    o: Origin[mut=True]
+](
+    rp: Pointer[UInt32, o],
+    ap: Pointer[UInt32, _],
+    bp: Pointer[UInt32, _],
+    n_pairs: Int,
+    carry_in: UInt64,
+) -> UInt64:
+    """Adds `n_pairs` 64-bit limbs of two magnitudes: `r = a + b`, LSB first.
+
+    Two base-2^32 words at a time. The words are little-endian, so a pair of
+    them *is* one base-2^64 limb, and a single 64-bit add does the work of two
+    32-bit ones. The carry out of a limb is the unsigned overflow of that add,
+    which a comparison recovers without the shift-and-mask the 32-bit form
+    needs.
+
+    The pointers only have to be word-aligned, not limb-aligned: the accesses
+    request `alignment=4` explicitly, so `a`, `b` and `r` may each begin at any
+    word offset, and at different ones. `r` may alias `a` or `b` exactly.
+
+    Args:
+        rp: Destination, at least `2 * n_pairs` words.
+        ap: First summand, at least `2 * n_pairs` words.
+        bp: Second summand, at least `2 * n_pairs` words.
+        n_pairs: Number of 64-bit limbs to add.
+        carry_in: Carry into the lowest limb, 0 or 1.
+
+    Returns:
+        The carry out of the highest limb, 0 or 1.
+    """
+    var r64 = rp.unsafe_bitcast[UInt64]()
+    var a64 = ap.unsafe_bitcast[UInt64]()
+    var b64 = bp.unsafe_bitcast[UInt64]()
+    var carry = carry_in
+    for i in range(n_pairs):
+        var x = a64.unsafe_load[alignment=4](i)
+        var y = b64.unsafe_load[alignment=4](i)
+        var sum_xy = x + y
+        var carried = UInt64(sum_xy < x)
+        var total = sum_xy + carry
+        r64.unsafe_store[alignment=4](i, total)
+        carry = carried | UInt64(total < sum_xy)
+    return carry
+
+
+@always_inline
+def _subtract_word_pairs[
+    o: Origin[mut=True]
+](
+    rp: Pointer[UInt32, o],
+    ap: Pointer[UInt32, _],
+    bp: Pointer[UInt32, _],
+    n_pairs: Int,
+    borrow_in: UInt64,
+) -> UInt64:
+    """Subtracts `n_pairs` 64-bit limbs: `r = a - b`, LSB first.
+
+    The borrow counterpart of `_add_word_pairs()`, with the same alignment and
+    aliasing freedom. A limb borrows exactly when its 64-bit subtraction
+    wraps, so the borrow is again a comparison rather than a mask.
+
+    Args:
+        rp: Destination, at least `2 * n_pairs` words.
+        ap: Minuend, at least `2 * n_pairs` words.
+        bp: Subtrahend, at least `2 * n_pairs` words.
+        n_pairs: Number of 64-bit limbs to subtract.
+        borrow_in: Borrow into the lowest limb, 0 or 1.
+
+    Returns:
+        The borrow out of the highest limb, 0 or 1.
+    """
+    var r64 = rp.unsafe_bitcast[UInt64]()
+    var a64 = ap.unsafe_bitcast[UInt64]()
+    var b64 = bp.unsafe_bitcast[UInt64]()
+    var borrow = borrow_in
+    for i in range(n_pairs):
+        var x = a64.unsafe_load[alignment=4](i)
+        var y = b64.unsafe_load[alignment=4](i)
+        var difference = x - y
+        var borrowed = UInt64(x < y)
+        var total = difference - borrow
+        r64.unsafe_store[alignment=4](i, total)
+        borrow = borrowed | UInt64(difference < borrow)
+    return borrow
+
+
 def _add_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     """Adds two unsigned magnitudes represented as little-endian UInt32 words.
 
@@ -92,16 +180,38 @@ def _add_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     var len_a = len(a)
     var len_b = len(b)
     var len_max = max(len_a, len_b)
+    var len_min = min(len_a, len_b)
     var result = List[UInt32](capacity=len_max + 1)
     result.resize(unsafe_uninit_length=len_max)
 
-    var carry: UInt64 = 0
-    for i in range(len_max):
-        var ai: UInt64 = UInt64(a[i]) if i < len_a else 0
-        var bi: UInt64 = UInt64(b[i]) if i < len_b else 0
-        var s = ai + bi + carry
-        result[i] = UInt32(s & 0xFFFF_FFFF)
+    var ap = a.unsafe_ptr()
+    var bp = b.unsafe_ptr()
+    var rp = result.unsafe_ptr()
+
+    var pairs = len_min >> 1
+    var carry = _add_word_pairs(rp, ap, bp, pairs, UInt64(0))
+    var i = pairs << 1
+    while i < len_min:
+        var s = (
+            UInt64(ap[unsafe_offset=i]) + UInt64(bp[unsafe_offset=i]) + carry
+        )
+        rp[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
         carry = s >> 32
+        i += 1
+
+    # Only the longer operand is left: absorb the carry, then copy the rest.
+    var longer = ap if len_a > len_b else bp
+    while i < len_max and carry != 0:
+        var s = UInt64(longer[unsafe_offset=i]) + carry
+        rp[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
+        carry = s >> 32
+        i += 1
+    if i < len_max:
+        unsafe_memcpy(
+            dest=rp.unsafe_offset(i),
+            src=longer.unsafe_offset(i),
+            count=len_max - i,
+        )
 
     if carry > 0:
         result.append(UInt32(carry))
@@ -154,23 +264,36 @@ def _subtract_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     var len_a = len(a)
     var len_b = len(b)
     var result = List[UInt32](capacity=len_a)
+    result.resize(unsafe_uninit_length=len_a)
 
-    var borrow: UInt64 = 0
-    for i in range(len_a):
-        var ai: UInt64 = UInt64(a[i])
-        var bi: UInt64 = UInt64(b[i]) if i < len_b else 0
-        var diff = ai - bi - borrow
-        if ai < bi + borrow:
-            # Underflow — add 2^32 and set borrow
-            diff += BigInt.BASE
-            borrow = 1
-        else:
-            borrow = 0
-        result.append(UInt32(diff & 0xFFFF_FFFF))
+    var ap = a.unsafe_ptr()
+    var bp = b.unsafe_ptr()
+    var rp = result.unsafe_ptr()
 
-    # Strip leading zeros
-    while len(result) > 1 and result[len(result) - 1] == 0:
-        result.shrink(len(result) - 1)
+    var pairs = len_b >> 1
+    var borrow = _subtract_word_pairs(rp, ap, bp, pairs, UInt64(0))
+    var i = pairs << 1
+    while i < len_b:
+        var ai = UInt64(ap[unsafe_offset=i])
+        var bi = UInt64(bp[unsafe_offset=i]) + borrow
+        borrow = UInt64(ai < bi)
+        rp[unsafe_offset=i] = UInt32((ai - bi) & 0xFFFF_FFFF)
+        i += 1
+
+    # Only the minuend is left: absorb the borrow, then copy the rest.
+    while i < len_a and borrow != 0:
+        var ai = ap[unsafe_offset=i]
+        rp[unsafe_offset=i] = ai - UInt32(1)
+        borrow = UInt64(ai == 0)
+        i += 1
+    if i < len_a:
+        unsafe_memcpy(
+            dest=rp.unsafe_offset(i),
+            src=ap.unsafe_offset(i),
+            count=len_a - i,
+        )
+
+    _strip_leading_zeros_inplace(result)
 
     return result^
 
@@ -920,20 +1043,37 @@ def _add_slices(a: ImmSpan[UInt32, _], b: ImmSpan[UInt32, _]) -> List[UInt32]:
     var len_a = len(a)
     var len_b = len(b)
     var len_max = max(len_a, len_b)
+    var len_min = min(len_a, len_b)
     var result = List[UInt32](capacity=len_max + 1)
     result.resize(unsafe_uninit_length=len_max + 1)
-    result[len_max] = UInt32(0)
 
-    var carry: UInt64 = 0
     var ap = a.unsafe_ptr()
     var bp = b.unsafe_ptr()
     var rp = result._data
-    for i in range(len_max):
-        var ai: UInt64 = UInt64(ap[unsafe_offset=i]) if i < len_a else 0
-        var bi: UInt64 = UInt64(bp[unsafe_offset=i]) if i < len_b else 0
-        var s = ai + bi + carry
+
+    var pairs = len_min >> 1
+    var carry = _add_word_pairs(rp, ap, bp, pairs, UInt64(0))
+    var i = pairs << 1
+    while i < len_min:
+        var s = (
+            UInt64(ap[unsafe_offset=i]) + UInt64(bp[unsafe_offset=i]) + carry
+        )
         rp[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
         carry = s >> 32
+        i += 1
+
+    var longer = ap if len_a > len_b else bp
+    while i < len_max and carry != 0:
+        var s = UInt64(longer[unsafe_offset=i]) + carry
+        rp[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
+        carry = s >> 32
+        i += 1
+    if i < len_max:
+        unsafe_memcpy(
+            dest=rp.unsafe_offset(i),
+            src=longer.unsafe_offset(i),
+            count=len_max - i,
+        )
 
     if carry > 0:
         rp[unsafe_offset=len_max] = UInt32(carry)
@@ -964,26 +1104,28 @@ def _add_magnitudes_inplace(mut a: List[UInt32], imm b: List[UInt32]):
         for i in range(len_a, len_max + 1):
             a[i] = UInt32(0)
 
-    var carry: UInt64 = 0
-    for i in range(len_max):
-        var ai: UInt64 = UInt64(a[i]) if i < len_a else 0
-        var bi: UInt64 = UInt64(b[i]) if i < len_b else 0
-        var s = ai + bi + carry
-        a[i] = UInt32(s & 0xFFFF_FFFF)
-        carry = s >> 32
+    # `a` is now `len_max + 1` words long with a zero on top, so the sum and
+    # its carry both fit and every word of `b` has a counterpart in `a`.
+    var ap = a._data
+    var bp = b._data
 
-    if carry > 0:
-        if len_max < len(a):
-            a[len_max] = UInt32(UInt64(a[len_max]) + carry)
-        else:
-            a.append(UInt32(carry))
-    else:
-        # Trim to actual length
-        var alen = len(a)
-        while alen > 1 and a[alen - 1] == 0:
-            alen -= 1
-        while len(a) > alen:
-            a.shrink(len(a) - 1)
+    var pairs = len_b >> 1
+    var carry = _add_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var i = pairs << 1
+    while i < len_b:
+        var s = (
+            UInt64(ap[unsafe_offset=i]) + UInt64(bp[unsafe_offset=i]) + carry
+        )
+        ap[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
+        carry = s >> 32
+        i += 1
+    while carry != 0:
+        var s = UInt64(ap[unsafe_offset=i]) + carry
+        ap[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
+        carry = s >> 32
+        i += 1
+
+    _strip_leading_zeros_inplace(a)
 
 
 def _add_magnitudes_inplace(mut a: List[UInt32], b: UInt32):
@@ -1037,15 +1179,18 @@ def _add_at_offset_inplace(
         offset + len_b <= len(a),
         "_add_at_offset_inplace(): writes past the end of the accumulator",
     )
-    var carry: UInt64 = 0
     var ap = a._data.unsafe_offset(offset)
     var bp = b._data
-    for i in range(len_b):
+    var pairs = len_b >> 1
+    var carry = _add_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var i = pairs << 1
+    while i < len_b:
         var s = (
             UInt64(ap[unsafe_offset=i]) + UInt64(bp[unsafe_offset=i]) + carry
         )
         ap[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
         carry = s >> 32
+        i += 1
     # Propagate remaining carry
     var j = len_b
     while carry > 0 and (offset + j) < len(a):
@@ -1067,23 +1212,25 @@ def _subtract_magnitudes_inplace(mut a: List[UInt32], imm b: List[UInt32]):
     var len_a = len(a)
     var len_b = len(b)
 
-    var borrow: UInt64 = 0
     var ap = a._data
     var bp = b._data
-    for i in range(len_a):
-        var ai = UInt64(ap[unsafe_offset=i])
-        var bi: UInt64 = UInt64(bp[unsafe_offset=i]) if i < len_b else 0
-        var diff = ai - bi - borrow
-        if ai < bi + borrow:
-            diff += BigInt.BASE
-            borrow = 1
-        else:
-            borrow = 0
-        ap[unsafe_offset=i] = UInt32(diff & 0xFFFF_FFFF)
 
-    # Strip leading zeros
-    while len(a) > 1 and a[len(a) - 1] == 0:
-        a.shrink(len(a) - 1)
+    var pairs = len_b >> 1
+    var borrow = _subtract_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var i = pairs << 1
+    while i < len_b:
+        var ai = UInt64(ap[unsafe_offset=i])
+        var bi = UInt64(bp[unsafe_offset=i]) + borrow
+        borrow = UInt64(ai < bi)
+        ap[unsafe_offset=i] = UInt32((ai - bi) & 0xFFFF_FFFF)
+        i += 1
+    while i < len_a and borrow != 0:
+        var ai = ap[unsafe_offset=i]
+        ap[unsafe_offset=i] = ai - UInt32(1)
+        borrow = UInt64(ai == 0)
+        i += 1
+
+    _strip_leading_zeros_inplace(a)
 
 
 def _shift_left_words_inplace(mut a: List[UInt32], n: Int):
@@ -1506,25 +1653,28 @@ def _add_from_slice_inplace(mut a: List[UInt32], b: ImmSpan[UInt32, _]):
         for i in range(len_a, len_max + 1):
             a[i] = UInt32(0)
 
-    var carry: UInt64 = 0
-    for i in range(len_max):
-        var ai: UInt64 = UInt64(a[i]) if i < len_a else 0
-        var bi: UInt64 = UInt64(b[i]) if i < len_b_slice else 0
-        var s = ai + bi + carry
-        a[i] = UInt32(s & 0xFFFF_FFFF)
-        carry = s >> 32
+    # As in `_add_magnitudes_inplace()`, `a` now has `len_max + 1` words with a
+    # zero on top, so the carry always lands inside it.
+    var ap = a._data
+    var bp = b.unsafe_ptr()
 
-    if carry > 0:
-        if len_max < len(a):
-            a[len_max] = UInt32(UInt64(a[len_max]) + carry)
-        else:
-            a.append(UInt32(carry))
-    else:
-        var alen = len(a)
-        while alen > 1 and a[alen - 1] == 0:
-            alen -= 1
-        while len(a) > alen:
-            a.shrink(len(a) - 1)
+    var pairs = len_b_slice >> 1
+    var carry = _add_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var i = pairs << 1
+    while i < len_b_slice:
+        var s = (
+            UInt64(ap[unsafe_offset=i]) + UInt64(bp[unsafe_offset=i]) + carry
+        )
+        ap[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
+        carry = s >> 32
+        i += 1
+    while carry != 0:
+        var s = UInt64(ap[unsafe_offset=i]) + carry
+        ap[unsafe_offset=i] = UInt32(s & 0xFFFF_FFFF)
+        carry = s >> 32
+        i += 1
+
+    _strip_leading_zeros_inplace(a)
 
 
 def _multiply_magnitudes_slices(
@@ -2001,19 +2151,33 @@ def add(x1: BigInt, x2: BigInt) -> BigInt:
     Returns:
         The sum of the two BigInt numbers.
     """
+    # Same sign: add magnitudes, preserve sign. First, because it is both the
+    # common case and the one that does no comparison.
+    if x1.sign == x2.sign:
+        if x1.is_zero():
+            return x2.copy()
+        if x2.is_zero():
+            return x1.copy()
+        var result_words = _add_magnitudes(x1.words, x2.words)
+        return BigInt(raw_words=result_words^, sign=x1.sign)
+
     # If one of the numbers is zero, return the other
     if x1.is_zero():
         return x2.copy()
     if x2.is_zero():
         return x1.copy()
 
-    # Different signs: a + (-b) = a - b
-    if x1.sign != x2.sign:
-        return subtract(x1, -x2)
-
-    # Same sign: add magnitudes, preserve sign
-    var result_words = _add_magnitudes(x1.words, x2.words)
-    return BigInt(raw_words=result_words^, sign=x1.sign)
+    # Opposite signs: the magnitudes cancel, and the larger one wins the sign.
+    # Done here rather than as `subtract(x1, -x2)` so that negating `x2` does
+    # not copy its whole magnitude first.
+    var cmp = compare_magnitudes(x1, x2)
+    if cmp == 0:
+        return BigInt()
+    if cmp > 0:
+        var result_words = _subtract_magnitudes(x1.words, x2.words)
+        return BigInt(raw_words=result_words^, sign=x1.sign)
+    var result_words = _subtract_magnitudes(x2.words, x1.words)
+    return BigInt(raw_words=result_words^, sign=x2.sign)
 
 
 def subtract(x1: BigInt, x2: BigInt) -> BigInt:
@@ -2033,9 +2197,12 @@ def subtract(x1: BigInt, x2: BigInt) -> BigInt:
     if x1.is_zero():
         return -x2
 
-    # Different signs: a - (-b) = a + b
+    # Different signs: a - (-b) = a + b, with a's sign. Inlined rather than
+    # routed through `add(x1, -x2)` so that negating `x2` does not copy its
+    # whole magnitude first.
     if x1.sign != x2.sign:
-        return add(x1, -x2)
+        var sum_words = _add_magnitudes(x1.words, x2.words)
+        return BigInt(raw_words=sum_words^, sign=x1.sign)
 
     # Same sign: compare magnitudes to determine result sign
     var cmp = compare_magnitudes(x1, x2)

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -802,15 +802,42 @@ def _exact_divide_by_3_inplace(mut a: List[UInt32]):
     once the last word is consumed. Toom-3's interpolation is the only caller
     and its dividend is exactly divisible by construction.
 
+    The straightforward form — build `remainder * 2^32 + word`, divide it, take
+    the modulus — puts *two* dependent multiplications on the loop-carried
+    chain, because a compiler turns both the division and the modulus by a
+    constant into multiply-high. That cost about nine cycles per word, roughly
+    nine times what the neighbouring word-at-a-time helpers cost.
+
+    The division comes off the chain by splitting it. Since `2^32 = 3 * T + 1`
+    with `T = 0x5555_5555`, writing `word = 3 * d + m`:
+
+        remainder * 2^32 + word = 3 * (remainder * T + d) + (remainder + m)
+
+    so, with `remainder + m <= 4`,
+
+        quotient      = remainder * T + d + (remainder + m >= 3)
+        new remainder = (remainder + m) mod 3
+
+    `d` and `m` depend only on `word`, so the one division left is off the
+    chain; what stays on it is an add and a reduction of a value below five.
+
     Args:
         a: The magnitude to divide in-place. Must be a multiple of three.
     """
-    var remainder: UInt64 = 0
+    comptime BASE_OVER_THREE = UInt32(0x5555_5555)  # (2^32 - 1) / 3
+
+    var remainder = UInt32(0)  # 0, 1 or 2
     var ap = a._data
     for i in range(len(a) - 1, -1, -1):
-        var current = (remainder << 32) | UInt64(ap[unsafe_offset=i])
-        ap[unsafe_offset=i] = UInt32(current // 3)
-        remainder = current % 3
+        var word = ap[unsafe_offset=i]
+        var word_quotient = word // 3  # off the chain
+        var word_remainder = word - 3 * word_quotient  # off the chain, 0..2
+        var total = remainder + word_remainder  # on the chain, 0..4
+        var carried = UInt32(total >= 3)
+        ap[unsafe_offset=i] = (
+            remainder * BASE_OVER_THREE + word_quotient + carried
+        )
+        remainder = total - 3 * carried
     _strip_leading_zeros_inplace(a)
 
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -2035,16 +2035,42 @@ def exact_divide_by_3_inplace(mut x: BigUInt):
     The caller must ensure that x is divisible by 3.
     Uses base-10^9 long division from MSB to LSB.
 
+    Notes:
+
+    The straightforward form — build `carry * BASE + word`, divide it, take the
+    modulus — puts *two* dependent multiplications on the loop-carried chain,
+    because a compiler turns both the division and the modulus by a constant
+    into multiply-high.
+
+    The division comes off the chain by splitting it. Since `10^9 = 3 * T + 1`
+    with `T = 333_333_333`, writing `word = 3 * d + m`:
+
+        carry * 10^9 + word = 3 * (carry * T + d) + (carry + m)
+
+    so, with `carry + m <= 4`,
+
+        quotient = carry * T + d + (carry + m >= 3)
+        new carry = (carry + m) mod 3
+
+    `d` and `m` depend only on `word`, so the one division left is off the
+    chain. See `bigint.arithmetics._exact_divide_by_3_inplace()`, which uses
+    the same identity in base 2^32 — both bases happen to be `1 mod 3`.
+
     Args:
         x: The `BigUInt` value to divide, modified in place.
     """
-    var carry: UInt32 = 0
+    comptime BASE_OVER_THREE = UInt32(333_333_333)  # (10^9 - 1) / 3
+
+    var carry = UInt32(0)  # 0, 1 or 2
+    var xp = x.words._data
     for i in range(len(x.words) - 1, -1, -1):
-        # carry is 0..2; carry * BASE + words[i] fits in UInt32
-        # because max = 2 * 10^9 + 999_999_999 = 2_999_999_999 < 2^32
-        var val = carry * UInt32(BigUInt.BASE) + x.words[i]
-        x.words[i] = val // 3
-        carry = val % 3
+        var word = xp[unsafe_offset=i]
+        var word_quotient = word // 3  # off the chain
+        var word_remainder = word - 3 * word_quotient  # off the chain, 0..2
+        var total = carry + word_remainder  # on the chain, 0..4
+        var carried = UInt32(total >= 3)
+        xp[unsafe_offset=i] = carry * BASE_OVER_THREE + word_quotient + carried
+        carry = total - 3 * carried
     x.remove_leading_empty_words()
 
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -53,12 +53,13 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 # absolute(x: BigUInt) -> BigUInt
 #
 # add(x1: BigUInt, x2: BigUInt) -> BigUInt
-# add_slices_simd(x: BigUInt, y: BigUInt) -> BigUInt
+# add_slices_carry_select(x: BigUInt, y: BigUInt) -> BigUInt
 # add_slices(x: BigUInt, y: BigUInt, start_x: Int, end_x: Int, start_y: Int, end_y: Int) -> BigUInt
 # add_inplace(x1: BigUInt, x2: BigUInt)
 # add_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
 #
 # subtract(x1: BigUInt, x2: BigUInt) -> BigUInt
+# subtract_carry_select(x1: BigUInt, x2: BigUInt) -> BigUInt
 # subtract_inplace(x1: BigUInt, x2: BigUInt) -> None
 # subtract_no_check_inplace(x1: BigUInt, x2: BigUInt) -> None
 # subtract_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
@@ -100,6 +101,182 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 # Unary operations
 # negative, absolute
 # ===----------------------------------------------------------------------=== #
+
+
+# ===----------------------------------------------------------------------=== #
+# Word-level carry-select kernels
+#
+# A base-10^9 word does not carry by overflowing, so the carry out of a word
+# cannot be read off the hardware flags the way a base-2^32 one can: it is a
+# comparison against `BASE`, and the comparison depends on the carry coming in.
+# Written directly, that puts a compare on the loop-carried dependency chain.
+#
+# These kernels use the carry-select trick instead: both answers — the one for
+# carry-in 0 and the one for carry-in 1 — are computed from the operands alone,
+# off the critical path, and the incoming carry only picks between them. What
+# remains loop-carried is a select, so the chain is roughly one cycle per word
+# rather than the three or four an add-compare-branch chain costs.
+#
+# They also replace the older two-pass shape (a vectorized word-wise add over
+# the whole operand, then `normalize_carries_lt_2_bases()` over the whole
+# result). One pass touches the words once instead of twice, which is what the
+# large sizes were actually paying for, and a carry that dies early now stops
+# early instead of walking the rest of the accumulator.
+# ===----------------------------------------------------------------------=== #
+
+
+@always_inline
+def _add_words_carry_select[
+    o: Origin[mut=True]
+](
+    rp: Pointer[UInt32, o],
+    ap: Pointer[UInt32, _],
+    bp: Pointer[UInt32, _],
+    n_words: Int,
+    carry_in: UInt32,
+) -> UInt32:
+    """Adds `n_words` base-10^9 words: `r = a + b`, least significant first.
+
+    `r` may alias `a` or `b` word-for-word.
+
+    Args:
+        rp: Destination, at least `n_words` words.
+        ap: First summand, at least `n_words` words.
+        bp: Second summand, at least `n_words` words.
+        n_words: Number of words to add.
+        carry_in: Carry into the lowest word, 0 or 1.
+
+    Returns:
+        The carry out of the highest word, 0 or 1.
+    """
+    var carry = carry_in
+    for i in range(n_words):
+        var raw = ap[unsafe_offset=i] + bp[unsafe_offset=i]
+        var carry_if_0 = UInt32(raw >= BigUInt.BASE)
+        var carry_if_1 = UInt32(raw >= BigUInt.BASE_MAX)
+        var word_if_0 = raw - BigUInt.BASE if carry_if_0 != 0 else raw
+        var word_if_1 = raw + 1 - BigUInt.BASE if carry_if_1 != 0 else raw + 1
+        rp[unsafe_offset=i] = word_if_1 if carry != 0 else word_if_0
+        carry = carry_if_1 if carry != 0 else carry_if_0
+    return carry
+
+
+@always_inline
+def _subtract_words_borrow_select[
+    o: Origin[mut=True]
+](
+    rp: Pointer[UInt32, o],
+    ap: Pointer[UInt32, _],
+    bp: Pointer[UInt32, _],
+    n_words: Int,
+    borrow_in: UInt32,
+) -> UInt32:
+    """Subtracts `n_words` base-10^9 words: `r = a - b`, least significant first.
+
+    The borrow counterpart of `_add_words_carry_select()`, with the same
+    aliasing freedom. The wrapped `a - b` is deliberate: it is the right answer
+    modulo 2^32 once `BASE` is added back.
+
+    Args:
+        rp: Destination, at least `n_words` words.
+        ap: Minuend, at least `n_words` words.
+        bp: Subtrahend, at least `n_words` words.
+        n_words: Number of words to subtract.
+        borrow_in: Borrow into the lowest word, 0 or 1.
+
+    Returns:
+        The borrow out of the highest word, 0 or 1.
+    """
+    var borrow = borrow_in
+    for i in range(n_words):
+        var minuend = ap[unsafe_offset=i]
+        var subtrahend = bp[unsafe_offset=i]
+        var raw = minuend - subtrahend
+        var borrow_if_0 = UInt32(minuend < subtrahend)
+        var borrow_if_1 = UInt32(minuend <= subtrahend)
+        var word_if_0 = raw + BigUInt.BASE if borrow_if_0 != 0 else raw
+        var word_if_1 = raw - 1 + BigUInt.BASE if borrow_if_1 != 0 else raw - 1
+        rp[unsafe_offset=i] = word_if_1 if borrow != 0 else word_if_0
+        borrow = borrow_if_1 if borrow != 0 else borrow_if_0
+    return borrow
+
+
+@always_inline
+def _carry_into_tail[
+    o: Origin[mut=True]
+](
+    rp: Pointer[UInt32, o],
+    ap: Pointer[UInt32, _],
+    start: Int,
+    end: Int,
+    carry_in: UInt32,
+) -> UInt32:
+    """Copies `a[start:end]` into `r`, absorbing a carry on the way.
+
+    The carry dies at the first word below `BASE_MAX`, so the loop usually runs
+    once; the untouched remainder is a single memory copy. `r` may alias `a`,
+    in which case the copy is elided.
+
+    Args:
+        rp: Destination, at least `end` words.
+        ap: Source, at least `end` words.
+        start: First word to process.
+        end: One past the last word to process.
+        carry_in: Carry into word `start`, 0 or 1.
+
+    Returns:
+        The carry out of word `end - 1`, 0 or 1.
+    """
+    var carry = carry_in
+    var i = start
+    while carry != 0 and i < end:
+        var raw = ap[unsafe_offset=i] + carry
+        carry = UInt32(raw >= BigUInt.BASE)
+        rp[unsafe_offset=i] = raw - BigUInt.BASE if carry != 0 else raw
+        i += 1
+    if i < end and rp.unsafe_offset(i) != ap.unsafe_offset(i):
+        unsafe_memcpy(
+            dest=rp.unsafe_offset(i), src=ap.unsafe_offset(i), count=end - i
+        )
+    return carry
+
+
+@always_inline
+def _borrow_into_tail[
+    o: Origin[mut=True]
+](
+    rp: Pointer[UInt32, o],
+    ap: Pointer[UInt32, _],
+    start: Int,
+    end: Int,
+    borrow_in: UInt32,
+) -> UInt32:
+    """Copies `a[start:end]` into `r`, absorbing a borrow on the way.
+
+    The borrow counterpart of `_carry_into_tail()`.
+
+    Args:
+        rp: Destination, at least `end` words.
+        ap: Source, at least `end` words.
+        start: First word to process.
+        end: One past the last word to process.
+        borrow_in: Borrow into word `start`, 0 or 1.
+
+    Returns:
+        The borrow out of word `end - 1`, 0 or 1.
+    """
+    var borrow = borrow_in
+    var i = start
+    while borrow != 0 and i < end:
+        var minuend = ap[unsafe_offset=i]
+        borrow = UInt32(minuend == 0)
+        rp[unsafe_offset=i] = BigUInt.BASE_MAX if borrow != 0 else minuend - 1
+        i += 1
+    if i < end and rp.unsafe_offset(i) != ap.unsafe_offset(i):
+        unsafe_memcpy(
+            dest=rp.unsafe_offset(i), src=ap.unsafe_offset(i), count=end - i
+        )
+    return borrow
 
 
 def negative(x: BigUInt) raises -> BigUInt:
@@ -156,7 +333,7 @@ def add(x: BigUInt, y: BigUInt) -> BigUInt:
     Notes:
 
     This function will consider the special cases first, and then call
-    `add_slices_simd()` to handle the addition of the two BigUInt numbers.
+    `add_slices_carry_select()` to handle the addition of the two numbers.
     """
     debug_assert[assert_mode="none"](
         len(x.words) != 0, "BigUInt is uninitialized!"
@@ -209,7 +386,7 @@ def add(x: BigUInt, y: BigUInt) -> BigUInt:
     # can be simplified to addition and subtraction instead of floor division
     # and modulo operations.
     # This speeds up the addition by 2x-4x for large numbers.
-    return add_slices_simd(x, y, (0, len(x.words)), (0, len(y.words)))
+    return add_slices_carry_select(x, y, (0, len(x.words)), (0, len(y.words)))
 
 
 def add_slices(
@@ -229,7 +406,7 @@ def add_slices(
     Notes:
 
     This function will consider the special cases first, and then call
-    `add_slices_simd()` to handle the addition of the two BigUInt slices.
+    `add_slices_carry_select()` to handle the addition of the two slices.
     """
 
     var n_words_x_slice = bounds_x[1] - bounds_x[0]
@@ -261,13 +438,13 @@ def add_slices(
 
     # Normal cases
     # Use SIMD operations for addition if both numbers are large enough.
-    return add_slices_simd(x, y, bounds_x, bounds_y)
+    return add_slices_carry_select(x, y, bounds_x, bounds_y)
 
 
-def add_slices_simd(
+def add_slices_carry_select(
     x: BigUInt, y: BigUInt, bounds_x: Tuple[Int, Int], bounds_y: Tuple[Int, Int]
 ) -> BigUInt:
-    """Adds two BigUInt slices using SIMD operations.
+    """Adds two BigUInt slices in a single carry-select pass.
 
     Args:
         x: The first BigUInt operand (first summand).
@@ -276,87 +453,35 @@ def add_slices_simd(
         bounds_y: A tuple containing the start and end indices of the slice in y.
 
     Returns:
-        A new BigUInt containing the sum of the two numbers.
+        A new BigUInt containing the sum of the two slices.
 
     Notes:
 
     **Special cases are not handled here**. Please handle them in the caller.
 
-    This function uses **SIMD operations** to add the words of the two BigUInt
-    slices in parallel. It is optimized for performance and can handle
-    large numbers efficiently.
-
-    After the parallel addition, it normalizes the carries to ensure that
-    the result is a valid BigUInt number.
-
-    Although you use an extra loop to normalize the carries, this is still
-    faster than the school method for large numbers, as the normalized carries
-    can be simplified to addition and subtraction instead of floor division
-    and modulo operations.
-
-    This function conducts addtion of the two **BigUInt slices**. It avoids
-    creating copies of the BigUInt objects by using the indices to access
-    the words directly. This is useful for performance in cases where the
-    BigUInt objects are large and we only need to add a part of them.
+    Working on the slices in place, through the indices, is what keeps this off
+    the copy path: neither operand is materialised. See the kernel comment
+    above `_add_words_carry_select()` for why the loop is shaped the way it is.
     """
+
     var n_words_x_slice = bounds_x[1] - bounds_x[0]
     var n_words_y_slice = bounds_y[1] - bounds_y[0]
+    var n_words_longer = max(n_words_x_slice, n_words_y_slice)
+    var n_words_shorter = min(n_words_x_slice, n_words_y_slice)
 
-    var result = BigUInt(
-        unsafe_uninit_length=max(n_words_x_slice, n_words_y_slice)
-    )
+    var result = BigUInt(unsafe_uninit_length=n_words_longer)
+    result.words.reserve(n_words_longer + 1)
 
-    def vector_add[
-        simd_width: Int
-    ](i: Int) {mut result, imm x, imm y, imm bounds_x, imm bounds_y}:
-        result.words.unsafe_ptr().unsafe_store[width=simd_width](
-            i,
-            x.words.unsafe_ptr().unsafe_load[width=simd_width](i + bounds_x[0])
-            + y.words.unsafe_ptr().unsafe_load[width=simd_width](
-                i + bounds_y[0]
-            ),
-        )
+    var xp = x.words._data.unsafe_offset(bounds_x[0])
+    var yp = y.words._data.unsafe_offset(bounds_y[0])
+    var rp = result.words._data
 
-    vectorize[BigUInt.VECTOR_WIDTH](
-        min(n_words_x_slice, n_words_y_slice), vector_add
-    )
+    var carry = _add_words_carry_select(rp, xp, yp, n_words_shorter, UInt32(0))
+    var longer = xp if n_words_x_slice > n_words_y_slice else yp
+    carry = _carry_into_tail(rp, longer, n_words_shorter, n_words_longer, carry)
+    if carry != 0:
+        result.words.append(UInt32(1))
 
-    var longer: Pointer[BigUInt, origin_of(x, y)]
-    var n_words_longer_slice: Int
-    var n_words_shorter_slice: Int
-    var longer_start: Int
-
-    if n_words_x_slice >= n_words_y_slice:
-        longer = Pointer[BigUInt, origin_of(x, y)](to=x)
-        n_words_longer_slice = n_words_x_slice
-        n_words_shorter_slice = n_words_y_slice
-        longer_start = bounds_x[0]
-    else:
-        longer = Pointer[BigUInt, origin_of(x, y)](to=y)
-        n_words_longer_slice = n_words_y_slice
-        n_words_shorter_slice = n_words_x_slice
-        longer_start = bounds_y[0]
-
-    def vector_copy_rest_from_longer[
-        simd_width: Int
-    ](i: Int) {
-        mut result, imm longer, imm n_words_shorter_slice, imm longer_start
-    }:
-        result.words.unsafe_ptr().unsafe_store[width=simd_width](
-            n_words_shorter_slice + i,
-            longer[]
-            .words.unsafe_ptr()
-            .unsafe_load[width=simd_width](
-                longer_start + n_words_shorter_slice + i
-            ),
-        )
-
-    vectorize[BigUInt.VECTOR_WIDTH](
-        n_words_longer_slice - n_words_shorter_slice,
-        vector_copy_rest_from_longer,
-    )
-
-    normalize_carries_lt_2_bases(result)
     result.remove_leading_empty_words()
     return result^
 
@@ -370,7 +495,8 @@ def add_inplace(mut x: BigUInt, y: BigUInt) -> None:
 
     Notes:
 
-    This function uses SIMD operations to add the words of the two BigUInt.
+    A single carry-select pass over the words of `y`, then the carry alone
+    through whatever of `x` extends past it.
     """
 
     # Short circuit cases
@@ -394,17 +520,14 @@ def add_inplace(mut x: BigUInt, y: BigUInt) -> None:
     if len(x.words) < len(y.words):
         x.words.resize(length=len(y.words), fill=UInt32(0))
 
-    def vector_add[simd_width: Int](i: Int) {mut x, imm y}:
-        x.words.unsafe_ptr().unsafe_store[width=simd_width](
-            i,
-            x.words.unsafe_ptr().unsafe_load[width=simd_width](i)
-            + y.words.unsafe_ptr().unsafe_load[width=simd_width](i),
-        )
+    var xp = x.words._data
+    var carry = _add_words_carry_select(
+        xp, xp, y.words._data, len(y.words), UInt32(0)
+    )
+    carry = _carry_into_tail(xp, xp, len(y.words), len(x.words), carry)
+    if carry != 0:
+        x.words.append(UInt32(1))
 
-    vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_add)
-
-    # Normalize carries after addition
-    normalize_carries_lt_2_bases(x)
     x.remove_leading_empty_words()
 
     return
@@ -444,19 +567,17 @@ def add_by_slice_inplace(
     if len(x.words) < n_words_y_slice:
         x.words.resize(length=n_words_y_slice, fill=UInt32(0))
 
-    def vector_add[simd_width: Int](i: Int) {mut x, imm y, imm bounds_y}:
-        x.words.unsafe_ptr().unsafe_store[width=simd_width](
-            i,
-            x.words.unsafe_ptr().unsafe_load[width=simd_width](i)
-            + y.words.unsafe_ptr().unsafe_load[width=simd_width](
-                i + bounds_y[0]
-            ),
-        )
-
-    vectorize[BigUInt.VECTOR_WIDTH](n_words_y_slice, vector_add)
-
-    # Normalize carries after addition
-    normalize_carries_lt_2_bases(x)
+    var xp = x.words._data
+    var carry = _add_words_carry_select(
+        xp,
+        xp,
+        y.words._data.unsafe_offset(bounds_y[0]),
+        n_words_y_slice,
+        UInt32(0),
+    )
+    carry = _carry_into_tail(xp, xp, n_words_y_slice, len(x.words), carry)
+    if carry != 0:
+        x.words.append(UInt32(1))
 
     return
 
@@ -500,9 +621,9 @@ def subtract(x: BigUInt, y: BigUInt) raises -> BigUInt:
     Returns:
         The result of subtracting y from x.
     """
-    # I will use the SIMD approach for subtraction
-    # This speeds up the subtraction by 1.25x for large numbers.
-    return subtract_simd(x, y)
+    # A single borrow-select pass. The school method below is kept for
+    # reference; it is the same algorithm with the borrow on the critical path.
+    return subtract_carry_select(x, y)
 
     # Yuhao ZHU:
     # Below is a school method for subtraction.
@@ -590,8 +711,8 @@ def subtract_schoolbook(x: BigUInt, y: BigUInt) raises -> BigUInt:
     return result^
 
 
-def subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
-    """Returns the difference of two unsigned integers using SIMD operations.
+def subtract_carry_select(x: BigUInt, y: BigUInt) raises -> BigUInt:
+    """Returns the difference of two unsigned integers, borrow-select.
 
     Args:
         x: The first unsigned integer (minuend).
@@ -605,10 +726,8 @@ def subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
 
     Notes:
 
-    I will make use of SIMD operations to subtract the words in parallel.
-    This will first subtract the words in parallel and then handle the borrows.
-    Note that there will be potential overflow in the subtraction,
-    but I will take advantage of that.
+    One pass over the words of `y`, then the borrow alone through the rest of
+    `x`. See the kernel comment above `_add_words_carry_select()`.
     """
     debug_assert[assert_mode="none"](
         len(x.words) != 0, "BigUInt is uninitialized!"
@@ -617,16 +736,14 @@ def subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
         len(y.words) != 0, "BigUInt is uninitialized!"
     )
 
-    # If the subtrahend is zero, return the minuend
+    # If the subtrahend is zero, return the minuend.
     # Yuhao ZHU:
-    # This step is important because y can be of zero words and is longer than x.
-    # This will makes the subtraction beyond the boundary of the result number,
-    # whose length is equal to the length of x.
-    # Note that our subtraction is via SIMD, so it is directly worked on unsafe
-    # pointers.
+    # This step is important because y can be of zero words and is longer than
+    # x. That would run the loop past the end of the result, whose length is
+    # the length of x, and the loop works on unsafe pointers.
     if y.is_zero():
         debug_assert[assert_mode="none"](
-            len(y.words) == 1, "subtract_simd(): leading zero words"
+            len(y.words) == 1, "subtract_carry_select(): leading zero words"
         )
         return x.copy()
 
@@ -644,37 +761,17 @@ def subtract_simd(x: BigUInt, y: BigUInt) raises -> BigUInt:
             ),
         )
 
-    # Now it is safe to subtract the smaller number from the larger one
-    # The result will have no more words than the first number
+    # Now it is safe to subtract the smaller number from the larger one.
+    # The result will have no more words than the first number.
     var result = BigUInt(unsafe_uninit_length=len(x.words))
 
-    # Yuhao ZHU:
-    # We will make use of SIMD operations to subtract the words in parallel.
-    # This will first subtract the words in parallel and then handle the borrows.
-    # Note that there will be potential overflow in the subtraction,
-    # but we will take advantage of that.
-    def vector_subtract[simd_width: Int](i: Int) {mut result, imm x, imm y}:
-        result.words.unsafe_ptr().unsafe_store[width=simd_width](
-            i,
-            x.words.unsafe_ptr().unsafe_load[width=simd_width](i)
-            - y.words.unsafe_ptr().unsafe_load[width=simd_width](i),
-        )
-
-    vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_subtract)
-
-    def vector_copy_rest[simd_width: Int](i: Int) {mut result, imm x, imm y}:
-        result.words.unsafe_ptr().unsafe_store[width=simd_width](
-            len(y.words) + i,
-            x.words.unsafe_ptr().unsafe_load[width=simd_width](
-                len(y.words) + i
-            ),
-        )
-
-    vectorize[BigUInt.VECTOR_WIDTH](
-        len(x.words) - len(y.words), vector_copy_rest
+    var xp = x.words._data
+    var rp = result.words._data
+    var borrow = _subtract_words_borrow_select(
+        rp, xp, y.words._data, len(y.words), UInt32(0)
     )
+    _ = _borrow_into_tail(rp, xp, len(y.words), len(x.words), borrow)
 
-    normalize_borrows(result)
     result.remove_leading_empty_words()
 
     return result^
@@ -705,11 +802,11 @@ def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
         x.words[0] = UInt32(0)  # Result is zero
         # This return is load-bearing. Without it the equal-operands case falls
         # through into the subtraction below, which subtracts `y` from the
-        # one-word zero that `x` has just become: the vectorized loop runs over
+        # one-word zero that `x` has just become: the loop runs over
         # `len(y.words)` words and reads and writes past the end of `x`, and
-        # `normalize_borrows()` then turns the garbage into a plausible-looking
-        # value. `x -= x` returned `877910460` for one 18-word operand. The
-        # out-of-place `subtract()` is unaffected; only this in-place path was.
+        # the result looks plausible rather than obviously wrong. `x -= x`
+        # returned `877910460` for one 18-word operand. The out-of-place
+        # `subtract()` is unaffected; only this in-place path was.
         return
     elif comparison_result < 0:
         raise OverflowError(
@@ -728,18 +825,12 @@ def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
         return
 
     # Note that len(x.words) >= len(y.words) here
-    # Use SIMD operations to subtract the words in parallel.
-    def vector_subtract[simd_width: Int](i: Int) {mut x, imm y}:
-        x.words.unsafe_ptr().unsafe_store[width=simd_width](
-            i,
-            x.words.unsafe_ptr().unsafe_load[width=simd_width](i)
-            - y.words.unsafe_ptr().unsafe_load[width=simd_width](i),
-        )
+    var xp = x.words._data
+    var borrow = _subtract_words_borrow_select(
+        xp, xp, y.words._data, len(y.words), UInt32(0)
+    )
+    _ = _borrow_into_tail(xp, xp, len(y.words), len(x.words), borrow)
 
-    vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_subtract)
-
-    # Normalize borrows after subtraction
-    normalize_borrows(x)
     x.remove_leading_empty_words()
 
     return
@@ -768,18 +859,12 @@ def subtract_no_check_inplace(mut x: BigUInt, y: BigUInt) -> None:
 
     # Underflow checks are skipped here, so we assume x >= y
     # Note that len(x.words) >= len(y.words) under this assumption
+    var xp = x.words._data
+    var borrow = _subtract_words_borrow_select(
+        xp, xp, y.words._data, len(y.words), UInt32(0)
+    )
+    _ = _borrow_into_tail(xp, xp, len(y.words), len(x.words), borrow)
 
-    def vector_subtract[simd_width: Int](i: Int) {mut x, imm y}:
-        x.words.unsafe_ptr().unsafe_store[width=simd_width](
-            i,
-            x.words.unsafe_ptr().unsafe_load[width=simd_width](i)
-            - y.words.unsafe_ptr().unsafe_load[width=simd_width](i),
-        )
-
-    vectorize[BigUInt.VECTOR_WIDTH](len(y.words), vector_subtract)
-
-    # Normalize borrows after subtraction
-    normalize_borrows(x)
     x.remove_leading_empty_words()
 
     return
@@ -3827,49 +3912,6 @@ def normalize_carries_lt_4_bases(mut x: BigUInt):
     if carry > 0:
         # If there is still a carry, we need to add a new word
         x.words.append(UInt32(carry))
-    return
-
-
-def normalize_borrows(mut x: BigUInt):
-    """Normalizes the values of words into valid range by borrowing.
-    The caller should ensure that the final result is non-negative.
-    The initial values of the words should be in the range:
-    [0, BASE-1] or [3294967297, 4294967295], in other words,
-    [UInt32.MAX - 999_999_998, ..., UInt32.MAX, 0, ..., BASE-1].
-
-    Notes:
-
-    If we subtract two BigUInt numbers word-by-word, we may end up with
-    a situation where some words are **underflowed**. We can take advantage of
-    the overflowed values of the words to normalize the borrows,
-    ensuring that all words are within the valid range.
-
-    Args:
-        x: The `BigUInt` to normalize, modified in place.
-    """
-
-    comptime NEG_BASE_MAX = UInt32(3294967297)  # UInt32(0) - BigUInt.BASE_MAX
-
-    # Yuhao ZHU:
-    # By construction, the words of x are in the range [-BASE_MAX, BASE_MAX].
-    # Thus, the borrow can only be 0 or 1.
-    var borrow: UInt32 = 0
-    for ref word in x.words:
-        if borrow == 0:
-            if word <= BigUInt.BASE_MAX:  # 0 <= word <= 999_999_999
-                pass  # borrow = 0
-            else:  # word >= 3294967297, overflowed value
-                word += BigUInt.BASE
-                borrow = 1
-        else:  # borrow == 1
-            if (word >= 1) and (
-                word <= BigUInt.BASE_MAX
-            ):  # 1 <= word <= 999_999_999
-                word -= 1
-                borrow = 0
-            else:  # word >= 3294967297 or word == 0, overflowed value
-                word = (word + BigUInt.BASE) - 1
-                # borrow = 1
     return
 
 

--- a/tests/bigint/test_bigint_arithmetics.mojo
+++ b/tests/bigint/test_bigint_arithmetics.mojo
@@ -679,5 +679,67 @@ def test_bigint_biguint_truncate_divide() raises:
     )
 
 
+def test_bigint_add_subtract_carry_chains() raises:
+    """Carry and borrow cascades that run the whole length of the operand.
+
+    `2^k - 1` is a run of all-ones words, so adding to it carries through every
+    one of them and subtracting borrows back through every one. The magnitude
+    loops work on 64-bit pairs of words, so the sweep of `k` crosses both the
+    word boundary and the pair boundary, and the second operand is short enough
+    that the carry has to leave the common region on its own. The mixed-sign
+    cases go through the opposite dispatch arm.
+    """
+    var py_builtins = Python.import_module("builtins")
+    for k in range(1, 300):
+        var py_ones = (py_builtins.int(1) << k) - 1
+        var ones = BigInt(String(py_ones))
+        var label = " at 2^" + String(k) + " - 1"
+        testing.assert_equal(
+            String(ones), String(py_ones), "round trip" + label
+        )
+
+        for small in range(1, 4):
+            var addend = BigInt(small)
+            var py_addend = py_builtins.int(small)
+            testing.assert_equal(
+                String(ones + addend),
+                String(py_ones + py_addend),
+                "add" + label,
+            )
+            testing.assert_equal(
+                String(ones - addend),
+                String(py_ones - py_addend),
+                "subtract" + label,
+            )
+            # Opposite signs: the same magnitudes, through the other arm.
+            testing.assert_equal(
+                String(ones + (-addend)),
+                String(py_ones - py_addend),
+                "add of opposite signs" + label,
+            )
+            testing.assert_equal(
+                String(ones - (-addend)),
+                String(py_ones + py_addend),
+                "subtract of opposite signs" + label,
+            )
+            testing.assert_equal(
+                String((-ones) + addend),
+                String(py_addend - py_ones),
+                "add into a negative" + label,
+            )
+
+        testing.assert_equal(
+            String(ones + ones), String(py_ones + py_ones), "doubling" + label
+        )
+        testing.assert_equal(String(ones - ones), "0", "self subtract" + label)
+        var accumulator = ones.copy()
+        accumulator += ones
+        testing.assert_equal(
+            String(accumulator), String(py_ones + py_ones), "+=" + label
+        )
+        accumulator -= ones
+        testing.assert_equal(String(accumulator), String(py_ones), "-=" + label)
+
+
 def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_large_algorithms.mojo
+++ b/tests/bigint/test_bigint_large_algorithms.mojo
@@ -18,6 +18,7 @@ below and just above the boundary. Generated with seed 20260812.
 
 from std import testing
 from decimo.bigint.bigint import BigInt
+import decimo.bigint.arithmetics as bigint_arithmetics
 
 
 # ===----------------------------------------------------------------=== #
@@ -812,6 +813,50 @@ def test_multiply_lopsided_across_the_packing_boundary() raises:
             String(_blockwise_product(a, b, 200)),
             "lopsided product is not commutative for " + case_label,
         )
+
+
+def test_exact_divide_by_three_round_trips() raises:
+    """`(x * 3) / 3 == x` for word patterns that stress the remainder chain.
+
+    Toom-3's interpolation is the only caller, and a wrong quotient there shows
+    up as a wrong product rather than as anything local, so the helper is worth
+    testing directly. The three carried remainders are exercised by sweeping
+    the word count against all-ones, all-zero and alternating magnitudes, which
+    is where an off-by-one in the `carry + word_remainder` reduction would land.
+    """
+    var patterns = [
+        String("all ones"),
+        String("all zeros but the top"),
+        String("alternating"),
+    ]
+    for n_words in range(1, 40):
+        for p in range(len(patterns)):
+            var magnitude = BigInt.zero()
+            for k in range(n_words):
+                var word: UInt32
+                if p == 0:
+                    word = UInt32(0xFFFF_FFFF)
+                elif p == 1:
+                    word = UInt32(0xFFFF_FFFF) if k == n_words - 1 else UInt32(
+                        0
+                    )
+                else:
+                    word = UInt32(0xFFFF_FFFF) if k % 2 == 0 else UInt32(0)
+                magnitude += BigInt(Int(word)) << (32 * k)
+            if magnitude.is_zero():
+                continue
+            var tripled = magnitude * BigInt(3)
+            var words = tripled.words.copy()
+            bigint_arithmetics._exact_divide_by_3_inplace(words)
+            testing.assert_equal(
+                String(BigInt(raw_words=words^, sign=False)),
+                String(magnitude),
+                "(x * 3) / 3 != x for "
+                + patterns[p]
+                + " at "
+                + String(n_words)
+                + " words",
+            )
 
 
 def main() raises:

--- a/tests/bigint/test_bigint_sqrt_divmod.mojo
+++ b/tests/bigint/test_bigint_sqrt_divmod.mojo
@@ -204,8 +204,8 @@ def test_reciprocal_sqrt_fixed_point_brackets_the_exact_value() raises:
     perfect squares (exact answers, where an off-by-one is easiest to make)
     and values above `2^53`, which no longer round-trip through the `Float64`
     seed. The `fractional_bits` values cross the point where the Newton schedule
-    starts running at all (`fractional_bits <= 44 + bits(x) / 2` returns the seed
-    directly) and then several doublings past it.
+    starts running at all (`fractional_bits <= 44 + ceil(bits(x) / 2)` returns
+    the seed directly) and then several doublings past it.
     """
     var xs = [
         UInt64(1),

--- a/tests/biguint/test_biguint_arithmetics.mojo
+++ b/tests/biguint/test_biguint_arithmetics.mojo
@@ -603,6 +603,69 @@ def test_biguint_inplace_arithmetics_match_out_of_place() raises:
         )
 
 
+def _digit_run(digit: String, count: Int) -> String:
+    var out = String("")
+    for _ in range(count):
+        out += digit
+    return out^
+
+
+def test_biguint_add_subtract_carry_chains() raises:
+    """Carry and borrow cascades that run the whole length of the operand.
+
+    `10^n - 1` is a run of `999_999_999` words, so adding to it carries through
+    every one of them and subtracting borrows back through every one. The digit
+    counts sweep across the word boundary at every multiple of nine, and the
+    second operand is short so that the carry has to leave the common region
+    and walk the rest of the accumulator on its own.
+    """
+    _set_max_str_digits(500000)
+
+    for n_digits in range(1, 120):
+        var nines = _digit_run("9", n_digits)
+        var x = BigUInt(nines)
+        var py_x = Python.int(nines)
+        var label = " at " + String(n_digits) + " digits"
+
+        for n_short in range(1, 4):
+            var short = _digit_run("9", n_short)
+            var y = BigUInt(short)
+            var py_y = Python.int(short)
+            var py_sum = String(py_x + py_y)
+            var py_difference = String(py_x - py_y)
+
+            assert_equal(String(add(x, y)), py_sum, "add" + label)
+            var accumulator = x.copy()
+            add_inplace(accumulator, y)
+            assert_equal(String(accumulator), py_sum, "add_inplace" + label)
+
+            if py_x >= py_y:
+                assert_equal(
+                    String(subtract(x, y)), py_difference, "subtract" + label
+                )
+                var minuend = x.copy()
+                subtract_inplace(minuend, y)
+                assert_equal(
+                    String(minuend), py_difference, "subtract_inplace" + label
+                )
+                var minuend_unchecked = x.copy()
+                subtract_no_check_inplace(minuend_unchecked, y)
+                assert_equal(
+                    String(minuend_unchecked),
+                    py_difference,
+                    "subtract_no_check_inplace" + label,
+                )
+
+        # x + x doubles every word at once; x - x is the equal-operands path.
+        assert_equal(String(add(x, x)), String(py_x + py_x), "x + x" + label)
+        var self_sum = x.copy()
+        add_inplace(self_sum, x)
+        assert_equal(String(self_sum), String(py_x + py_x), "x += x" + label)
+        var self_difference = x.copy()
+        subtract_inplace(self_difference, x)
+        assert_equal(String(self_difference), "0", "x -= x" + label)
+
+
 def main() raises:
     # test_biguint_arithmetics()
     # test_biguint_truncate_divide()


### PR DESCRIPTION
This PR optimizes the core arithmetic kernels that BigInt/BigUInt rely on by removing carry/borrow propagation work from the loop-carried critical path, improving throughput for add/subtract and exact divide-by-3. It also adds targeted regression/stress tests and updates internal/perf documentation to reflect the new implementations and measured gains.
- `BigInt`: add/sub magnitude loops now operate on 64-bit “limb pairs” (two UInt32 words at once) with explicit `alignment=4`, plus updated add/sub dispatch to avoid magnitude-copying via negation.
- `BigUInt`: replaces the prior vector-add + normalize two-pass approach with single-pass carry/borrow-select kernels, and updates exact divide-by-3 to a split form that removes dependent multiply-high chains.
- Adds new tests that stress full-length carry/borrow cascades and validates exact divide-by-3 round-trips for patterns that exercise remainder chains.