### PR TITLE
[core][integer] Implement NTT + `BDec` constructor no longer copies coefficients

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,18 @@ fixed.
 
 ### 🦋 Changed in Unreleased
 
+1. **`BigDecimal` construction no longer copies its coefficient.** The
+   component constructor took `coefficient` borrowed and then copied it, so
+   every call site already written as `coefficient=coef^` — 27 of them, the
+   whole of the arithmetic module among them — paid a full heap allocation for
+   a move it had explicitly asked for. The parameter is now owned.
+
+   Small-operand arithmetic is dominated by allocation rather than by
+   arithmetic, so this shows up across the board: `a + b` on short operands
+   goes from 73 ns to 43 ns. Against CPython's `decimal` (libmpdec), multiply
+   goes from 2.3x to 1.2x, subtract and `from_string` reach parity, and add
+   goes from 2.5x to 1.9x.
+
 1. **`BigInt` multiplication gains a number-theoretic transform, and `pi()`
    inherits it.** Above Toom-3, `_multiply_magnitudes()` now evaluates the
    product as a cyclic convolution modulo the Goldilocks prime

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,9 +8,12 @@ This is a list of changes for the Decimo package (formerly DeciMojo).
 `from_integral_scalar()` / `from_float_scalar()` naming used by the other
 numeric types, `BigInt10` is no longer referenced by the rest of the library,
 and `BigDecimal.pi()` gets four orders of magnitude faster — 100 000 digits in
-36 ms, and ahead of pure-Python mpmath from 500 digits up. Multiplication is
-2-3x faster for both `BigInt` and `BigUInt`, which puts `BigInt` ahead of
-CPython's `int` on every large operation. Addition and subtraction are 2-3x
+35 ms, a million in 0.8 s, and ahead of pure-Python mpmath from 500 digits up.
+`BigInt` multiplication gains a number-theoretic transform, which is 2.3x
+faster than Toom-3 at a million digits and closes the last asymptotic gap in
+the library. Multiplication is 2-3x faster for both `BigInt` and `BigUInt` at
+smaller sizes too, which puts `BigInt` ahead of CPython's `int` on every large
+operation. Addition and subtraction are 2-3x
 faster in turn, which the recursive multiplications and divisions inherit.
 Burnikel-Ziegler division loses a padding choice that cost it its own
 asymptotics on some sizes, which speeds up every division in the library. A
@@ -33,6 +36,30 @@ fixed.
    `BigInt10.from_bigint()` and `BigInt10.to_bigint()` (PR #269).
 
 ### 🦋 Changed in Unreleased
+
+1. **`BigInt` multiplication gains a number-theoretic transform, and `pi()`
+   inherits it.** Above Toom-3, `_multiply_magnitudes()` now evaluates the
+   product as a cyclic convolution modulo the Goldilocks prime
+   `2^64 - 2^32 + 1`, which brings the exponent down from `n^1.465` to
+   `n log n`. One prime, so there is no CRT step, and `P - 1 = 2^32 (2^32 - 1)`
+   supplies the powers-of-two roots of unity the transform needs. A 128-bit
+   product reduces in a shift, a subtract and two conditional fixups, because
+   `2^64 = 2^32 - 1 (mod P)`.
+
+   Two choices carried most of the speedup. The width of the chunks the
+   operands are cut into is left free rather than fixed at 16 bits: the
+   transform length has to be a power of two, so a fixed width leaves the
+   rounding up as pure waste, and at 10 400 words a 16-bit cut needs a
+   transform twice as long as a 25-bit cut does. The dispatch compares fitted
+   cost models rather than
+   a word count, because the transform's cost steps at powers of two while
+   Toom-3's climbs smoothly — the transform loses at 4 096 words, ties at
+   8 192, and wins from 16 384 up.
+
+   Multiplication at a million digits (104 200 words) goes from 54.7 ms to
+   24.0 ms, and 1.45x at 100 000 words. `BigDecimal.pi()` at a million digits
+   goes from 1189 ms to 821 ms; the binary-splitting stage, which is half the
+   run, goes from 627 ms to 436 ms.
 
 1. **Addition and subtraction are 2-3x faster, and everything built on them
    moves with them.** Both types carried word by word in 32-bit steps, and

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -1,5 +1,26 @@
 # Internal Notes
 
+## Goals
+
+Two targets to steer by, both about being competitive with the established
+libraries rather than beating them everywhere. Measured on Apple M4 Pro,
+20260825.
+
+**1. `pi(10^6)` within 1.2x of mpmath+GMP** — 314 ms, against 796 ms today
+(3.0x). Two steps get there and neither needs a new algorithm: Newton
+reciprocal division (T-D6) is worth about 115 ms, and the rest has to come
+from a cheaper NTT butterfly — precomputed twiddles and radix-4, together
+about 2.5x. Detail in the sections on the NTT and on GMP's ratios below.
+
+**2. Beat CPython's `decimal` on small numbers** — this is what a
+`decimal.Decimal` drop-in is judged on, and today we are at parity on
+subtract, multiply and `from_string`, and 1.8-2.1x behind on add, round and
+divide. It is almost entirely memory management, not arithmetic: a small add
+does about 5 ns of real work and spends 36 ns allocating the result. Giving
+`BigUInt` inline storage for one or two words would remove the allocation
+and should put small operations clearly ahead of libmpdec. See "Small
+operations are allocation, not arithmetic".
+
 ## Inconsistencies between libraries
 
 - For power functionality: `BigDecimal.power()`, Python's decimal, WolframAlpha
@@ -272,6 +293,31 @@ top few levels of its tree are above the transform's crossover.
 
 decimo wins outright at 100 and 1 000 digits, including against MPFR. That is
 real and not a warm-up artifact — decimo was timed in-process, best-of-N.
+
+### Small operations are allocation, not arithmetic
+
+Measured on one-word operands:
+
+| | ns |
+| --- | --- |
+| `+=` in place, no allocation | 5 |
+| one `List[UInt32]` alloc + free | 36 |
+| `a + b` out of place | 43 |
+| libmpdec small add, for reference | 32 |
+
+The arithmetic is already fast; a small `BigDecimal` operation is one or two
+malloc/free pairs with a little work attached. That is the whole gap against
+libmpdec, which keeps small coefficients inline and never calls malloc for
+them.
+
+One instance of this was a plain bug and is fixed: `BigDecimal.__init__`
+took its coefficient *borrowed* and then copied it, so the 27 call sites
+already written as `coefficient=coef^` were all paying a full extra
+allocation for a move they had asked for. Making the parameter owned took
+`a + b` from 73 ns to 43 ns, multiply from 2.3x libmpdec to 1.2x, and
+subtract to parity.
+
+What is left is the allocation itself, and only inline storage removes it.
 
 ### MPFR computes pi by AGM, mpmath by Chudnovsky
 

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -231,7 +231,81 @@ only 6% here. The exactness guarantee costs a divide and a square at full width,
 and the fix is to stop paying for them in base 10^9 (T-Sq2, same argument as
 T-PI4).
 
+### Where `pi()` stands against mpmath and MPFR, and what the exponent says
+
+Measured 20260825 on Apple M4 Pro, after the NTT landed. Every engine was
+verified to produce the same digits first: at 1 000 000 digits decimo agrees
+with MPFR on all of them, and where a shorter run appears to disagree in its
+last digit it is decimo rounding half-even against a truncated reference.
+mpmath and MPFR both cache pi internally, so each measurement ran in a cold
+process.
+
+Compute pi and produce the decimal digits — the fair column, because decimo's
+pi is decimal-native while the other two are binary and pay conversion only on
+demand:
+
+| digits    | decimo   | mpmath (py) | mpmath+GMP | MPFR     |
+| --------- | -------- | ----------- | ---------- | -------- |
+| 100       | 7.0 us   | 28.0 us     | 37.9 us    | 37.5 us  |
+| 1 000     | 63 us    | 153 us      | 99 us      | 63.8 us  |
+| 10 000    | 1.25 ms  | 5.71 ms     | 0.85 ms    | 0.65 ms  |
+| 100 000   | 33.0 ms  | 182 ms      | 15.1 ms    | 23.7 ms  |
+| 1 000 000 | 797 ms   | 8.49 s      | 262 ms     | 410 ms   |
+
+Empirical exponent `t ~ digits^k`, per decade:
+
+| engine      | 100->1k | 1k->10k | 10k->100k | 100k->1M |
+| ----------- | ------- | ------- | --------- | -------- |
+| decimo      | 0.95    | 1.30    | 1.42      | **1.38** |
+| mpmath (py) | 0.74    | 1.57    | 1.50      | 1.67     |
+| mpmath+GMP  | 0.42    | 0.93    | 1.25      | 1.24     |
+| MPFR        | 0.23    | 1.01    | 1.56      | 1.24     |
+
+The exponent is the whole story of the widening ratio: 1.47x behind mpmath+GMP
+at 10 000 digits becomes 3.04x at 10^6 purely by compounding 1.38 against 1.24.
+decimo is still at 1.38 rather than the ~1.1 a fully-FFT pipeline would show
+because 39% of `pi(10^6)` is division and base conversion, which run at
+Toom-3's 1.465 — Burnikel-Ziegler reaches multiplication only through operands
+half the size and smaller, where the transform has not opened up. The binary
+splitting stage itself measures 1.38, not ~1.05, for the same reason: only the
+top few levels of its tree are above the transform's crossover.
+
+decimo wins outright at 100 and 1 000 digits, including against MPFR. That is
+real and not a warm-up artifact — decimo was timed in-process, best-of-N.
+
+### MPFR computes pi by AGM, mpmath by Chudnovsky
+
+Why MPFR is the *slower* of the two GMP-backed engines, which is otherwise
+surprising. At 10^6 digits a single `gmpy2.agm()` costs 341 ms and
+`mpfr_const_pi` costs 371 ms: `mpfr_const_pi` is one Brent-Salamin AGM plus
+change. The AGM needs a full-precision square root per iteration and about
+`log2(bits)` iterations — 22 sqrt at 12.5 ms is already 275 ms of the 371.
+mpmath instead runs Chudnovsky with binary splitting over GMP integers, the
+same algorithm we use, and lands at 262 ms. Both are `O(M(n) log n)` and both
+measure an exponent of 1.24; the difference is entirely the constant, which is
+why every pi record uses Chudnovsky and not AGM.
+
+### GMP's own division and base-conversion ratios, as a target
+
+Measured at 104 200 words (10^6 digits), against a same-size multiply:
+
+| operation           | GMP      | ratio to mul | decimo ratio |
+| ------------------- | -------- | ------------ | ------------ |
+| mul n x n           | 5.83 ms  | 1.00         | 1.00         |
+| divmod 2n / n       | 15.69 ms | 2.69         | 4.90         |
+| base 2^k -> decimal | 33.71 ms | 5.78         | 8.50         |
+
+Two things to take from this. GMP's division is 2.69x a multiply *with* all of
+its Newton-reciprocal machinery, so 2.7x is the realistic floor for T-D6 — not
+the ~2.1x the textbook operation count suggests. And our raw multiply is
+24.0 ms against GMP's 5.83, a 4.1x gap that is pure constant factor: same
+algorithm class, thirty years of tuning apart.
+
 ### GMP is on FFT from ~32 000 digits, and that is most of the gap
+
+Superseded in part by the table above — the 6.1x multiply gap it describes is
+now 4.1x, and the FFT half of it is closed. Kept for the measurement method.
+
 
 `mpz_mul` normalised to Toom-3's exponent, `t / n^1.465` with `n` in 64-bit
 limbs, is flat until it suddenly isn't:
@@ -325,6 +399,41 @@ Reading a `UInt32` array two words at a time needs
 explicit alignment the load claims 8-byte alignment, which a slice starting at
 an odd word offset does not have — and the Karatsuba and Toom-3 helpers pass
 exactly those.
+
+### `_data` is not a substitute for `unsafe_ptr()` on an appended list
+
+`list._data` reads the wrong address for a list built with `append()`: the
+element at index 0 comes back as zero while every later index reads correctly.
+It cost an afternoon in the NTT twiddle table, where the first entry of the
+root-of-unity table is `w^0 = 1` and silently became `0`. `unsafe_ptr()` is
+right in every case; `_data` is only for the one situation described above,
+where an origin would trip the exclusivity checker, and those lists are all
+built with `resize(unsafe_uninit_length=...)`.
+
+### Where the NTT actually wins, and where it does not
+
+Per-stage timings for `pi(1000000)`, in milliseconds, before and after the
+transform landed:
+
+| Stage                     | before | after |
+| ------------------------- | ------ | ----- |
+| binary splitting          | 627    | 436   |
+| base 2^32 -> 10^9         | 206    | 204   |
+| final division, binary    | 145    | 135   |
+| `sqrt(10005)`             | 62     | 44    |
+| final multiplies          | 56     | 25    |
+| scaling multiply          | 52     | 12    |
+| `5^s`                     | 26     | 15    |
+
+Every stage that is a multiplication moved. The two that did not are the two
+that are divisions, and the reason is worth recording: Burnikel-Ziegler is
+built out of multiplications, but of operands half the size and smaller, where
+the transform's advantage has not opened up yet, and its own constant did not
+change. Division measured 2.64x a same-size multiplication before the
+transform and 4.9x after — the denominator got cheaper and the numerator did
+not. That inverts the earlier assessment of reciprocal-Newton division: it was
+worth about 4% of `pi` when division was 2.64x a multiply, and it is worth
+about 20% now.
 
 ### A missing `return` in `subtract_inplace()`
 

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -115,6 +115,8 @@ that range-reduces against π (`sin`/`cos`/`tan`) inherits it.
 |          |      | 100 000 words. Multiply and divide inherit ~1.3×. Total: 44.2 → 36.1 ms               |
 | 20260825 | —    | `exact_divide_by_3_inplace()` division taken off the carry chain (T-A4);              |
 |          |      | 2.50 → 1.13 ns/word, but only ~2% of a Toom-3 multiply                                |
+| 20260825 | —    | NTT multiplication on `BigInt` over `2^64 - 2^32 + 1` (T-5), with a floating chunk    |
+|          |      | width and a cost-model dispatch. 104 200 words 54.9 → 24.0 ms; pi(10^6) 1189 → 821 ms |
 
 ### 2.4 Performance tracking — absolute decimo median ns/iter (ascending precision)
 
@@ -190,7 +192,7 @@ kernels (parse/render are precision-insensitive ops).
 | 3g  | AGM-based ln for very high precision          | OPEN — long-term, complex                                     |
 | 4   | sqrt via Newton-with-division is slow         | DONE (T4) — reciprocal-Newton + precision doubling;           |
 |     |                                               | 20× improvement                                               |
-| 5   | NTT multiplication for n ≥ 1024 words         | OPEN — single biggest long-term gap vs libmpdec               |
+| 5   | NTT multiplication for n ≥ 1024 words         | DONE (T-5) — Goldilocks prime, 2.3× at 1M digits             |
 | 6   | Toom-3 between Karatsuba and NTT              | DONE (T6) — +14–29% for ≥256w                                 |
 | 7a  | `integer_root` via direct Newton              | DONE (T7a) — 0.14×→25× py at p=1000 for cbrt                  |
 |     | (was exp(ln(x)/n))                            |                                                               |
@@ -715,8 +717,35 @@ P5 — ln far-from-1 (4.6×–9.2× py → target ≤2×)
   largely addressed by T-3e, which removed the dominant constant-series
   cost.)
 
-- **T-5: NTT multiplication. The largest remaining lever, and it pays at
-  the sizes we already benchmark (re-assessed 20260824).** NTT is the
+- **T-5: NTT multiplication. DONE (20260825).** Built on `BigInt` in
+  `bigint/ntt.mojo`, over the Goldilocks prime `2^64 - 2^32 + 1`, single
+  prime and no CRT. Multiplication at 1M digits (104 200 words) went
+  54.9 → 24.0 ms; `pi(1000000)` went 1189 → 821 ms.
+
+  Two things decided the result, and neither was the transform itself.
+  *The chunk width is a free variable.* Fixing it at 16 bits — one
+  half-word, the obvious choice — leaves the transform length rounding up
+  to a power of two on its own. At 10 400 words a 16-bit cut needs 41 599
+  coefficients and so a transform of 65 536; 25 bits needs 26 623 and fits
+  in 32 768 — the same product in half the transform. Letting the width
+  float (the planner picks 22-26 bits) recovers that 2× wherever the fixed
+  width overshoots.
+  *The dispatch cannot be a word count.* The transform length steps by
+  powers of two while Toom-3 climbs smoothly, so the winner alternates —
+  at a quarter of the slots filled the transform loses at 4 096 words,
+  ties at 8 192 and wins from 16 384 up. Comparing the two fitted cost
+  models predicts every measured crossover; a flat cutoff cannot.
+
+  Also worth recording: `_multiply_magnitudes_slices()` is a second
+  dispatcher, and Burnikel-Ziegler reaches its multiplications only
+  through it. Wiring the transform into `_multiply_magnitudes()` alone
+  left division and base conversion entirely on Toom-3.
+
+  The follow-on is now T-D6, and it is worth far more than it was before
+  this: division was 2.64× multiply and is now 4.9×, because the multiply
+  got cheaper and B-Z's constant did not.
+
+- **T-5 (original assessment, kept for the reasoning). NTT is the
   enabler for T-D3 / T-L3 / T-7b. GMP's own FFT threshold measures at
   ~1 600 limbs (≈32 000 digits) and is worth 3.7× to it at 100 000
   digits — see `internal/internal_notes.md`. That kills the earlier
@@ -1014,7 +1043,8 @@ some ops < 1.0×):
 | T-A2   | 64-bit limb pairs in `BigInt` add/sub      | S      | **DONE** | 0.71 → 0.25 ns/word; mul 1.26×, div 1.22× at 10 400w    |
 | T-A3   | Carry-select single-pass `BigUInt` add/sub | M      | **DONE** | 1.75 → 0.83 ns/word; mul 1.30×, div 1.27×               |
 | T-A4   | Exact divide-by-3 off the carry chain      | S      | **DONE** | 2.50 → 1.13 ns/word; ~2% of a Toom-3 multiply           |
-| T-5    | NTT multiplication                         | XL     | **NEXT** | largest lever: 3.7× of the GMP mul gap is FFT           |
+| T-5    | NTT multiplication                         | XL     | **DONE** | 2.3× mul at 1M digits; pi(1M) 1189 → 821 ms             |
+| T-D6   | Newton reciprocal division                 | L      | **NEXT** | B-Z now 4.9× mul (was 2.6×); ~20% of pi(1M)             |
 | T-9    | deferred-carry schoolbook mul              | M      | **DONE** | deferred-carry (product-scanning);                      |
 |        |                                            |        |          | Definitely worth bringing it to `BigInt` too            |
 | T-3e   | Faster ln constant series                  | L      | **DONE** | exact-reciprocal divide; ln(2) 9–21×,                   |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -210,6 +210,46 @@ larger radix only helps if it avoids the software-emulated 128-bit divide.
 PR4d rejected 10^18 chunks for exactly this reason; re-verify on current
 hardware before trying again.
 
+### multiply — T-M5 (NTT) done (2026-08-25)
+
+**T-M5 — number-theoretic transform. DONE.** `bigint/ntt.mojo`, over the
+Goldilocks prime `2^64 - 2^32 + 1`: one prime, no CRT, and reduction of a
+128-bit product in a shift, a subtract and two conditional fixups. Against the
+Toom-3 path it displaces:
+
+| words   | Toom-3   | NTT      | speedup |
+| ------- | -------- | -------- | ------- |
+| 3 072   | 267 µs   | 244 µs   | 1.09    |
+| 6 144   | 735      | 574      | 1.28    |
+| 10 400  | 1 746    | 1 201    | 1.45    |
+| 20 000  | 4 755    | 2 388    | 1.99    |
+| 65 536  | 25 424   | 11 477   | 2.22    |
+| 104 200 | 54 748   | 24 030   | 2.28    |
+
+Two design points carried most of the win, and neither is the transform.
+
+*The chunk width is a free variable, not 16 bits.* A magnitude is a bit string;
+nothing forces the transform to see it in half-words. Since the transform
+length must be a power of two, a fixed width leaves the rounding-up as pure
+waste — at 10 400 words a 16-bit cut needs 41 599 coefficients and so a
+transform of 65 536, where 25 bits needs 26 623 and fits in 32 768. Letting the
+width float subject to the modulus bound (the planner lands on 22-26 bits)
+recovers that 2× wherever the fixed width overshoots and costs nothing where it
+does not.
+
+*The dispatch cannot be a word count.* The transform's cost steps at powers of
+two while Toom-3's climbs smoothly, so the winner alternates: at a quarter of
+the transform slots filled the transform loses at 4 096 words, ties at 8 192
+and wins from 16 384 up. `should_multiply_ntt()` compares the two fitted cost
+models — `L log2(L)` against `(len_a * len_b)^0.7325` — which predicts every
+measured crossover from 512 to 104 200 words. No flat cutoff can.
+
+One trap worth remembering: `_multiply_magnitudes_slices()` is a *second*
+dispatcher, and Burnikel-Ziegler reaches its multiplications only through it.
+Wiring the transform into `_multiply_magnitudes()` alone left division and
+base conversion entirely on Toom-3, and the division benchmark barely moved
+until both were done.
+
 ### multiply — T-M1 done (2026-08-24)
 
 **T-M1 — Toom-3 multiplication. DONE.** `_multiply_magnitudes_toom3()`,
@@ -427,4 +467,5 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-SH1 | Pre-size the shift result buffer                 | OPEN                                  |
 | T-W1  | Base-2^64 limbs throughout                       | PARTLY — T-M4 does it in the kernel   |
 | T-E1  | `reciprocal_sqrt_fixed_point()` binary recip. sqrt    | DONE 2026-08-24 — enables T-PI4       |
-| T-D4  | Reciprocal-Newton divide                         | DEFERRED — needs NTT, not Toom-3      |
+| T-M5  | NTT multiply over `2^64 - 2^32 + 1`              | DONE 2026-08-25 — 2.3× at 104 200w    |
+| T-D4  | Reciprocal-Newton divide                         | NEXT — NTT landed; B-Z now 4.9× mul   |

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -198,17 +198,17 @@ struct BigDecimal(
         self.sign = False
 
     @implicit
-    def __init__(out self, coefficient: BigUInt):
+    def __init__(out self, var coefficient: BigUInt):
         """Constructs a BigDecimal from a BigUInt object.
 
         Args:
             coefficient: The unsigned integer coefficient.
         """
-        self.coefficient = coefficient.copy()
+        self.coefficient = coefficient^
         self.scale = 0
         self.sign = False
 
-    def __init__(out self, coefficient: BigUInt, scale: Int, sign: Bool):
+    def __init__(out self, var coefficient: BigUInt, scale: Int, sign: Bool):
         """Constructs a BigDecimal from its components.
 
         Args:
@@ -216,7 +216,7 @@ struct BigDecimal(
             scale: The number of decimal places (power of 10 divisor).
             sign: Whether the value is negative.
         """
-        self.coefficient = coefficient.copy()
+        self.coefficient = coefficient^
         self.scale = scale
         self.sign = sign
 
@@ -991,7 +991,7 @@ struct BigDecimal(
             The absolute value.
         """
         return Self(
-            coefficient=self.coefficient,
+            coefficient=self.coefficient.copy(),
             scale=self.scale,
             sign=False,
         )
@@ -1005,7 +1005,7 @@ struct BigDecimal(
             The negated value.
         """
         return Self(
-            coefficient=self.coefficient,
+            coefficient=self.coefficient.copy(),
             scale=self.scale,
             sign=not self.sign,
         )

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -2576,7 +2576,7 @@ struct BigDecimal(
             A copy of this number with the sign taken from `other`.
         """
         return Self(
-            coefficient=self.coefficient,
+            coefficient=self.coefficient.copy(),
             scale=self.scale,
             sign=other.sign,
         )
@@ -2950,7 +2950,7 @@ struct BigDecimal(
             )
 
         return Self(
-            coefficient,
+            coefficient^,
             self.scale - number_of_digits_to_remove,
             self.sign,
         )

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -1786,9 +1786,10 @@ def sqrt_decimal_approach(x: BigDecimal, precision: Int) raises -> BigDecimal:
         value = value * UInt128(10)
     var sqrt_value = decimal128_utility.sqrt(value)
     var sqrt_value_biguint = BigUInt.from_integral_scalar(sqrt_value)
+    var sqrt_value_ndigits = sqrt_value_biguint.number_of_digits()
     guess = BigDecimal(
-        sqrt_value_biguint,
-        sqrt_value_biguint.number_of_digits() - ndigits_int_part_sqrt,
+        sqrt_value_biguint^,
+        sqrt_value_ndigits - ndigits_int_part_sqrt,
         False,
     )
 

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -34,6 +34,7 @@ Algorithms:
 """
 
 from std.bit import count_leading_zeros
+from std.sys import is_little_endian
 from std.memory import unsafe_memcpy, unsafe_memset_zero
 
 from decimo.bigint.bigint import BigInt
@@ -95,6 +96,10 @@ def _add_word_pairs[
     which a comparison recovers without the shift-and-mask the 32-bit form
     needs.
 
+    That identity — `a[2i] + 2^32 * a[2i+1]` being exactly what a 64-bit load
+    at `&a[2i]` returns — holds only on a little-endian target, hence the
+    assertion below. Nothing else here depends on byte order.
+
     The pointers only have to be word-aligned, not limb-aligned: the accesses
     request `alignment=4` explicitly, so `a`, `b` and `r` may each begin at any
     word offset, and at different ones. `r` may alias `a` or `b` exactly.
@@ -109,6 +114,11 @@ def _add_word_pairs[
     Returns:
         The carry out of the highest limb, 0 or 1.
     """
+    comptime assert is_little_endian(), (
+        "_add_word_pairs() reads two UInt32 words as one base-2^64 limb, which"
+        " is only the value they represent on a little-endian target"
+    )
+
     var r64 = rp.unsafe_bitcast[UInt64]()
     var a64 = ap.unsafe_bitcast[UInt64]()
     var b64 = bp.unsafe_bitcast[UInt64]()
@@ -150,6 +160,11 @@ def _subtract_word_pairs[
     Returns:
         The borrow out of the highest limb, 0 or 1.
     """
+    comptime assert is_little_endian(), (
+        "_subtract_word_pairs() reads two UInt32 words as one base-2^64 limb,"
+        " which is only the value they represent on a little-endian target"
+    )
+
     var r64 = rp.unsafe_bitcast[UInt64]()
     var a64 = ap.unsafe_bitcast[UInt64]()
     var b64 = bp.unsafe_bitcast[UInt64]()

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -39,6 +39,7 @@ from std.memory import unsafe_memcpy, unsafe_memset_zero
 
 from decimo.bigint.bigint import BigInt
 from decimo.bigint.comparison import compare_magnitudes
+import decimo.bigint.ntt as bigint_ntt
 from decimo.errors import ValueError, ZeroDivisionError
 
 
@@ -316,8 +317,10 @@ def _subtract_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
 def _multiply_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     """Multiplies two unsigned magnitudes, dispatching to the best algorithm.
 
-    Toom-3 O(n^1.465) above `CUTOFF_TOOM3`, Karatsuba O(n^1.585) above
-    `CUTOFF_KARATSUBA`, product-scanning schoolbook O(n*m) below it. The
+    A number-theoretic transform O(n log n) where its cost model beats Toom-3's
+    (see `ntt.should_multiply_ntt()`), Toom-3 O(n^1.465) above `CUTOFF_TOOM3`,
+    Karatsuba O(n^1.585) above `CUTOFF_KARATSUBA`, product-scanning schoolbook
+    O(n*m) below it. The
     schoolbook base case accumulates in `UInt128` over packed 64-bit limbs,
     or in `UInt64` over 32-bit words when the operands are too small to repay
     the packing - see `_multiply_magnitudes_schoolbook()`.
@@ -355,6 +358,10 @@ def _multiply_magnitudes(a: List[UInt32], b: List[UInt32]) -> List[UInt32]:
     if len_max <= CUTOFF_KARATSUBA:
         return _multiply_magnitudes_schoolbook(a, b)
     elif len_max > CUTOFF_TOOM3:
+        if bigint_ntt.should_multiply_ntt(len_a, len_b):
+            return bigint_ntt.multiply_magnitudes_ntt(
+                ImmSpan[UInt32](a), ImmSpan[UInt32](b)
+            )
         return _multiply_magnitudes_toom3(a, b)
     else:
         return _multiply_magnitudes_karatsuba(a, b)
@@ -1724,6 +1731,11 @@ def _multiply_magnitudes_slices(
 ) -> List[UInt32]:
     """Multiplies two magnitude slices, dispatching to the best algorithm.
 
+    The same ladder as `_multiply_magnitudes()`, over slices rather than owned
+    lists. Burnikel-Ziegler division reaches its multiplications only through
+    here, so leaving the transform out of this one would keep division - and
+    the base conversion built on it - on Toom-3 however large the operands got.
+
     Args:
         a: First magnitude.
         b: Second magnitude.
@@ -1744,6 +1756,8 @@ def _multiply_magnitudes_slices(
     if len_max <= CUTOFF_KARATSUBA:
         return _multiply_magnitudes_schoolbook(a, b)
     if len_max > CUTOFF_TOOM3:
+        if bigint_ntt.should_multiply_ntt(len_a, len_b):
+            return bigint_ntt.multiply_magnitudes_ntt(a, b)
         return _multiply_magnitudes_toom3(a, b)
     return _multiply_magnitudes_karatsuba(a, b)
 

--- a/src/decimo/bigint/ntt.mojo
+++ b/src/decimo/bigint/ntt.mojo
@@ -1,0 +1,596 @@
+"""Number-theoretic transform multiplication for base-2^32 magnitudes.
+
+Multiplying two `n`-word magnitudes is a convolution of their digit sequences,
+and a convolution is a pointwise product under a discrete Fourier transform.
+Toom-3 gets the exponent down to `log_3(5) = 1.465` by evaluating at five
+points; the transform evaluates at `L` points at once and brings the exponent
+down to `n log n`.
+
+The transform runs over the integers modulo the Goldilocks prime
+
+    P = 2^64 - 2^32 + 1
+
+rather than over the complex numbers, so every value is exact and there is no
+error analysis to get wrong: the answer either is the product or is not, and
+the tests decide which. `P - 1 = 2^32 * (2^32 - 1)` is divisible by `2^32`, so
+`P` has primitive roots of unity of every power-of-two order up to `2^32`,
+which is the only property the transform needs. It also sits just under `2^64`,
+so a residue is one machine word and reduction after a multiplication costs a
+shift, a subtract and two conditional fixups rather than a division.
+
+Reduction rests on `2^64 = 2^32 - 1 (mod P)`. Writing a 128-bit product as
+`hi * 2^64 + lo` and `hi` as `h1 * 2^32 + h0`,
+
+    hi * 2^64 + lo = lo - h1 + h0 * (2^32 - 1)   (mod P)
+
+and each of the three terms is already a single word, so `_mod_mul()` finishes
+with one subtract and one add. See `_mod_mul()` for why no term can overflow.
+
+The operands are re-cut before the transform. A base-2^32 magnitude is a bit
+string, and nothing forces the transform to see it in 32-bit pieces: cutting it
+into `chunk_bits`-bit pieces instead trades the number of coefficients against
+how large each convolution coefficient can grow. That freedom is what
+`_plan()` spends, and it is worth up to a factor of two - see there.
+"""
+
+from std.bit import count_leading_zeros
+from std.memory import unsafe_memset_zero
+
+# ===----------------------------------------------------------------------=== #
+# Field arithmetic modulo the Goldilocks prime
+# ===----------------------------------------------------------------------=== #
+
+comptime NTT_PRIME: UInt64 = 0xFFFF_FFFF_0000_0001
+"""The Goldilocks prime `2^64 - 2^32 + 1`."""
+
+comptime _P_COMPLEMENT: UInt64 = 0xFFFF_FFFF
+"""`2^64 - NTT_PRIME`, the amount a wrapped 64-bit sum is short by."""
+
+comptime _NTT_GENERATOR: UInt64 = 7
+"""A primitive root modulo `NTT_PRIME`, so `7^((P-1)/2^k)` has order `2^k`."""
+
+comptime MAX_TRANSFORM_LOG: Int = 32
+"""`P - 1` is divisible by `2^32` and no more, capping the transform length."""
+
+
+@always_inline
+def _mod_add(a: UInt64, b: UInt64) -> UInt64:
+    """Adds two residues already reduced into `[0, P)`.
+
+    A wrapped sum is short by `2^64`, and `2^64 = 2^32 - 1 (mod P)`, so the
+    fixup adds `_P_COMPLEMENT` rather than subtracting `P`. That add cannot
+    itself wrap: the true sum is below `2 * P`, so the wrapped value is below
+    `2 * P - 2^64 = 2^64 - 2^33 + 2`.
+    """
+    var total = a + b
+    if total < a:
+        return total + _P_COMPLEMENT
+    if total >= NTT_PRIME:
+        return total - NTT_PRIME
+    return total
+
+
+@always_inline
+def _mod_sub(a: UInt64, b: UInt64) -> UInt64:
+    """Subtracts two residues already reduced into `[0, P)`."""
+    if a >= b:
+        return a - b
+    return NTT_PRIME - (b - a)
+
+
+@always_inline
+def _mod_mul(a: UInt64, b: UInt64) -> UInt64:
+    """Multiplies two residues already reduced into `[0, P)`.
+
+    With the product written `hi * 2^64 + lo` and `hi = h1 * 2^32 + h0`, the
+    identity `2^64 = 2^32 - 1 (mod P)` gives `lo - h1 + h0 * (2^32 - 1)`. Each
+    term reduces to `[0, P)` on its own before the two additions:
+
+    - `lo` is a full word, so one conditional subtract suffices.
+    - `h1 < 2^32 < P` already.
+    - `h0 * (2^32 - 1)` is written `(h0 << 32) - h0`, which needs no wider
+      arithmetic: `h0 < 2^32` makes the shift exact, and the subtract cannot
+      go negative. Its value is at most `(2^32 - 1)^2 = 2^64 - 2^33 + 1`,
+      which is below `P`, so it is reduced already.
+    """
+    var product = UInt128(a) * UInt128(b)
+    var lo = UInt64(product & 0xFFFF_FFFF_FFFF_FFFF)
+    var hi = UInt64(product >> 64)
+    var h0 = hi & 0xFFFF_FFFF
+    var h1 = hi >> 32
+    var reduced_lo = lo - NTT_PRIME if lo >= NTT_PRIME else lo
+    return _mod_add(_mod_sub(reduced_lo, h1), (h0 << 32) - h0)
+
+
+def _mod_power(base: UInt64, exponent: UInt64) -> UInt64:
+    """Raises `base` to `exponent` modulo `NTT_PRIME`."""
+    var result: UInt64 = 1
+    var current = base
+    var remaining = exponent
+    while remaining > 0:
+        if (remaining & 1) != 0:
+            result = _mod_mul(result, current)
+        current = _mod_mul(current, current)
+        remaining >>= 1
+    return result
+
+
+# ===----------------------------------------------------------------------=== #
+# Choosing the transform length and the chunk width
+# ===----------------------------------------------------------------------=== #
+
+
+@fieldwise_init
+struct _TransformPlan(Copyable, Movable):
+    """How one product will be cut up and transformed."""
+
+    var chunk_bits: Int
+    """Width in bits of each transform coefficient taken from the operands."""
+    var coefficients_a: Int
+    """Number of coefficients the first operand occupies."""
+    var coefficients_b: Int
+    """Number of coefficients the second operand occupies."""
+    var log_length: Int
+    """Base-two logarithm of the transform length."""
+    var length: Int
+    """The transform length, a power of two."""
+
+
+def _plan(bits_a: Int, bits_b: Int) -> _TransformPlan:
+    """Chooses the cheapest chunk width and transform length for one product.
+
+    The transform costs `L log L` for a length `L` that must be a power of two,
+    so the whole game is to make `L` small. Cutting the operands into
+    `chunk_bits`-bit coefficients pulls in two directions:
+
+    - Wider chunks mean fewer coefficients, so a shorter transform.
+    - Wider chunks mean larger coefficients. A convolution coefficient is a sum
+      of at most `min(coefficients_a, coefficients_b)` products of two chunks,
+      and it must stay below `P` or the answer wraps and is silently wrong.
+
+    Fixing the chunk width at 16 bits - one half-word, the obvious choice -
+    leaves the transform length rounding up to a power of two on its own, and
+    the rounding is pure waste. At 10 400 words a 16-bit cut needs 41 599
+    coefficients and so a transform of 65 536, where 25 bits needs 26 623 and
+    fits in 32 768: the same product, half the transform. Letting the width
+    float lands the coefficient count just under a power of two instead, which
+    is worth a factor of two whenever the fixed width overshoots and nothing
+    when it does not.
+
+    The search runs the width up while the magnitude bound holds. That bound
+    fails monotonically - the coefficient count falls like `1/chunk_bits` while
+    the square of a chunk grows like `4^chunk_bits` - so the first failure ends
+    it.
+
+    Args:
+        bits_a: Bit length of the first operand, rounded up to whole words.
+        bits_b: Bit length of the second operand, rounded up to whole words.
+
+    Returns:
+        The plan to hand to `_multiply_planned()`.
+    """
+    var best_bits = 1
+    var best_a = bits_a
+    var best_b = bits_b
+
+    for chunk_bits in range(1, 33):
+        var count_a = (bits_a + chunk_bits - 1) // chunk_bits
+        var count_b = (bits_b + chunk_bits - 1) // chunk_bits
+        var terms = UInt128(min(count_a, count_b))
+        var chunk_max = UInt128((UInt64(1) << UInt64(chunk_bits)) - 1)
+        if terms * chunk_max * chunk_max >= UInt128(NTT_PRIME):
+            break
+        best_bits = chunk_bits
+        best_a = count_a
+        best_b = count_b
+
+    var needed = best_a + best_b - 1
+    var log_length = 0
+    while (1 << log_length) < needed:
+        log_length += 1
+
+    return _TransformPlan(
+        best_bits, best_a, best_b, log_length, 1 << log_length
+    )
+
+
+# ===----------------------------------------------------------------------=== #
+# Twiddle tables
+# ===----------------------------------------------------------------------=== #
+
+
+def _build_twiddles(
+    log_length: Int, mut forward: List[UInt64], mut inverse: List[UInt64]
+):
+    """Fills the per-level twiddle tables for a transform of `2^log_length`.
+
+    Both transforms walk one level at a time, and within a level the twiddle
+    index advances by one per butterfly. Storing each level's twiddles
+    contiguously therefore turns what would be a strided gather into a linear
+    scan. The levels have sizes `L/2, L/4, ..., 1`, so the concatenation fits
+    in `L` entries with one to spare.
+
+    Only the top-level powers `w^k` are chained; every lower level is a stride
+    subsample of that one, because `w_(L/2)^j = w_L^(2j)`. Chaining each level
+    separately would multiply the serial dependency, and the chain is the one
+    part of the build that cannot be overlapped.
+
+    Args:
+        log_length: Base-two logarithm of the transform length.
+        forward: Destination for the decimation-in-frequency twiddles.
+        inverse: Destination for the decimation-in-time twiddles.
+    """
+    var length = 1 << log_length
+    var half = length >> 1
+    var root = _mod_power(_NTT_GENERATOR, (NTT_PRIME - 1) >> UInt64(log_length))
+
+    # `root^k` for `k < half`, generated in blocks rather than as one chain.
+    # Chaining every power makes the build latency-bound on `_mod_mul()` for
+    # `half` steps in a row; splitting it into blocks of about `sqrt(half)`
+    # leaves only `sqrt(half)` steps on the chain and makes the rest - one
+    # independent multiply per entry - throughput-bound instead.
+    var powers = List[UInt64](capacity=half if half > 0 else 1)
+    powers.resize(unsafe_uninit_length=half if half > 0 else 1)
+    var power_scratch = powers.unsafe_ptr()
+    if half > 0:
+        var block = 1
+        while block * block < half:
+            block <<= 1
+
+        var current: UInt64 = 1
+        var head = min(block, half)
+        for j in range(head):
+            power_scratch[unsafe_offset=j] = current
+            current = _mod_mul(current, root)
+
+        var step = current  # root^block
+        var start = step
+        var base = block
+        while base < half:
+            var count = min(block, half - base)
+            for j in range(count):
+                power_scratch[unsafe_offset=base + j] = _mod_mul(
+                    start, power_scratch[unsafe_offset=j]
+                )
+            start = _mod_mul(start, step)
+            base += block
+
+    forward.resize(unsafe_uninit_length=length)
+    inverse.resize(unsafe_uninit_length=length)
+    var power_ptr = powers.unsafe_ptr()
+    var forward_ptr = forward.unsafe_ptr()
+    var inverse_ptr = inverse.unsafe_ptr()
+
+    # Forward level `l` halves a block of `length >> l`, so its twiddles are
+    # `w^(j << l)` and there are `length >> (l + 1)` of them. The levels before
+    # it have used `length - (length >> l)` entries.
+    for level in range(log_length):
+        var offset = length - (length >> level)
+        var count = length >> (level + 1)
+        for j in range(count):
+            forward_ptr[unsafe_offset=offset + j] = power_ptr[
+                unsafe_offset=j << level
+            ]
+
+    # Inverse level `l` joins blocks of `2 << l`, so its twiddles are the
+    # conjugates `w^(-(j << (log_length - 1 - l)))` and there are `1 << l` of
+    # them. `w^(-k) = w^(L - k) = -w^(L/2 - k)`, which is where the negation
+    # comes from; the table of positive powers is the only one stored.
+    for level in range(log_length):
+        var offset = (1 << level) - 1
+        var count = 1 << level
+        var shift = log_length - 1 - level
+        for j in range(count):
+            var k = j << shift
+            if k == 0:
+                inverse_ptr[unsafe_offset=offset + j] = UInt64(1)
+            else:
+                inverse_ptr[unsafe_offset=offset + j] = (
+                    NTT_PRIME - power_ptr[unsafe_offset=half - k]
+                )
+
+
+# ===----------------------------------------------------------------------=== #
+# The transforms
+# ===----------------------------------------------------------------------=== #
+
+
+def _transform_forward[
+    o: Origin[mut=True]
+](
+    values: Pointer[UInt64, o],
+    length: Int,
+    log_length: Int,
+    twiddles: Pointer[UInt64, _],
+):
+    """Decimation-in-frequency transform: natural order in, bit-reversed out.
+
+    Pairing this with a decimation-in-time inverse is what lets both skip the
+    bit-reversal permutation entirely - the pointwise product in the middle
+    does not care what order the points are in, as long as both operands agree.
+
+    The last level is peeled off because its only twiddle is `1`, and a
+    multiplication by one over `length / 2` butterflies is not free.
+    """
+    var block = length
+    var level = 0
+    while block > 2:
+        var half = block >> 1
+        var offset = length - (length >> level)
+        var start = 0
+        while start < length:
+            for j in range(half):
+                var low = values[unsafe_offset=start + j]
+                var high = values[unsafe_offset=start + j + half]
+                values[unsafe_offset=start + j] = _mod_add(low, high)
+                values[unsafe_offset=start + j + half] = _mod_mul(
+                    _mod_sub(low, high), twiddles[unsafe_offset=offset + j]
+                )
+            start += block
+        block = half
+        level += 1
+
+    if length >= 2:
+        var start = 0
+        while start < length:
+            var low = values[unsafe_offset=start]
+            var high = values[unsafe_offset=start + 1]
+            values[unsafe_offset=start] = _mod_add(low, high)
+            values[unsafe_offset=start + 1] = _mod_sub(low, high)
+            start += 2
+
+
+def _transform_inverse[
+    o: Origin[mut=True]
+](
+    values: Pointer[UInt64, o],
+    length: Int,
+    log_length: Int,
+    twiddles: Pointer[UInt64, _],
+):
+    """Decimation-in-time transform: bit-reversed order in, natural out.
+
+    Undoes `_transform_forward()` up to the factor of `length` that a
+    forward-then-inverse pair leaves behind, which the final scaling removes.
+    The first level is peeled off for the same reason the forward transform
+    peels its last: the twiddle there is `1`.
+    """
+    if length >= 2:
+        var start = 0
+        while start < length:
+            var low = values[unsafe_offset=start]
+            var high = values[unsafe_offset=start + 1]
+            values[unsafe_offset=start] = _mod_add(low, high)
+            values[unsafe_offset=start + 1] = _mod_sub(low, high)
+            start += 2
+
+    var block = 4
+    var level = 1
+    while block <= length:
+        var half = block >> 1
+        var offset = (1 << level) - 1
+        var start = 0
+        while start < length:
+            for j in range(half):
+                var low = values[unsafe_offset=start + j]
+                var high = _mod_mul(
+                    values[unsafe_offset=start + j + half],
+                    twiddles[unsafe_offset=offset + j],
+                )
+                values[unsafe_offset=start + j] = _mod_add(low, high)
+                values[unsafe_offset=start + j + half] = _mod_sub(low, high)
+            start += block
+        block <<= 1
+        level += 1
+
+    var scale = _mod_power(UInt64(length) % NTT_PRIME, NTT_PRIME - 2)
+    for k in range(length):
+        values[unsafe_offset=k] = _mod_mul(values[unsafe_offset=k], scale)
+
+
+# ===----------------------------------------------------------------------=== #
+# Packing magnitudes into coefficients and back
+# ===----------------------------------------------------------------------=== #
+
+
+def _pack[
+    o: Origin[mut=True]
+](
+    destination: Pointer[UInt64, o],
+    words: ImmSpan[UInt32, _],
+    count: Int,
+    chunk_bits: Int,
+):
+    """Cuts `words` into `count` chunks of `chunk_bits` bits each, LSB first.
+
+    A chunk starts at an arbitrary bit offset, so the read takes the two words
+    straddling it as one 64-bit value and shifts. That needs
+    `chunk_bits + 31 <= 64`, which holds because `_plan()` never returns a
+    width above 32.
+    """
+    var word_count = len(words)
+    var source = words.unsafe_ptr()
+    var mask = (UInt64(1) << UInt64(chunk_bits)) - 1
+    for i in range(count):
+        var bit = i * chunk_bits
+        var index = bit >> 5
+        var shift = UInt64(bit & 31)
+        var low = UInt64(
+            source[unsafe_offset=index]
+        ) if index < word_count else UInt64(0)
+        var high = UInt64(
+            source[unsafe_offset=index + 1]
+        ) if index + 1 < word_count else UInt64(0)
+        destination[unsafe_offset=i] = ((low | (high << 32)) >> shift) & mask
+
+
+def _unpack(
+    coefficients: Pointer[UInt64, _],
+    count: Int,
+    chunk_bits: Int,
+    word_count: Int,
+) -> List[UInt32]:
+    """Reassembles `sum(coefficients[k] * 2^(k * chunk_bits))` into words.
+
+    The coefficients overlap once `chunk_bits` is not a multiple of 32, and
+    each is far wider than its own chunk - it is a sum of products, not a
+    chunk - so this is a carry propagation rather than a concatenation. A
+    128-bit accumulator holds the words still being written into: the
+    coefficients landing in one output word number about `32 / chunk_bits`,
+    each below `2^62` and shifted by at most 31, which leaves the accumulator
+    far short of overflowing.
+    """
+    var result = List[UInt32](capacity=word_count)
+    result.resize(unsafe_uninit_length=word_count)
+    var destination = result.unsafe_ptr()
+
+    var accumulator = UInt128(0)
+    var next_word = 0
+    for k in range(count):
+        var bit = k * chunk_bits
+        var index = bit >> 5
+        var shift = bit & 31
+        while next_word < index and next_word < word_count:
+            destination[unsafe_offset=next_word] = UInt32(
+                accumulator & 0xFFFF_FFFF
+            )
+            accumulator >>= 32
+            next_word += 1
+        if next_word >= word_count:
+            break
+        accumulator += UInt128(coefficients[unsafe_offset=k]) << UInt128(shift)
+
+    while next_word < word_count:
+        destination[unsafe_offset=next_word] = UInt32(accumulator & 0xFFFF_FFFF)
+        accumulator >>= 32
+        next_word += 1
+
+    var length = word_count
+    while length > 1 and result[length - 1] == 0:
+        length -= 1
+    while len(result) > length:
+        result.shrink(len(result) - 1)
+    return result^
+
+
+# ===----------------------------------------------------------------------=== #
+# Entry point
+# ===----------------------------------------------------------------------=== #
+
+
+def _bit_length(words: ImmSpan[UInt32, _]) -> Int:
+    """Returns the bit length of a magnitude, or zero for a zero magnitude."""
+    var top = len(words)
+    while top > 0 and words[top - 1] == 0:
+        top -= 1
+    if top == 0:
+        return 0
+    return top * 32 - Int(count_leading_zeros(words[top - 1]))
+
+
+comptime CUTOFF_NTT: Int = 1024
+"""Below this many words the transform is never considered.
+
+A floor, not the crossover: `should_multiply_ntt()` decides the crossover from
+the cost models, and it never chooses the transform anywhere near here. This
+only keeps the planning arithmetic off the path of the small multiplications
+that dominate the recursion of every other algorithm.
+"""
+
+comptime _NTT_RELATIVE_COST: Float64 = 1.10
+"""Cost of one `L * log2(L)` transform step against one `n^1.465` Toom-3 step.
+
+Both algorithms were fitted over 512 to 104 200 words on Apple Silicon arm64.
+The transform came out at 2.3-2.5e-3 microseconds per `L * log2(L)` and Toom-3
+at 1.8-2.4e-3 per `n^1.465`, so their ratio sits between 1.0 and 1.25 with no
+trend in size - which is what makes a single constant the right shape for this.
+The value is the upper end of that band rather than the middle, so that a tie
+goes to Toom-3, which allocates far less. Adjust if benchmarking on another
+target shows a better value.
+"""
+
+
+def should_multiply_ntt(len_a: Int, len_b: Int) -> Bool:
+    """Reports whether the transform is the cheaper way to form this product.
+
+    A flat word count cannot answer this. The transform length has to be a
+    power of two, so its cost climbs in steps while Toom-3's climbs smoothly,
+    and the winner alternates: at a quarter of the transform slots filled the
+    transform loses at 4 096 words, ties at 8 192 and wins from 16 384 up. What
+    settles it is comparing the two cost models directly.
+
+    Toom-3's `n^1.465` is written over the operand area so that it still means
+    something when the operands differ in size - `(len_a * len_b)^0.7325` is
+    exactly `n^1.465` when they do not.
+
+    Args:
+        len_a: Word count of the first operand.
+        len_b: Word count of the second operand.
+
+    Returns:
+        True if the transform should be used.
+    """
+    if len_a < CUTOFF_NTT or len_b < CUTOFF_NTT:
+        return False
+
+    var plan = _plan(len_a * 32, len_b * 32)
+    if plan.log_length > MAX_TRANSFORM_LOG:
+        return False
+
+    var transform_cost = (
+        Float64(plan.length) * Float64(plan.log_length) * _NTT_RELATIVE_COST
+    )
+    var toom3_cost = (Float64(len_a) * Float64(len_b)) ** 0.7325
+    return transform_cost < toom3_cost
+
+
+def multiply_magnitudes_ntt(
+    a: ImmSpan[UInt32, _], b: ImmSpan[UInt32, _]
+) -> List[UInt32]:
+    """Multiplies two magnitudes through a number-theoretic transform.
+
+    The caller guarantees both operands are non-empty, non-zero and small
+    enough for `can_multiply()`.
+
+    Args:
+        a: First magnitude (little-endian UInt32 words).
+        b: Second magnitude (little-endian UInt32 words).
+
+    Returns:
+        The product magnitude as a new word list.
+    """
+    var plan = _plan(_bit_length(a), _bit_length(b))
+    var length = plan.length
+
+    var forward_twiddles = List[UInt64]()
+    var inverse_twiddles = List[UInt64]()
+    _build_twiddles(plan.log_length, forward_twiddles, inverse_twiddles)
+
+    var left = List[UInt64](capacity=length)
+    left.resize(unsafe_uninit_length=length)
+    var right = List[UInt64](capacity=length)
+    right.resize(unsafe_uninit_length=length)
+    var left_ptr = left.unsafe_ptr()
+    var right_ptr = right.unsafe_ptr()
+
+    unsafe_memset_zero(ptr=left_ptr, count=length)
+    unsafe_memset_zero(ptr=right_ptr, count=length)
+    _pack(left_ptr, a, plan.coefficients_a, plan.chunk_bits)
+    _pack(right_ptr, b, plan.coefficients_b, plan.chunk_bits)
+
+    var forward_ptr = forward_twiddles.unsafe_ptr()
+    var inverse_ptr = inverse_twiddles.unsafe_ptr()
+    _transform_forward(left_ptr, length, plan.log_length, forward_ptr)
+    _transform_forward(right_ptr, length, plan.log_length, forward_ptr)
+    for i in range(length):
+        left_ptr[unsafe_offset=i] = _mod_mul(
+            left_ptr[unsafe_offset=i], right_ptr[unsafe_offset=i]
+        )
+    _transform_inverse(left_ptr, length, plan.log_length, inverse_ptr)
+
+    return _unpack(
+        left_ptr,
+        plan.coefficients_a + plan.coefficients_b - 1,
+        plan.chunk_bits,
+        len(a) + len(b),
+    )

--- a/src/decimo/bigint/ntt.mojo
+++ b/src/decimo/bigint/ntt.mojo
@@ -549,8 +549,11 @@ def multiply_magnitudes_ntt(
 ) -> List[UInt32]:
     """Multiplies two magnitudes through a number-theoretic transform.
 
-    The caller guarantees both operands are non-empty, non-zero and small
-    enough for `can_multiply()`.
+    The caller guarantees both operands are non-empty and non-zero.
+    `should_multiply_ntt()` answers whether this is the cheaper way to form a
+    given product, and rejects any size whose transform length would exceed
+    `MAX_TRANSFORM_LOG`; correctness here does not depend on going through it,
+    only cost does.
 
     Args:
         a: First magnitude (little-endian UInt32 words).

--- a/tests/bigint/test_bigint_ntt.mojo
+++ b/tests/bigint/test_bigint_ntt.mojo
@@ -1,0 +1,366 @@
+"""
+Test the number-theoretic transform multiplication: field arithmetic, the
+transform round trip, and agreement with the Toom-3 path it replaces.
+"""
+
+from std import testing
+from decimo.bigint.bigint import BigInt
+import decimo.bigint.arithmetics as bigint_arithmetics
+import decimo.bigint.ntt as bigint_ntt
+
+
+# ===----------------------------------------------------------------------=== #
+# Helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def _pseudo_random_words(count: Int, seed: UInt64) -> List[UInt32]:
+    """Builds `count` words from a linear congruential generator.
+
+    The top word is forced non-zero so that the operand really is `count`
+    words long, which is what the size-dependent dispatch keys on.
+    """
+    var state = seed | 1
+    var words = List[UInt32](capacity=count)
+    for _ in range(count):
+        state = state * 6364136223846793005 + 1442695040888963407
+        words.append(UInt32(state >> 32))
+    words[count - 1] |= UInt32(1) << 31
+    return words^
+
+
+def _assert_matches_reference(
+    len_a: Int, len_b: Int, seed: UInt64, top_bits: Int
+) raises:
+    """Checks the transform against `_multiply_magnitudes()` on one product.
+
+    Toom-3 and schoolbook are the reference: they are covered by their own
+    tests and by every arithmetic test in the suite, so agreement with them is
+    a strong check with no second implementation to maintain here.
+
+    Args:
+        len_a: Word count of the first operand.
+        len_b: Word count of the second operand.
+        seed: Seed for the operand generator.
+        top_bits: When in `1..31`, shortens the first operand's top word to
+            this many bits, so that bit lengths are not all multiples of 32.
+            The chunk width the planner picks depends on the bit length, not
+            the word count.
+    """
+    var words_a = _pseudo_random_words(len_a, seed)
+    var words_b = _pseudo_random_words(len_b, seed ^ 0xFFFF_FFFF_FFFF_FFFF)
+    if top_bits > 0 and top_bits < 32:
+        words_a[len_a - 1] = UInt32(1) << UInt32(top_bits - 1)
+
+    var expected = bigint_arithmetics.multiply(
+        BigInt(raw_words=words_a.copy(), sign=False),
+        BigInt(raw_words=words_b.copy(), sign=False),
+    )
+    var actual = bigint_ntt.multiply_magnitudes_ntt(
+        ImmSpan[UInt32](words_a), ImmSpan[UInt32](words_b)
+    )
+
+    var expected_length = len(expected.words)
+    while expected_length > 1 and expected.words[expected_length - 1] == 0:
+        expected_length -= 1
+
+    var label = " for len_a=" + String(len_a) + ", len_b=" + String(len_b)
+    testing.assert_equal(
+        len(actual),
+        expected_length,
+        "transform product has the wrong word count" + label,
+    )
+    for i in range(expected_length):
+        testing.assert_equal(
+            actual[i],
+            expected.words[i],
+            "transform product differs at word " + String(i) + label,
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Test: field arithmetic
+# ===----------------------------------------------------------------------=== #
+
+
+def test_ntt_prime_supports_the_transform() raises:
+    """`P - 1` is divisible by `2^32`, which is what gives the roots of unity.
+    """
+    testing.assert_equal(
+        bigint_ntt.NTT_PRIME - 1,
+        (UInt64(1) << 32) * ((UInt64(1) << 32) - 1),
+        "P - 1 should be 2^32 * (2^32 - 1)",
+    )
+
+
+def test_ntt_generator_is_primitive() raises:
+    """`7` generates the whole multiplicative group modulo `P`.
+
+    A generator is exactly an element whose order is not a proper divisor of
+    `P - 1`, so it suffices to check `7^((P-1)/q) != 1` at every prime `q`
+    dividing `P - 1 = 2^32 * 3 * 5 * 17 * 257 * 65537`. Without this the
+    transform would still run, but on a root of unity of too small an order,
+    and would silently wrap for long inputs.
+    """
+    var prime_factors = [
+        UInt64(2),
+        UInt64(3),
+        UInt64(5),
+        UInt64(17),
+        UInt64(257),
+        UInt64(65537),
+    ]
+    var modulus = bigint_ntt.NTT_PRIME
+    for i in range(len(prime_factors)):
+        var power = bigint_ntt._mod_power(
+            UInt64(7), (modulus - 1) // prime_factors[i]
+        )
+        testing.assert_not_equal(
+            power,
+            UInt64(1),
+            "7 is not a primitive root: order divides (P-1)/"
+            + String(prime_factors[i]),
+        )
+    testing.assert_equal(
+        bigint_ntt._mod_power(UInt64(7), modulus - 1),
+        UInt64(1),
+        "Fermat: 7^(P-1) should be 1",
+    )
+
+
+def test_ntt_modular_multiplication_reduces() raises:
+    """Every product lands in `[0, P)` and matches a 128-bit reference."""
+    var modulus = bigint_ntt.NTT_PRIME
+    var samples = [
+        UInt64(0),
+        UInt64(1),
+        UInt64(2),
+        UInt64(0xFFFF_FFFF),
+        UInt64(1) << 32,
+        UInt64(0xDEAD_BEEF_1234_5678),
+        modulus - 1,
+        modulus - 2,
+    ]
+    for i in range(len(samples)):
+        for j in range(len(samples)):
+            var a = samples[i] % modulus
+            var b = samples[j] % modulus
+            var expected = UInt64((UInt128(a) * UInt128(b)) % UInt128(modulus))
+            var actual = bigint_ntt._mod_mul(a, b)
+            testing.assert_equal(
+                actual,
+                expected,
+                "mod_mul is wrong at i=" + String(i) + ", j=" + String(j),
+            )
+
+
+# ===----------------------------------------------------------------------=== #
+# Test: the planner
+# ===----------------------------------------------------------------------=== #
+
+
+def test_ntt_plan_never_overflows_the_modulus() raises:
+    """The planned chunk width keeps every convolution coefficient below `P`.
+
+    This is the one bound that cannot be caught by spot-checking products: a
+    plan that is one bit too wide only wraps on operands whose chunks happen to
+    be near the top of their range, which random tests miss most of the time.
+    Checking the bound itself covers every operand at that size.
+    """
+    var word_counts = [
+        1,
+        2,
+        7,
+        63,
+        64,
+        255,
+        1000,
+        1024,
+        4096,
+        10400,
+        65536,
+        104200,
+        1000000,
+    ]
+    for i in range(len(word_counts)):
+        var bits = word_counts[i] * 32
+        var plan = bigint_ntt._plan(bits, bits)
+        var terms = UInt128(min(plan.coefficients_a, plan.coefficients_b))
+        var chunk_max = UInt128((UInt64(1) << UInt64(plan.chunk_bits)) - 1)
+        testing.assert_true(
+            terms * chunk_max * chunk_max < UInt128(bigint_ntt.NTT_PRIME),
+            "plan overflows the modulus at "
+            + String(word_counts[i])
+            + " words",
+        )
+        testing.assert_true(
+            plan.coefficients_a + plan.coefficients_b - 1 <= plan.length,
+            "transform is too short at " + String(word_counts[i]) + " words",
+        )
+        testing.assert_true(
+            plan.chunk_bits * plan.coefficients_a >= bits,
+            "chunks do not cover the operand at "
+            + String(word_counts[i])
+            + " words",
+        )
+
+
+def test_ntt_dispatch_prefers_toom3_when_small() raises:
+    """The transform is never chosen where Toom-3 is known to be faster."""
+    testing.assert_false(
+        bigint_ntt.should_multiply_ntt(1, 1), "1 word should not use the NTT"
+    )
+    testing.assert_false(
+        bigint_ntt.should_multiply_ntt(768, 768),
+        "the Toom-3 cutoff should not use the NTT",
+    )
+    testing.assert_false(
+        bigint_ntt.should_multiply_ntt(2048, 2048),
+        "2048 words should not use the NTT",
+    )
+    testing.assert_true(
+        bigint_ntt.should_multiply_ntt(65536, 65536),
+        "65536 words should use the NTT",
+    )
+
+
+# ===----------------------------------------------------------------------=== #
+# Test: products
+# ===----------------------------------------------------------------------=== #
+
+
+def test_ntt_matches_reference_on_small_sizes() raises:
+    """Every word-count pair up to 24 x 24, so no edge case hides in a corner.
+
+    Small operands never reach the transform through the dispatcher, but they
+    exercise the shortest transforms, where an off-by-one in the level indexing
+    or the twiddle offsets shows up immediately.
+    """
+    for len_a in range(1, 25):
+        for len_b in range(1, 25):
+            _assert_matches_reference(
+                len_a, len_b, UInt64(len_a * 1000 + len_b), (len_a * 7) % 33
+            )
+
+
+def test_ntt_matches_reference_around_power_of_two_boundaries() raises:
+    """Sizes that straddle a transform-length step and a chunk-width change.
+
+    The planner's choice changes discontinuously at these sizes, so a product
+    just below and just above each one exercises both branches.
+    """
+    var word_counts = [
+        63,
+        64,
+        65,
+        255,
+        256,
+        257,
+        511,
+        512,
+        513,
+        1023,
+        1024,
+        1025,
+        2047,
+        2048,
+        2049,
+        4095,
+        4096,
+        4097,
+    ]
+    for i in range(len(word_counts)):
+        _assert_matches_reference(
+            word_counts[i], word_counts[i], UInt64(i * 977 + 1), (i * 5) % 33
+        )
+
+
+def test_ntt_matches_reference_on_unbalanced_operands() raises:
+    """One long operand against a short one, in both orders."""
+    var pairs_long = [4096, 3000, 1024, 5000]
+    var pairs_short = [3, 64, 999, 1]
+    for i in range(len(pairs_long)):
+        _assert_matches_reference(
+            pairs_long[i], pairs_short[i], UInt64(i * 13 + 7), (i * 11) % 33
+        )
+        _assert_matches_reference(
+            pairs_short[i], pairs_long[i], UInt64(i * 13 + 7), (i * 11) % 33
+        )
+
+
+def test_ntt_matches_reference_on_extreme_words() raises:
+    """All-ones and single-bit operands, where the chunk bound is tightest.
+
+    Random words average half the chunk range; all-ones operands sit at the top
+    of it, which is where a chunk width one bit too wide would wrap.
+    """
+
+    def _all_ones(count: Int) -> List[UInt32]:
+        var words = List[UInt32](capacity=count)
+        for _ in range(count):
+            words.append(UInt32(0xFFFF_FFFF))
+        return words^
+
+    var word_counts = [1, 2, 17, 64, 1024, 2048, 4096]
+    for i in range(len(word_counts)):
+        var count = word_counts[i]
+        var ones = _all_ones(count)
+        var expected = bigint_arithmetics.multiply(
+            BigInt(raw_words=ones.copy(), sign=False),
+            BigInt(raw_words=ones.copy(), sign=False),
+        )
+        var actual = bigint_ntt.multiply_magnitudes_ntt(
+            ImmSpan[UInt32](ones), ImmSpan[UInt32](ones)
+        )
+        var expected_length = len(expected.words)
+        while expected_length > 1 and expected.words[expected_length - 1] == 0:
+            expected_length -= 1
+        testing.assert_equal(
+            len(actual),
+            expected_length,
+            "all-ones square has the wrong length at "
+            + String(count)
+            + " words",
+        )
+        for k in range(expected_length):
+            testing.assert_equal(
+                actual[k],
+                expected.words[k],
+                "all-ones square differs at word "
+                + String(k)
+                + " of "
+                + String(count),
+            )
+
+
+def test_ntt_matches_reference_above_the_dispatch_cutoff() raises:
+    """Sizes the dispatcher actually routes through the transform."""
+    var word_counts = [5000, 8192, 10400]
+    for i in range(len(word_counts)):
+        _assert_matches_reference(
+            word_counts[i],
+            word_counts[i],
+            UInt64(i * 6151 + 3),
+            (i * 9 + 1) % 33,
+        )
+
+
+def test_ntt_product_round_trips_through_division() raises:
+    """`(a * b) / b == a` for operands routed through the transform.
+
+    An independent check on the transform that does not lean on the Toom-3
+    path at all: division is implemented by a different algorithm entirely, so
+    a shared bug would have to be present in both.
+    """
+    var words_a = _pseudo_random_words(6000, 0xABCD_1234_5678_9ABC)
+    var words_b = _pseudo_random_words(5000, 0x1357_9BDF_2468_ACE0)
+    var a = BigInt(raw_words=words_a^, sign=False)
+    var b = BigInt(raw_words=words_b^, sign=False)
+
+    var product = bigint_arithmetics.multiply(a, b)
+    var quotient = bigint_arithmetics.truncate_divide(product, b)
+    testing.assert_equal(String(quotient), String(a), "(a * b) / b should be a")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigint/test_bigint_ntt.mojo
+++ b/tests/bigint/test_bigint_ntt.mojo
@@ -32,11 +32,18 @@ def _pseudo_random_words(count: Int, seed: UInt64) -> List[UInt32]:
 def _assert_matches_reference(
     len_a: Int, len_b: Int, seed: UInt64, top_bits: Int
 ) raises:
-    """Checks the transform against `_multiply_magnitudes()` on one product.
+    """Checks the transform against the schoolbook path on one product.
 
-    Toom-3 and schoolbook are the reference: they are covered by their own
-    tests and by every arithmetic test in the suite, so agreement with them is
-    a strong check with no second implementation to maintain here.
+    The reference is `_multiply_magnitudes_schoolbook()` specifically, and not
+    the `multiply()` dispatcher, because `multiply()` now routes large operands
+    to the transform itself — comparing against it would compare the transform
+    with itself and pass no matter what. Schoolbook is the only multiplication
+    in the module that neither recurses nor dispatches, so it stays independent
+    however the cutoffs move. It is covered by its own tests and by every
+    arithmetic test in the suite.
+
+    It is O(n*m), which at the sizes here costs a few milliseconds. That is the
+    price of an independent reference and it is worth paying.
 
     Args:
         len_a: Word count of the first operand.
@@ -52,16 +59,15 @@ def _assert_matches_reference(
     if top_bits > 0 and top_bits < 32:
         words_a[len_a - 1] = UInt32(1) << UInt32(top_bits - 1)
 
-    var expected = bigint_arithmetics.multiply(
-        BigInt(raw_words=words_a.copy(), sign=False),
-        BigInt(raw_words=words_b.copy(), sign=False),
+    var expected = bigint_arithmetics._multiply_magnitudes_schoolbook(
+        ImmSpan[UInt32](words_a), ImmSpan[UInt32](words_b)
     )
     var actual = bigint_ntt.multiply_magnitudes_ntt(
         ImmSpan[UInt32](words_a), ImmSpan[UInt32](words_b)
     )
 
-    var expected_length = len(expected.words)
-    while expected_length > 1 and expected.words[expected_length - 1] == 0:
+    var expected_length = len(expected)
+    while expected_length > 1 and expected[expected_length - 1] == 0:
         expected_length -= 1
 
     var label = " for len_a=" + String(len_a) + ", len_b=" + String(len_b)
@@ -73,7 +79,7 @@ def _assert_matches_reference(
     for i in range(expected_length):
         testing.assert_equal(
             actual[i],
-            expected.words[i],
+            expected[i],
             "transform product differs at word " + String(i) + label,
         )
 
@@ -305,15 +311,14 @@ def test_ntt_matches_reference_on_extreme_words() raises:
     for i in range(len(word_counts)):
         var count = word_counts[i]
         var ones = _all_ones(count)
-        var expected = bigint_arithmetics.multiply(
-            BigInt(raw_words=ones.copy(), sign=False),
-            BigInt(raw_words=ones.copy(), sign=False),
+        var expected = bigint_arithmetics._multiply_magnitudes_schoolbook(
+            ImmSpan[UInt32](ones), ImmSpan[UInt32](ones)
         )
         var actual = bigint_ntt.multiply_magnitudes_ntt(
             ImmSpan[UInt32](ones), ImmSpan[UInt32](ones)
         )
-        var expected_length = len(expected.words)
-        while expected_length > 1 and expected.words[expected_length - 1] == 0:
+        var expected_length = len(expected)
+        while expected_length > 1 and expected[expected_length - 1] == 0:
             expected_length -= 1
         testing.assert_equal(
             len(actual),
@@ -325,7 +330,7 @@ def test_ntt_matches_reference_on_extreme_words() raises:
         for k in range(expected_length):
             testing.assert_equal(
                 actual[k],
-                expected.words[k],
+                expected[k],
                 "all-ones square differs at word "
                 + String(k)
                 + " of "
@@ -334,14 +339,24 @@ def test_ntt_matches_reference_on_extreme_words() raises:
 
 
 def test_ntt_matches_reference_above_the_dispatch_cutoff() raises:
-    """Sizes the dispatcher actually routes through the transform."""
+    """Sizes the dispatcher actually routes through the transform.
+
+    The assertion on `should_multiply_ntt()` is the point of the test rather
+    than a precondition: without it, a later change to the cutoffs could move
+    these sizes back onto Toom-3 and leave the whole file testing a path that
+    production never takes, silently and with everything still green.
+    """
     var word_counts = [5000, 8192, 10400]
     for i in range(len(word_counts)):
+        var count = word_counts[i]
+        testing.assert_true(
+            bigint_ntt.should_multiply_ntt(count, count),
+            "the dispatcher no longer routes "
+            + String(count)
+            + " words through the transform, so this test covers nothing",
+        )
         _assert_matches_reference(
-            word_counts[i],
-            word_counts[i],
-            UInt64(i * 6151 + 3),
-            (i * 9 + 1) % 33,
+            count, count, UInt64(i * 6151 + 3), (i * 9 + 1) % 33
         )
 
 


### PR DESCRIPTION
This PR adds an NTT-based multiplication path for `BigInt` magnitudes (base-2^32) using the Goldilocks prime, wiring it into the existing multiplication dispatch so very large products can run in `O(n log n)` instead of Toom-3’s `O(n^1.465)`.

`BigDecimal` constructor no longer copies its coefficients.