### PR TITLE
[core][bigdecimal] Halve small-operation cost, and replace `List._data` with `unsafe_ptr()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,10 @@ repos:
         language: system
         files: '\.py$'
         stages: [pre-commit]
+
+      - id: debug-assert-messages
+        name: debug-assert-messages
+        entry: python3 scripts/check_debug_assert_messages.py
+        language: system
+        files: '\.(mojo|🔥)$'
+        stages: [pre-commit]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,27 @@ fixed.
 
 ### 🦋 Changed in Unreleased
 
+1. **Small operations are about twice as fast.** At these sizes the library
+   spends ~4 ns doing arithmetic and ~33 ns per allocation, so an operation's
+   speed is very nearly its allocation count -- and several were allocating
+   for nothing. `add()` and `subtract()` scaled both coefficients to a common
+   scale when only one of them ever needs it, since the target scale is by
+   construction one of the two. `add_slices_carry_select()` allocated an
+   exact-size buffer and then reserved one more word, which reallocates.
+   `multiply()`'s single-word paths copied the other operand and then grew the
+   copy. And three `debug_assert` calls in the division paths built their
+   message with `"..." + String(n)`, which allocates on every call even in a
+   build with assertions compiled out, because arguments are evaluated before
+   the assert can discard them (upstream bug modular/modular#6439).
+   Measured on small operands: add 1.90x, subtract 1.82x, multiply 2.06x,
+   round 2.45x, divide 1.73x, `BigUInt` add 1.95x.
+1. **`List._data` is no longer used anywhere.** All 63 sites moved to
+   `unsafe_ptr()`, which returns the same address with an origin attached, so
+   the compiler tracks the buffer's lifetime and we no longer depend on a
+   private field of the standard library. No performance change. Restoring
+   origins exposed twelve deliberate in-place aliases, which now say so
+   explicitly through `alias_as_immutable_source()` instead of hiding behind
+   an untracked pointer.
 1. **`BigDecimal` construction no longer copies its coefficient.** The
    component constructor took `coefficient` borrowed and then copied it, so
    every call site already written as `coefficient=coef^` — 27 of them, the

--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -13,13 +13,41 @@ from a cheaper NTT butterfly — precomputed twiddles and radix-4, together
 about 2.5x. Detail in the sections on the NTT and on GMP's ratios below.
 
 **2. Beat CPython's `decimal` on small numbers** — this is what a
-`decimal.Decimal` drop-in is judged on, and today we are at parity on
-subtract, multiply and `from_string`, and 1.8-2.1x behind on add, round and
-divide. It is almost entirely memory management, not arithmetic: a small add
-does about 5 ns of real work and spends 36 ns allocating the result. Giving
-`BigUInt` inline storage for one or two words would remove the allocation
-and should put small operations clearly ahead of libmpdec. See "Small
-operations are allocation, not arithmetic".
+`decimal.Decimal` drop-in is judged on. It is almost entirely memory
+management, not arithmetic: a small operation does about 4 ns of real work
+and ~33 ns per allocation, so its speed is very nearly its allocation count.
+
+Most of the gap turned out to be allocations nothing needed, and removing
+them (20260825) roughly halved the small operations:
+
+| | before | after | |
+|---|---|---|---|
+| add | 79.7 ns | 42.0 ns | 1.90x |
+| subtract | 81.5 ns | 44.9 ns | 1.82x |
+| multiply | 81.6 ns | 39.7 ns | 2.06x |
+| round | 100.5 ns | 41.0 ns | 2.45x |
+| divide | 249.9 ns | 144.7 ns | 1.73x |
+| `BigUInt` add | 73.5 ns | 37.6 ns | 1.95x |
+
+Three causes, all worth watching for elsewhere: scaling both operands when
+only one needed it; allocating an exact-size buffer and then growing it; and
+a `debug_assert` building its message with `+ String(n)`, which allocates on
+every call even with assertions compiled out (upstream bug
+modular/modular#6439 — a pre-commit hook now guards against it).
+
+Still open, in order of size:
+
+- **`divide` still allocates a full product** to test whether the division
+  was exact (`coef * y == coef_x` in `true_divide_general()`). The remainder
+  would answer it for free; `floor_divide_by_uint32()` already computes it
+  and throws it away. Worth roughly one allocation.
+- **`subtract_inplace()` copies a whole coefficient** just to flip a sign
+  before calling `add_inplace()`.
+- **`from_string` is unchanged at ~93 ns**, about three allocations, and
+  was not investigated.
+
+After those, inline storage for one or two words (SBO) removes the last
+allocation and is what puts small operations clearly ahead of libmpdec.
 
 ## Inconsistencies between libraries
 

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -553,6 +553,14 @@ P2 — Multiply small-precision (2.3× py → target ≤1.5×)
   at >=256 words across 3 runs with no small-input regression (the small-n path
   is allocation-bound, so it stays neutral). This is the same mechanism as
   `multiply_slices_deferred_carry` (Lesson #17), amplified by two buffers.
+
+  **No longer reproduces (20260826, Mojo 1.0.0).** Re-benched on the real
+  function at 256/1024/8192/65536 words: the two forms are within 1.6% and the
+  indexed form is marginally ahead at the largest sizes. The loop runs at
+  ~3.35 ns/word either way -- that is the two 64-bit divides, and addressing
+  never surfaces behind them. `floor_divide_by_uint32` is back on the indexed
+  form, which is also bounds-checked under `-D ASSERT=all`.
+
   **Reverted (no stable win / small-input regressions):**
   `multiply_by_uint32_inplace` (mixed; -3..-8% at 16-64w),
   `floor_divide_by_uint32_inplace` (single buffer; +3% only at large n,

--- a/scripts/check_debug_assert_messages.py
+++ b/scripts/check_debug_assert_messages.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fails if a `debug_assert` builds its message instead of passing it in pieces.
+
+Mojo evaluates a call's arguments before `debug_assert`'s own `comptime if`
+can discard them, so anything that allocates in an argument -- `String(n)`,
+`"a" + b`, `.format(...)` -- runs on every call even in a build compiled with
+`-D ASSERT=none`. In decimo this was measured at ~59 ns per call inside
+`floor_divide_by_power_of_ten_inplace()`, which is more than the operation it
+was guarding.
+
+`debug_assert` is variadic, so the fix is always to pass the pieces
+separately: `debug_assert(cond, "n was ", n)` rather than
+`debug_assert(cond, "n was " + String(n))`.
+
+Upstream bug, still open as of Mojo 1.0.0:
+https://github.com/modular/modular/issues/6439 -- when it is fixed this check
+can go away.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+CALL = re.compile(r"debug_assert(?:\[[^\]]*\])?\(")
+ALLOCATING = (
+    (re.compile(r"\.format\("), "`.format(...)` builds a String"),
+    (re.compile(r"\bString\("), "`String(...)` allocates"),
+    (re.compile(r'"\s*\+|\+\s*String|\+\s*"'), "string concatenation allocates"),
+    (re.compile(r"\.join\("), "`.join(...)` allocates"),
+)
+
+
+def spans(text: str):
+    """Yields (line_number, argument_text) for every `debug_assert` call."""
+    for match in CALL.finditer(text):
+        start = match.end()
+        depth, i = 1, start
+        while i < len(text) and depth:
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+            i += 1
+        yield text.count("\n", 0, match.start()) + 1, text[start : i - 1]
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(a) for a in argv[1:]] or sorted(Path("src").rglob("*.mojo"))
+    failures = []
+    for path in paths:
+        if path.suffix != ".mojo" or not path.exists():
+            continue
+        text = path.read_text()
+        for line, args in spans(text):
+            for pattern, why in ALLOCATING:
+                if pattern.search(args):
+                    failures.append(f"{path}:{line}: {why}")
+                    break
+
+    if failures:
+        print("debug_assert messages must be passed as pieces, not built:\n")
+        for failure in failures:
+            print("  " + failure)
+        print(
+            '\nUse the variadic form:  debug_assert(cond, "n was ", n)'
+            "\nWhy: https://github.com/modular/modular/issues/6439"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_debug_assert_messages.py
+++ b/scripts/check_debug_assert_messages.py
@@ -46,11 +46,22 @@ def spans(text: str):
         yield text.count("\n", 0, match.start()) + 1, text[start : i - 1]
 
 
+MOJO_SUFFIXES = (".mojo", ".\U0001f525")
+
+
+def discover() -> list[Path]:
+    """Every Mojo source under `src`, in either spelling of the suffix."""
+    found: list[Path] = []
+    for suffix in MOJO_SUFFIXES:
+        found.extend(Path("src").rglob("*" + suffix))
+    return sorted(found)
+
+
 def main(argv: list[str]) -> int:
-    paths = [Path(a) for a in argv[1:]] or sorted(Path("src").rglob("*.mojo"))
+    paths = [Path(a) for a in argv[1:]] or discover()
     failures = []
     for path in paths:
-        if path.suffix != ".mojo" or not path.exists():
+        if path.suffix not in MOJO_SUFFIXES or not path.exists():
             continue
         text = path.read_text()
         for line, args in spans(text):

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -103,29 +103,72 @@ def add(
     if x2.coefficient.is_zero():
         return x1.extend_precision(scale_factor1)
 
-    # Scale coefficients to match
-    var coef1 = x1.coefficient.multiply_by_power_of_ten(scale_factor1)
-    var coef2 = x2.coefficient.multiply_by_power_of_ten(scale_factor2)
-
-    # Handle addition based on signs
-    if x1.sign == x2.sign:
-        # Same sign: Add coefficients, keep sign
-        coef1 += coef2
-        return BigDecimal(coefficient=coef1^, scale=max_scale, sign=x1.sign)
-    # Different signs: Subtract smaller coefficient from larger
-    if coef1 > coef2:
-        # |x1| > |x2|, result sign is x1's sign
-        coef1 -= coef2
-        return BigDecimal(coefficient=coef1^, scale=max_scale, sign=x1.sign)
-    elif coef2 > coef1:
-        # |x2| > |x1|, result sign is x2's sign
-        coef2 -= coef1
-        return BigDecimal(coefficient=coef2^, scale=max_scale, sign=x2.sign)
-    else:
-        # |x1| == |x2|, signs differ, result is 0
-        return BigDecimal(
-            coefficient=BigUInt.zero(), scale=max_scale, sign=False
+    # `max_scale` is one of the two scales, so at least one of the two scale
+    # factors is zero, and `multiply_by_power_of_ten(0)` is a plain copy: a
+    # whole coefficient allocated and memcpy'd to produce the value we were
+    # already holding. Scale only the operand that needs it and fold the other
+    # one in by reference, which costs one allocation on this path instead of
+    # two. At these sizes that is most of the operation -- a small `BigUInt`
+    # allocation is ~32 ns against ~4 ns of actual arithmetic.
+    if scale_factor2 == 0:
+        return _combine_scaled_coefficients(
+            x1.coefficient.multiply_by_power_of_ten(scale_factor1),
+            x2.coefficient,
+            x1.sign,
+            x2.sign,
+            max_scale,
         )
+    return _combine_scaled_coefficients(
+        x2.coefficient.multiply_by_power_of_ten(scale_factor2),
+        x1.coefficient,
+        x2.sign,
+        x1.sign,
+        max_scale,
+    )
+
+
+@always_inline
+def _combine_scaled_coefficients(
+    var scaled: BigUInt,
+    other: BigUInt,
+    scaled_sign: Bool,
+    other_sign: Bool,
+    scale: Int,
+) raises -> BigDecimal:
+    """Combines a coefficient we own with one we only borrow.
+
+    Both coefficients are already at `scale`. `scaled` is owned, so the
+    same-sign sum and the `scaled > other` difference both run in place and
+    allocate nothing further. Only the `other > scaled` difference has to
+    build a new magnitude, because the larger operand is the borrowed one.
+
+    Args:
+        scaled: The owned coefficient, consumed by this call.
+        other: The borrowed coefficient, at the same scale as `scaled`.
+        scaled_sign: Sign of the operand `scaled` came from.
+        other_sign: Sign of the operand `other` came from.
+        scale: Scale shared by both coefficients, and of the result.
+
+    Returns:
+        The combined value.
+    """
+    if scaled_sign == other_sign:
+        scaled += other
+        return BigDecimal(coefficient=scaled^, scale=scale, sign=scaled_sign)
+
+    if scaled > other:
+        scaled -= other
+        return BigDecimal(coefficient=scaled^, scale=scale, sign=scaled_sign)
+
+    if other > scaled:
+        return BigDecimal(
+            coefficient=biguint_arithmetics.subtract(other, scaled),
+            scale=scale,
+            sign=other_sign,
+        )
+
+    # Equal magnitudes with opposite signs.
+    return BigDecimal(coefficient=BigUInt.zero(), scale=scale, sign=False)
 
 
 def subtract(

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -255,30 +255,25 @@ def subtract(
         result.sign = not result.sign
         return result^
 
-    # Scale coefficients to match
-    var coef1 = x1.coefficient.multiply_by_power_of_ten(scale_factor1)
-    var coef2 = x2.coefficient.multiply_by_power_of_ten(scale_factor2)
-
-    # Handle subtraction based on signs
-    if x1.sign != x2.sign:
-        # Different signs: x1 - (-x2) = x1 + x2, or (-x1) - x2 = -(x1 + x2)
-        coef1 += coef2
-        return BigDecimal(coefficient=coef1^, scale=max_scale, sign=x1.sign)
-
-    # Same signs: Must perform actual subtraction
-    if coef1 > coef2:
-        # |x1| > |x2|, result sign is x1's sign
-        coef1 -= coef2
-        return BigDecimal(coefficient=coef1^, scale=max_scale, sign=x1.sign)
-    elif coef2 > coef1:
-        # |x1| < |x2|, result sign is opposite of x1's sign
-        coef2 -= coef1
-        return BigDecimal(coefficient=coef2^, scale=max_scale, sign=not x1.sign)
-    else:
-        # |x1| == |x2|, result is 0
-        return BigDecimal(
-            coefficient=BigUInt.zero(), scale=max_scale, sign=False
+    # `x1 - x2` is `x1 + (-x2)`, so this is the same combination `add()` does
+    # with `x2`'s sign flipped, and it avoids the same wasted allocation: only
+    # one of the two scale factors can be non-zero, and scaling by zero is a
+    # plain copy. See `_combine_scaled_coefficients()`.
+    if scale_factor2 == 0:
+        return _combine_scaled_coefficients(
+            x1.coefficient.multiply_by_power_of_ten(scale_factor1),
+            x2.coefficient,
+            x1.sign,
+            not x2.sign,
+            max_scale,
         )
+    return _combine_scaled_coefficients(
+        x2.coefficient.multiply_by_power_of_ten(scale_factor2),
+        x1.coefficient,
+        not x2.sign,
+        x1.sign,
+        max_scale,
+    )
 
 
 def multiply(

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -38,6 +38,7 @@ from std.sys import is_little_endian
 from std.memory import unsafe_memcpy, unsafe_memset_zero
 
 from decimo.bigint.bigint import BigInt
+from decimo.utility import alias_as_immutable_source
 from decimo.bigint.comparison import compare_magnitudes
 import decimo.bigint.ntt as bigint_ntt
 from decimo.errors import ValueError, ZeroDivisionError
@@ -81,11 +82,13 @@ comptime CUTOFF_BURNIKEL_ZIEGLER: Int = 64
 
 @always_inline
 def _add_word_pairs[
-    o: Origin[mut=True]
+    o: Origin[mut=True],
+    o_a: Origin[mut=False],
+    o_b: Origin[mut=False],
 ](
     rp: Pointer[UInt32, o],
-    ap: Pointer[UInt32, _],
-    bp: Pointer[UInt32, _],
+    ap: Pointer[UInt32, o_a],
+    bp: Pointer[UInt32, o_b],
     n_pairs: Int,
     carry_in: UInt64,
 ) -> UInt64:
@@ -137,11 +140,13 @@ def _add_word_pairs[
 
 @always_inline
 def _subtract_word_pairs[
-    o: Origin[mut=True]
+    o: Origin[mut=True],
+    o_a: Origin[mut=False],
+    o_b: Origin[mut=False],
 ](
     rp: Pointer[UInt32, o],
-    ap: Pointer[UInt32, _],
-    bp: Pointer[UInt32, _],
+    ap: Pointer[UInt32, o_a],
+    bp: Pointer[UInt32, o_b],
     n_pairs: Int,
     borrow_in: UInt64,
 ) -> UInt64:
@@ -395,7 +400,7 @@ def _multiply_magnitude_by_word(
     var carry: UInt64 = 0
     var w64 = UInt64(w)
     var ap = a.unsafe_ptr()
-    var rp = result._data
+    var rp = result.unsafe_ptr()
     for i in range(len_a):
         var product = UInt64(ap[unsafe_offset=i]) * w64 + carry
         rp[unsafe_offset=i] = UInt32(product & 0xFFFF_FFFF)
@@ -453,7 +458,7 @@ def _multiply_magnitudes_comba32(
 
     var ap = a.unsafe_ptr()
     var bp = b.unsafe_ptr()
-    var rp = result._data
+    var rp = result.unsafe_ptr()
 
     var carry = UInt128(0)
     for k in range(result_len - 1):
@@ -561,7 +566,7 @@ def _multiply_magnitudes_schoolbook(
 
     var limbs_a = List[UInt64](capacity=n_a)
     limbs_a.resize(unsafe_uninit_length=n_a)
-    var lap = limbs_a._data
+    var lap = limbs_a.unsafe_ptr()
     for j in range(n_a - 1):
         lap[unsafe_offset=j] = UInt64(ap[unsafe_offset=2 * j]) | (
             UInt64(ap[unsafe_offset=2 * j + 1]) << 32
@@ -573,7 +578,7 @@ def _multiply_magnitudes_schoolbook(
 
     var limbs_b = List[UInt64](capacity=n_b)
     limbs_b.resize(unsafe_uninit_length=n_b)
-    var lbp = limbs_b._data
+    var lbp = limbs_b.unsafe_ptr()
     for j in range(n_b - 1):
         lbp[unsafe_offset=j] = UInt64(bp[unsafe_offset=2 * j]) | (
             UInt64(bp[unsafe_offset=2 * j + 1]) << 32
@@ -590,7 +595,7 @@ def _multiply_magnitudes_schoolbook(
     var result_len = n_out << 1
     var result = List[UInt32](capacity=result_len)
     result.resize(unsafe_uninit_length=result_len)
-    var rp = result._data
+    var rp = result.unsafe_ptr()
 
     # `carry` is the part of the column sum above 64 bits, which belongs to
     # the next column. The last column leaves it holding the top limb.
@@ -702,7 +707,7 @@ def _multiply_magnitudes_karatsuba(
         var rlen = len_a + len_b
         var result = List[UInt32](capacity=rlen)
         result.resize(unsafe_uninit_length=rlen)
-        unsafe_memset_zero(ptr=result._data, count=rlen)
+        unsafe_memset_zero(ptr=result.unsafe_ptr(), count=rlen)
         _add_at_offset_inplace(result, z0, 0)
         _add_at_offset_inplace(result, z1, m)
         while rlen > 1 and result[rlen - 1] == 0:
@@ -718,7 +723,7 @@ def _multiply_magnitudes_karatsuba(
         var rlen = len_a + len_b
         var result = List[UInt32](capacity=rlen)
         result.resize(unsafe_uninit_length=rlen)
-        unsafe_memset_zero(ptr=result._data, count=rlen)
+        unsafe_memset_zero(ptr=result.unsafe_ptr(), count=rlen)
         _add_at_offset_inplace(result, z0, 0)
         _add_at_offset_inplace(result, z1, m)
         while rlen > 1 and result[rlen - 1] == 0:
@@ -750,7 +755,7 @@ def _multiply_magnitudes_karatsuba(
     var result_len = len_a + len_b
     var result = List[UInt32](capacity=result_len)
     result.resize(unsafe_uninit_length=result_len)
-    unsafe_memset_zero(ptr=result._data, count=result_len)
+    unsafe_memset_zero(ptr=result.unsafe_ptr(), count=result_len)
 
     # Add z0 at offset 0
     _add_at_offset_inplace(result, z0, 0)
@@ -790,7 +795,7 @@ def _double_inplace(mut a: List[UInt32]):
         a: The magnitude to double in-place.
     """
     var carry: UInt32 = 0
-    var ap = a._data
+    var ap = a.unsafe_ptr()
     for i in range(len(a)):
         var word = ap[unsafe_offset=i]
         ap[unsafe_offset=i] = (word << 1) | carry
@@ -809,7 +814,7 @@ def _exact_divide_by_2_inplace(mut a: List[UInt32]):
         a: The magnitude to halve in-place. Must be even.
     """
     var carry: UInt32 = 0
-    var ap = a._data
+    var ap = a.unsafe_ptr()
     for i in range(len(a) - 1, -1, -1):
         var word = ap[unsafe_offset=i]
         ap[unsafe_offset=i] = (word >> 1) | (carry << 31)
@@ -849,7 +854,7 @@ def _exact_divide_by_3_inplace(mut a: List[UInt32]):
     comptime BASE_OVER_THREE = UInt32(0x5555_5555)  # (2^32 - 1) / 3
 
     var remainder = UInt32(0)  # 0, 1 or 2
-    var ap = a._data
+    var ap = a.unsafe_ptr()
     for i in range(len(a) - 1, -1, -1):
         var word = ap[unsafe_offset=i]
         var word_quotient = word // 3  # off the chain
@@ -1051,7 +1056,7 @@ def _multiply_magnitudes_toom3(
     var result_len = len_a + len_b
     var result = List[UInt32](capacity=result_len)
     result.resize(unsafe_uninit_length=result_len)
-    unsafe_memset_zero(ptr=result._data, count=result_len)
+    unsafe_memset_zero(ptr=result.unsafe_ptr(), count=result_len)
 
     _add_at_offset_inplace(result, v0, 0)
     _add_at_offset_inplace(result, t1, m)  # w1
@@ -1098,7 +1103,7 @@ def _add_slices(a: ImmSpan[UInt32, _], b: ImmSpan[UInt32, _]) -> List[UInt32]:
 
     var ap = a.unsafe_ptr()
     var bp = b.unsafe_ptr()
-    var rp = result._data
+    var rp = result.unsafe_ptr()
 
     var pairs = len_min >> 1
     var carry = _add_word_pairs(rp, ap, bp, pairs, UInt64(0))
@@ -1155,11 +1160,13 @@ def _add_magnitudes_inplace(mut a: List[UInt32], imm b: List[UInt32]):
 
     # `a` is now `len_max + 1` words long with a zero on top, so the sum and
     # its carry both fit and every word of `b` has a counterpart in `a`.
-    var ap = a._data
-    var bp = b._data
+    var ap = a.unsafe_ptr()
+    var bp = b.unsafe_ptr()
 
     var pairs = len_b >> 1
-    var carry = _add_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var carry = _add_word_pairs(
+        ap, alias_as_immutable_source(ap), bp, pairs, UInt64(0)
+    )
     var i = pairs << 1
     while i < len_b:
         var s = (
@@ -1228,10 +1235,12 @@ def _add_at_offset_inplace(
         offset + len_b <= len(a),
         "_add_at_offset_inplace(): writes past the end of the accumulator",
     )
-    var ap = a._data.unsafe_offset(offset)
-    var bp = b._data
+    var ap = a.unsafe_ptr().unsafe_offset(offset)
+    var bp = b.unsafe_ptr()
     var pairs = len_b >> 1
-    var carry = _add_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var carry = _add_word_pairs(
+        ap, alias_as_immutable_source(ap), bp, pairs, UInt64(0)
+    )
     var i = pairs << 1
     while i < len_b:
         var s = (
@@ -1261,11 +1270,13 @@ def _subtract_magnitudes_inplace(mut a: List[UInt32], imm b: List[UInt32]):
     var len_a = len(a)
     var len_b = len(b)
 
-    var ap = a._data
-    var bp = b._data
+    var ap = a.unsafe_ptr()
+    var bp = b.unsafe_ptr()
 
     var pairs = len_b >> 1
-    var borrow = _subtract_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var borrow = _subtract_word_pairs(
+        ap, alias_as_immutable_source(ap), bp, pairs, UInt64(0)
+    )
     var i = pairs << 1
     while i < len_b:
         var ai = UInt64(ap[unsafe_offset=i])
@@ -1305,12 +1316,12 @@ def _shift_left_words_inplace(mut a: List[UInt32], n: Int):
 
     # Move existing words right by n positions using backward copy
     # (destination is always at higher address, so backward is overlap-safe)
-    var p = a._data
+    var p = a.unsafe_ptr()
     for i in range(old_len - 1, -1, -1):
         p[unsafe_offset=i + n] = p[unsafe_offset=i]
 
     # Fill the first n words with zeros
-    unsafe_memset_zero(ptr=a._data, count=n)
+    unsafe_memset_zero(ptr=a.unsafe_ptr(), count=n)
 
 
 def _divmod_single_word(
@@ -1659,7 +1670,7 @@ def _normalized_copy(a: ImmSpan[UInt32, _]) -> List[UInt32]:
         return zero^
     var result = List[UInt32](capacity=len_slice)
     result.resize(unsafe_uninit_length=len_slice)
-    unsafe_memcpy(dest=result._data, src=a.unsafe_ptr(), count=len_slice)
+    unsafe_memcpy(dest=result.unsafe_ptr(), src=a.unsafe_ptr(), count=len_slice)
     # Strip leading zeros
     while len(result) > 1 and result[len(result) - 1] == 0:
         result.shrink(len(result) - 1)
@@ -1704,11 +1715,13 @@ def _add_from_slice_inplace(mut a: List[UInt32], b: ImmSpan[UInt32, _]):
 
     # As in `_add_magnitudes_inplace()`, `a` now has `len_max + 1` words with a
     # zero on top, so the carry always lands inside it.
-    var ap = a._data
+    var ap = a.unsafe_ptr()
     var bp = b.unsafe_ptr()
 
     var pairs = len_b_slice >> 1
-    var carry = _add_word_pairs(ap, ap, bp, pairs, UInt64(0))
+    var carry = _add_word_pairs(
+        ap, alias_as_immutable_source(ap), bp, pairs, UInt64(0)
+    )
     var i = pairs << 1
     while i < len_b_slice:
         var s = (
@@ -1841,14 +1854,14 @@ def _divmod_knuth_d_from_slices(
     var m = len_a_eff - n
     var u = List[UInt32](capacity=len_a_eff + 1)
     u.resize(unsafe_uninit_length=len_a_eff)
-    unsafe_memcpy(dest=u._data, src=a.unsafe_ptr(), count=len_a_eff)
+    unsafe_memcpy(dest=u.unsafe_ptr(), src=a.unsafe_ptr(), count=len_a_eff)
     # Ensure u has an extra leading word
     if len(u) <= m + n:
         u.append(UInt32(0))
 
     var quotient = List[UInt32](capacity=m + 1)
     quotient.resize(unsafe_uninit_length=m + 1)
-    unsafe_memset_zero(ptr=quotient._data, count=m + 1)
+    unsafe_memset_zero(ptr=quotient.unsafe_ptr(), count=m + 1)
 
     # v_n_minus_1 and v_n_minus_2 read directly from b via offset
     var v_n_minus_1 = UInt64(b[n - 1])
@@ -1864,9 +1877,9 @@ def _divmod_knuth_d_from_slices(
     # pointers for the same reason the multiply kernels are: a `List[i]` reads
     # the list's `_data` field again on every element (Lesson 7). None of them
     # is resized while these pointers are live.
-    var u_ptr = u._data
+    var u_ptr = u.unsafe_ptr()
     var b_ptr = b.unsafe_ptr()
-    var quotient_ptr = quotient._data
+    var quotient_ptr = quotient.unsafe_ptr()
 
     for j in range(m, -1, -1):
         var u_jn = UInt64(u_ptr[unsafe_offset=j + n])
@@ -2024,7 +2037,7 @@ def _divmod_burnikel_ziegler(
     var q_total_words = (t - 1) * n
     var quotient = List[UInt32](capacity=q_total_words + 1)
     quotient.resize(unsafe_uninit_length=q_total_words)
-    unsafe_memset_zero(ptr=quotient._data, count=q_total_words)
+    unsafe_memset_zero(ptr=quotient.unsafe_ptr(), count=q_total_words)
 
     # First iteration: divide top 2n words by norm_b.
     var result_pair = _bz_two_by_one_slices(

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -1807,7 +1807,6 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
-    @always_inline
     def assert_invariant(self, context: StaticString = "") -> None:
         """Checks the representation invariant documented on the struct.
 
@@ -1828,6 +1827,7 @@ struct BigInt(
             context,
         )
 
+    @always_inline
     def is_zero(self) -> Bool:
         """Returns True if the value is zero.
 

--- a/src/decimo/bigint/bigint.mojo
+++ b/src/decimo/bigint/bigint.mojo
@@ -91,6 +91,23 @@ struct BigInt(
     Arithmetic intermediate results use UInt64 for single products
     (UInt32 * UInt32 → UInt64) and UInt128 for accumulation, which allows
     efficient schoolbook and Karatsuba multiplication on 64-bit hardware.
+
+    Representation invariant:
+
+    1. `words` is never empty. It always holds at least one word.
+    2. There are no leading zero words: `words[len(words) - 1] != 0`, unless
+       `len(words) == 1`.
+    3. Unlike `BigUInt`, a word here uses the full `[0, 2^32 - 1]` range, so
+       there is no per-word bound to check.
+
+    Note that the sign of zero is *not* canonical: `is_zero()` scans the words
+    rather than trusting the leading-zero rule, and `is_negative()` is
+    `sign and not is_zero()`, so a zero carrying `sign = True` compares and
+    prints correctly. Do not write code that reads `sign` alone to decide
+    whether a value is negative.
+
+    Call `assert_invariant()` to check the first two. It is a `debug_assert`,
+    so it costs nothing in a normal build and fires in the test suite.
     """
 
     var words: List[UInt32]
@@ -1790,6 +1807,27 @@ struct BigInt(
     # ===------------------------------------------------------------------=== #
 
     @always_inline
+    @always_inline
+    def assert_invariant(self, context: StaticString = "") -> None:
+        """Checks the representation invariant documented on the struct.
+
+        A `debug_assert`, so it compiles away entirely unless the build sets
+        `-D ASSERT=all`.
+
+        Args:
+            context: Name of the calling function, shown if the check fires.
+        """
+        debug_assert(
+            len(self.words) > 0,
+            "BigInt.assert_invariant(): empty words. ",
+            context,
+        )
+        debug_assert(
+            len(self.words) == 1 or self.words[len(self.words) - 1] != 0,
+            "BigInt.assert_invariant(): leading zero word. ",
+            context,
+        )
+
     def is_zero(self) -> Bool:
         """Returns True if the value is zero.
 
@@ -2146,7 +2184,7 @@ def _from_decimal_digits_simple(
 
     # ---- Fast path: ≤ 9 digits → single UInt32 word, no allocation ----
     if digit_count <= 9:
-        var dp = digits._data.unsafe_offset(start)
+        var dp = digits.unsafe_ptr().unsafe_offset(start)
         var val: UInt32 = UInt32(dp[])
         for j in range(1, digit_count):
             val = val * 10 + UInt32(dp[unsafe_offset=j])
@@ -2156,7 +2194,7 @@ def _from_decimal_digits_simple(
 
     # ---- Fast path: 10–19 digits → parse into UInt64, at most 2 words ----
     if digit_count <= 19:
-        var dp = digits._data.unsafe_offset(start)
+        var dp = digits.unsafe_ptr().unsafe_offset(start)
         var val: UInt64 = UInt64(dp[])
         for j in range(1, digit_count):
             val = val * 10 + UInt64(dp[unsafe_offset=j])
@@ -2177,14 +2215,14 @@ def _from_decimal_digits_simple(
     var result = BigInt()
     result.words = List[UInt32](capacity=max_words)
     result.words.resize(unsafe_uninit_length=max_words)
-    var wp = result.words._data  # stable pointer: no reallocation occurs
+    var wp = result.words.unsafe_ptr()  # stable pointer: no reallocation occurs
 
     # Handle first chunk (1–9 digits) to align the rest to 9-digit boundaries.
     var first_chunk = digit_count % 9
     if first_chunk == 0:
         first_chunk = 9
 
-    var dp = digits._data.unsafe_offset(start)
+    var dp = digits.unsafe_ptr().unsafe_offset(start)
     var chunk_val: UInt32 = UInt32(dp[])
     for j in range(1, first_chunk):
         chunk_val = chunk_val * 10 + UInt32(dp[unsafe_offset=j])
@@ -2551,7 +2589,7 @@ def _magnitude_to_base_1e9_dc(
     var capacity = 1 << max_level
     var out = List[UInt32](capacity=capacity)
     out.resize(unsafe_uninit_length=capacity)
-    unsafe_memset_zero(ptr=out._data, count=capacity)
+    unsafe_memset_zero(ptr=out.unsafe_ptr(), count=capacity)
 
     _dc_to_base_1e9_recursive(n, power_table, num_powers - 1, out, 0)
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -2795,6 +2795,9 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     # `debug_assert` argument is built at the call site before the assert's
     # own `comptime if` can discard it, so `"..." + String(n)` allocates a
     # string on every call even in a build with assertions compiled out.
+    # That cost ~59 ns here, more than the division being guarded.
+    # Upstream bug, still open as of Mojo 1.0.0:
+    # https://github.com/modular/modular/issues/6439
     debug_assert[assert_mode="none"](
         n >= 0,
         (

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -30,6 +30,7 @@ from decimo.errors import (
     ZeroDivisionError,
 )
 from decimo.rounding_mode import RoundingMode
+from decimo.utility import alias_as_immutable_source
 
 comptime CUTOFF_KARATSUBA = 256
 """The cutoff number of words for using Karatsuba multiplication.
@@ -127,11 +128,13 @@ comptime CUTOFF_BURNIKEL_ZIEGLER = 32
 
 @always_inline
 def _add_words_carry_select[
-    o: Origin[mut=True]
+    o: Origin[mut=True],
+    o_a: Origin[mut=False],
+    o_b: Origin[mut=False],
 ](
     rp: Pointer[UInt32, o],
-    ap: Pointer[UInt32, _],
-    bp: Pointer[UInt32, _],
+    ap: Pointer[UInt32, o_a],
+    bp: Pointer[UInt32, o_b],
     n_words: Int,
     carry_in: UInt32,
 ) -> UInt32:
@@ -163,11 +166,13 @@ def _add_words_carry_select[
 
 @always_inline
 def _subtract_words_borrow_select[
-    o: Origin[mut=True]
+    o: Origin[mut=True],
+    o_a: Origin[mut=False],
+    o_b: Origin[mut=False],
 ](
     rp: Pointer[UInt32, o],
-    ap: Pointer[UInt32, _],
-    bp: Pointer[UInt32, _],
+    ap: Pointer[UInt32, o_a],
+    bp: Pointer[UInt32, o_b],
     n_words: Int,
     borrow_in: UInt32,
 ) -> UInt32:
@@ -203,10 +208,10 @@ def _subtract_words_borrow_select[
 
 @always_inline
 def _carry_into_tail[
-    o: Origin[mut=True]
+    o: Origin[mut=True], o_a: Origin[mut=False]
 ](
     rp: Pointer[UInt32, o],
-    ap: Pointer[UInt32, _],
+    ap: Pointer[UInt32, o_a],
     start: Int,
     end: Int,
     carry_in: UInt32,
@@ -243,10 +248,10 @@ def _carry_into_tail[
 
 @always_inline
 def _borrow_into_tail[
-    o: Origin[mut=True]
+    o: Origin[mut=True], o_a: Origin[mut=False]
 ](
     rp: Pointer[UInt32, o],
-    ap: Pointer[UInt32, _],
+    ap: Pointer[UInt32, o_a],
     start: Int,
     end: Int,
     borrow_in: UInt32,
@@ -472,9 +477,9 @@ def add_slices_carry_select(
     var result = BigUInt(unsafe_uninit_length=n_words_longer)
     result.words.reserve(n_words_longer + 1)
 
-    var xp = x.words._data.unsafe_offset(bounds_x[0])
-    var yp = y.words._data.unsafe_offset(bounds_y[0])
-    var rp = result.words._data
+    var xp = x.words.unsafe_ptr().unsafe_offset(bounds_x[0])
+    var yp = y.words.unsafe_ptr().unsafe_offset(bounds_y[0])
+    var rp = result.words.unsafe_ptr()
 
     var carry = _add_words_carry_select(rp, xp, yp, n_words_shorter, UInt32(0))
     var longer = xp if n_words_x_slice > n_words_y_slice else yp
@@ -520,11 +525,17 @@ def add_inplace(mut x: BigUInt, y: BigUInt) -> None:
     if len(x.words) < len(y.words):
         x.words.resize(length=len(y.words), fill=UInt32(0))
 
-    var xp = x.words._data
+    var xp = x.words.unsafe_ptr()
     var carry = _add_words_carry_select(
-        xp, xp, y.words._data, len(y.words), UInt32(0)
+        xp,
+        alias_as_immutable_source(xp),
+        y.words.unsafe_ptr(),
+        len(y.words),
+        UInt32(0),
     )
-    carry = _carry_into_tail(xp, xp, len(y.words), len(x.words), carry)
+    carry = _carry_into_tail(
+        xp, alias_as_immutable_source(xp), len(y.words), len(x.words), carry
+    )
     if carry != 0:
         x.words.append(UInt32(1))
 
@@ -567,15 +578,17 @@ def add_by_slice_inplace(
     if len(x.words) < n_words_y_slice:
         x.words.resize(length=n_words_y_slice, fill=UInt32(0))
 
-    var xp = x.words._data
+    var xp = x.words.unsafe_ptr()
     var carry = _add_words_carry_select(
         xp,
-        xp,
-        y.words._data.unsafe_offset(bounds_y[0]),
+        alias_as_immutable_source(xp),
+        y.words.unsafe_ptr().unsafe_offset(bounds_y[0]),
         n_words_y_slice,
         UInt32(0),
     )
-    carry = _carry_into_tail(xp, xp, n_words_y_slice, len(x.words), carry)
+    carry = _carry_into_tail(
+        xp, alias_as_immutable_source(xp), n_words_y_slice, len(x.words), carry
+    )
     if carry != 0:
         x.words.append(UInt32(1))
 
@@ -765,10 +778,10 @@ def subtract_carry_select(x: BigUInt, y: BigUInt) raises -> BigUInt:
     # The result will have no more words than the first number.
     var result = BigUInt(unsafe_uninit_length=len(x.words))
 
-    var xp = x.words._data
-    var rp = result.words._data
+    var xp = x.words.unsafe_ptr()
+    var rp = result.words.unsafe_ptr()
     var borrow = _subtract_words_borrow_select(
-        rp, xp, y.words._data, len(y.words), UInt32(0)
+        rp, xp, y.words.unsafe_ptr(), len(y.words), UInt32(0)
     )
     _ = _borrow_into_tail(rp, xp, len(y.words), len(x.words), borrow)
 
@@ -825,11 +838,17 @@ def subtract_inplace(mut x: BigUInt, y: BigUInt) raises -> None:
         return
 
     # Note that len(x.words) >= len(y.words) here
-    var xp = x.words._data
+    var xp = x.words.unsafe_ptr()
     var borrow = _subtract_words_borrow_select(
-        xp, xp, y.words._data, len(y.words), UInt32(0)
+        xp,
+        alias_as_immutable_source(xp),
+        y.words.unsafe_ptr(),
+        len(y.words),
+        UInt32(0),
     )
-    _ = _borrow_into_tail(xp, xp, len(y.words), len(x.words), borrow)
+    _ = _borrow_into_tail(
+        xp, alias_as_immutable_source(xp), len(y.words), len(x.words), borrow
+    )
 
     x.remove_leading_empty_words()
 
@@ -859,11 +878,17 @@ def subtract_no_check_inplace(mut x: BigUInt, y: BigUInt) -> None:
 
     # Underflow checks are skipped here, so we assume x >= y
     # Note that len(x.words) >= len(y.words) under this assumption
-    var xp = x.words._data
+    var xp = x.words.unsafe_ptr()
     var borrow = _subtract_words_borrow_select(
-        xp, xp, y.words._data, len(y.words), UInt32(0)
+        xp,
+        alias_as_immutable_source(xp),
+        y.words.unsafe_ptr(),
+        len(y.words),
+        UInt32(0),
     )
-    _ = _borrow_into_tail(xp, xp, len(y.words), len(x.words), borrow)
+    _ = _borrow_into_tail(
+        xp, alias_as_immutable_source(xp), len(y.words), len(x.words), borrow
+    )
 
     x.remove_leading_empty_words()
 
@@ -1073,6 +1098,7 @@ def multiply_slices_schoolbook(
         else:
             var result = BigUInt.from_slice(y, (bounds_y[0], bounds_y[1]))
             multiply_by_uint32_inplace(result, x_word)
+            result.assert_invariant("multiply_slices_schoolbook")
             return result^
     if n_words_y_slice == 1:
         var y_word = y.words[bounds_y[0]]
@@ -1620,7 +1646,7 @@ def multiply_slices_toom3(
     # Maximum result length: nx + ny words (product of two numbers).
     var result_len = nx + ny
     var result = BigUInt(unsafe_uninit_length=result_len)
-    unsafe_memset_zero(ptr=result.words._data, count=result_len)
+    unsafe_memset_zero(ptr=result.words.unsafe_ptr(), count=result_len)
 
     # Helper: add a BigUInt value at a word offset into result
     @parameter
@@ -1951,11 +1977,11 @@ def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
 
     var res = BigUInt(unsafe_uninit_length=len(x.words) + n)
     # Fill the first n words with zeros
-    unsafe_memset_zero(ptr=res.words._data, count=n)
+    unsafe_memset_zero(ptr=res.words.unsafe_ptr(), count=n)
     # Copy the original words to the end of the new list
     unsafe_memcpy(
-        dest=res.words._data.unsafe_offset(n),
-        src=x.words._data,
+        dest=res.words.unsafe_ptr().unsafe_offset(n),
+        src=x.words.unsafe_ptr(),
         count=len(x.words),
     )
 
@@ -2062,7 +2088,7 @@ def exact_divide_by_3_inplace(mut x: BigUInt):
     comptime BASE_OVER_THREE = UInt32(333_333_333)  # (10^9 - 1) / 3
 
     var carry = UInt32(0)  # 0, 1 or 2
-    var xp = x.words._data
+    var xp = x.words.unsafe_ptr()
     for i in range(len(x.words) - 1, -1, -1):
         var word = xp[unsafe_offset=i]
         var word_quotient = word // 3  # off the chain
@@ -2501,6 +2527,7 @@ def floor_divide_by_uint32(x: BigUInt, y: UInt32) -> BigUInt:
         "biguint.arithmetics.floor_divide_by_uint32(): ",
         "Result has leading zero words",
     )
+    result.assert_invariant("floor_divide_by_uint32")
     return result^
 
 
@@ -2791,8 +2818,8 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     var keep = len(x.words) - word_shift
     var result = BigUInt(unsafe_uninit_length=keep)
     unsafe_memcpy(
-        dest=result.words._data,
-        src=x.words._data.unsafe_offset(word_shift),
+        dest=result.words.unsafe_ptr(),
+        src=x.words.unsafe_ptr().unsafe_offset(word_shift),
         count=keep,
     )
     _shift_right_by_decimal_digits_inplace(result, digit_shift)
@@ -2927,8 +2954,8 @@ def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     else:
         var result = BigUInt(unsafe_uninit_length=n_words_of_result)
         unsafe_memcpy(
-            dest=result.words._data,
-            src=x.words._data.unsafe_offset(n),
+            dest=result.words.unsafe_ptr(),
+            src=x.words.unsafe_ptr().unsafe_offset(n),
             count=n_words_of_result,
         )
         return result^
@@ -3991,6 +4018,7 @@ def power_of_10(n: Int) raises -> BigUInt:
         # Add a 1 in the next position
         result.words.append(1)
 
+    result.assert_invariant("power_of_10")
     return result^
 
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -474,8 +474,12 @@ def add_slices_carry_select(
     var n_words_longer = max(n_words_x_slice, n_words_y_slice)
     var n_words_shorter = min(n_words_x_slice, n_words_y_slice)
 
-    var result = BigUInt(unsafe_uninit_length=n_words_longer)
-    result.words.reserve(n_words_longer + 1)
+    # One allocation sized for the possible carry word, not an exact-length
+    # allocation followed by a `reserve()` that has to move it.
+    var result = BigUInt(
+        unsafe_uninit_length=n_words_longer,
+        unsafe_uninit_capacity=n_words_longer + 1,
+    )
 
     var xp = x.words.unsafe_ptr().unsafe_offset(bounds_x[0])
     var yp = y.words.unsafe_ptr().unsafe_offset(bounds_y[0])
@@ -980,7 +984,10 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
         elif x_word == 1:
             return y.copy()
         else:
-            var result = y.copy()
+            # Multiplying by a single word can add one word, so copy with room
+            # for it: growing the buffer afterwards would allocate a second
+            # time and copy what was just allocated.
+            var result = y.copy_with_extra_capacity(1)
             multiply_by_uint32_inplace(result, x_word)
             return result^
 
@@ -991,7 +998,10 @@ def multiply(x: BigUInt, y: BigUInt) -> BigUInt:
         if y_word == 1:
             return x.copy()
         else:
-            var result = x.copy()
+            # Multiplying by a single word can add one word, so copy with room
+            # for it: growing the buffer afterwards would allocate a second
+            # time and copy what was just allocated.
+            var result = x.copy_with_extra_capacity(1)
             multiply_by_uint32_inplace(result, y_word)
             return result^
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -2791,13 +2791,17 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     In non-debug model, if n is less than or equal to 0, the function returns x
     unchanged. In debug mode, it asserts that n is non-negative.
     """
+    # The message is passed as separate pieces rather than concatenated: a
+    # `debug_assert` argument is built at the call site before the assert's
+    # own `comptime if` can discard it, so `"..." + String(n)` allocates a
+    # string on every call even in a build with assertions compiled out.
     debug_assert[assert_mode="none"](
         n >= 0,
         (
-            "biguint.arithmetics.floor_divide_by_power_of_ten(): "
-            "n must be non-negative but got "
-            + String(n)
+            "biguint.arithmetics.floor_divide_by_power_of_ten(): n must be"
+            " non-negative but got "
         ),
+        n,
     )
 
     if n <= 0:
@@ -2846,11 +2850,9 @@ def floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
     """
     debug_assert[assert_mode="none"](
         n >= 0,
-        (
-            "biguint.arithmetics.floor_divide_by_power_of_ten_inplace(): "
-            "n must be non-negative but got "
-            + String(n)
-        ),
+        "biguint.arithmetics.floor_divide_by_power_of_ten_inplace(): ",
+        "n must be non-negative but got ",
+        n,
     )
 
     if n <= 0:
@@ -2935,13 +2937,14 @@ def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     In non-debug model, if n is less than or equal to 0, the function returns x
     unchanged. In debug mode, it asserts that n is non-negative.
     """
+    # Message in pieces, not concatenated -- see `floor_divide_by_power_of_ten()`.
     debug_assert[assert_mode="none"](
         n >= 0,
         (
-            "biguint.arithmetics.floor_divide_by_power_of_billion(): "
-            "n must be non-negative but got "
-            + String(n)
+            "biguint.arithmetics.floor_divide_by_power_of_billion(): n must be"
+            " non-negative but got "
         ),
+        n,
     )
 
     if n <= 0:
@@ -2976,13 +2979,14 @@ def floor_divide_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
     `x` becomes the canonical zero (a single word holding 0). In
     debug mode, asserts that `n` is non-negative.
     """
+    # Message in pieces, not concatenated -- see `floor_divide_by_power_of_ten()`.
     debug_assert[assert_mode="none"](
         n >= 0,
         (
-            "biguint.arithmetics.floor_divide_by_power_of_billion_inplace(): "
-            "n must be non-negative but got "
-            + String(n)
+            "biguint.arithmetics.floor_divide_by_power_of_billion_inplace(): n"
+            " must be non-negative but got "
         ),
+        n,
     )
 
     if n <= 0:

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -2496,11 +2496,10 @@ def floor_divide_by_uint32(x: BigUInt, y: UInt32) -> BigUInt:
         y != 0, "biguint.arithmetics.floor_divide_by_uint32(): Division by zero"
     )
 
-    # Single-word dividend: O(1) exact result. This also guards the pointer
-    # hoisting below — for a one-word `x` with `x.words[0] < y` the quotient is
-    # 0, and without this path `result` would be built with zero words, making
-    # `result.words.unsafe_ptr()` operate on an empty buffer and returning a
-    # BigUInt that violates the non-empty-words invariant.
+    # Single-word dividend: O(1) exact result. This path is also what keeps the
+    # loop below well-formed -- for a one-word `x` with `x.words[0] < y` the
+    # quotient is 0, and without it `result` would be built with zero words,
+    # returning a `BigUInt` that violates the non-empty-words invariant.
     if len(x.words) == 1:
         return BigUInt.from_uint32_unsafe(x.words[0] // y)
 
@@ -2516,20 +2515,19 @@ def floor_divide_by_uint32(x: BigUInt, y: UInt32) -> BigUInt:
         result.words[len(result.words) - 1] = UInt32(dividend)
 
     # Process the rest of the words.
-    # Use raw data pointers for both buffers:
-    # this loop reads `x.words[i]` and writes `result.words[i]` every iteration,
-    # so the indexed form reloads two `List._data` fields per element.
-    # Using both pointers once removes those reloads and is a stable
-    # +4-8% at >=256 words.
-    # Safety: neither buffer is resized inside the loop,
-    # `x` is borrowed (owned by the caller) and `result` outlives the loop;
-    # `unsafe_ptr()` is origin-tied so both Lists stay alive while the pointers
-    # are used. Every index `i` is in `[0, len-2]`, provably in-bounds.
-    var x_ptr = x.words.unsafe_ptr()
-    var res_ptr = result.words.unsafe_ptr()
+    #
+    # This loop used to hoist raw pointers out of both buffers, on the
+    # reasoning that the indexed form reloads a `List` data field per element;
+    # it was recorded as a stable +4-8% at >=256 words. That no longer
+    # reproduces. Measured on this function on Mojo 1.0.0, at 256 / 1024 /
+    # 8192 / 65536 words, the two forms are within 1.6% of each other and the
+    # indexed form is marginally ahead at the largest sizes -- the loop runs at
+    # ~3.35 ns/word either way, which is the two 64-bit divides, and addressing
+    # never surfaces behind them. The indexed form is kept because it is also
+    # bounds-checked under `-D ASSERT=all`.
     for i in range(len(x.words) - 2, -1, -1):
-        dividend = carry * UInt64(BigUInt.BASE) + UInt64(x_ptr[unsafe_offset=i])
-        res_ptr[unsafe_offset=i] = UInt32(dividend // y_uint64)
+        dividend = carry * UInt64(BigUInt.BASE) + UInt64(x.words[i])
+        result.words[i] = UInt32(dividend // y_uint64)
         carry = dividend % y_uint64
 
     debug_assert[assert_mode="none"](

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -2320,7 +2320,6 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         return result
 
     @always_inline
-    @always_inline
     def assert_invariant(self, context: StaticString = "") -> None:
         """Checks the representation invariant documented on the struct.
 
@@ -2376,6 +2375,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         )
         return result^
 
+    @always_inline
     def remove_leading_empty_words(mut self):
         """Removes the most significant empty words of a BigUInt.
 

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -69,10 +69,29 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
     (1) words,
     (2) limbs,
     (3) base-billion digits.
+
+    Representation invariant:
+
+    Every `BigUInt` that leaves a function must satisfy all three of these.
+    Code may break them *inside* a function as long as it repairs them before
+    returning; `remove_leading_empty_words()` is the usual repair.
+
+    1. `words` is never empty. It always holds at least one word.
+    2. There are no leading zero words: `words[len(words) - 1] != 0`, unless
+       `len(words) == 1`. Zero is therefore exactly `[0]` and has no other
+       spelling, which is what lets `is_zero()` and comparison stay cheap.
+    3. Every word is a valid base-billion digit: `words[i] < BASE`.
+
+    Call `assert_invariant()` to check the first two. It is a `debug_assert`,
+    so it costs nothing in a normal build and fires in the test suite.
     """
 
     var words: List[UInt32]
-    """A list of UInt32 words representing the coefficient."""
+    """A list of UInt32 words representing the coefficient.
+
+    Little-endian: `words[0]` is the least significant base-billion digit.
+    Subject to the representation invariant documented on the struct.
+    """
 
     # ===------------------------------------------------------------------=== #
     # Constants
@@ -435,8 +454,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         # Now we can safely copy the words
         var result = BigUInt(unsafe_uninit_length=n_words)
         unsafe_memcpy(
-            dest=result.words._data,
-            src=value.words._data.unsafe_offset(start_index),
+            dest=result.words.unsafe_ptr(),
+            src=value.words.unsafe_ptr().unsafe_offset(start_index),
             count=n_words,
         )
         result.remove_leading_empty_words()
@@ -2028,7 +2047,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             "BigUInt should not contain leading zero words.",
         )  # 0 should have only one word by design
 
-        return len(self.words) == 1 and self.words._data[] == 0
+        return len(self.words) == 1 and self.words.unsafe_ptr()[] == 0
 
         # Yuhao ZHU:
         # The following code is commented out because BigUInt is designed
@@ -2267,6 +2286,29 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         return result
 
     @always_inline
+    @always_inline
+    def assert_invariant(self, context: StaticString = "") -> None:
+        """Checks the representation invariant documented on the struct.
+
+        A `debug_assert`, so it compiles away entirely unless the build sets
+        `-D ASSERT=all`. Call it at the end of any function that rebuilds
+        `words` by hand, and the test suite will catch a malformed result at
+        the point that produced it rather than wherever it later misbehaves.
+
+        Args:
+            context: Name of the calling function, shown if the check fires.
+        """
+        debug_assert(
+            len(self.words) > 0,
+            "BigUInt.assert_invariant(): empty words. ",
+            context,
+        )
+        debug_assert(
+            len(self.words) == 1 or self.words[len(self.words) - 1] != 0,
+            "BigUInt.assert_invariant(): leading zero word. ",
+            context,
+        )
+
     def remove_leading_empty_words(mut self):
         """Removes the most significant empty words of a BigUInt.
 
@@ -2297,6 +2339,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
                 else:
                     break
             self.words.shrink(len(self.words) - n_empty_words)
+            self.assert_invariant("remove_leading_empty_words")
 
     @always_inline
     def remove_trailing_digits_with_rounding(

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -210,6 +210,40 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         """
         self.words = List[UInt32](unsafe_uninit_length=unsafe_uninit_length)
 
+    def __init__(
+        out self, *, unsafe_uninit_length: Int, unsafe_uninit_capacity: Int
+    ):
+        """Creates an uninitialized BigUInt with a given length and capacity.
+
+        As `__init__(unsafe_uninit_length=)`, but reserves room for more words
+        than the value starts with. Use it when the result may grow by a known
+        amount -- a carry word out of an addition, say. Allocating the larger
+        buffer once is a single `malloc`; allocating the exact length and then
+        calling `reserve()` is two, plus a copy, and at these sizes an
+        allocation is most of what the operation costs.
+
+        Args:
+            unsafe_uninit_length: The length of the BigUInt.
+            unsafe_uninit_capacity: The capacity to allocate. Must be at least
+                `unsafe_uninit_length`.
+
+        Notes:
+
+        **UNSAFE**
+
+        The words are uninitialized and may hold any value, exactly as with
+        `__init__(unsafe_uninit_length=)`.
+        """
+        debug_assert(
+            unsafe_uninit_capacity >= unsafe_uninit_length,
+            "BigUInt.__init__(): capacity ",
+            unsafe_uninit_capacity,
+            " is below length ",
+            unsafe_uninit_length,
+        )
+        self.words = List[UInt32](capacity=unsafe_uninit_capacity)
+        self.words.resize(unsafe_uninit_length=unsafe_uninit_length)
+
     def __init__(out self, var words: List[UInt32]) raises:
         """Initializes a BigUInt from a list of UInt32 words.
         The BigUInt constructed in this way is guaranteed to be valid.
@@ -2308,6 +2342,39 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             "BigUInt.assert_invariant(): leading zero word. ",
             context,
         )
+
+    def copy_with_extra_capacity(self, extra_words: Int) -> Self:
+        """Copies `self`, leaving room for `extra_words` more words.
+
+        For the common shape "copy a value, then grow it by a bounded amount":
+        multiplying by a single word can add one word, adding can carry into
+        one. A plain `copy()` allocates exactly what it holds, so the growth
+        then reallocates and copies again -- two allocations where one would
+        do, and at small sizes an allocation is most of the operation.
+
+        Args:
+            extra_words: Number of words of spare capacity. Must not be
+                negative.
+
+        Returns:
+            A copy of `self` whose capacity is `len(words) + extra_words`.
+        """
+        debug_assert(
+            extra_words >= 0,
+            "BigUInt.copy_with_extra_capacity(): negative extra_words ",
+            extra_words,
+        )
+        var count = len(self.words)
+        var result = Self(
+            unsafe_uninit_length=count,
+            unsafe_uninit_capacity=count + extra_words,
+        )
+        unsafe_memcpy(
+            dest=result.words.unsafe_ptr(),
+            src=self.words.unsafe_ptr(),
+            count=count,
+        )
+        return result^
 
     def remove_leading_empty_words(mut self):
         """Removes the most significant empty words of a BigUInt.

--- a/src/decimo/biguint/exponential.mojo
+++ b/src/decimo/biguint/exponential.mojo
@@ -189,7 +189,7 @@ def sqrt_initial_guess(x: BigUInt) -> BigUInt:
         nsw = 999_999_999
 
     var result = BigUInt(unsafe_uninit_length=n_words + 1)
-    unsafe_memset_zero(ptr=result.words._data, count=n_words + 1)
+    unsafe_memset_zero(ptr=result.words.unsafe_ptr(), count=n_words + 1)
     # Boundary checks are not needed here because len(x.words) > 2
     result.words.unsafe_set(n_words, msw_sqrt)
     result.words.unsafe_set(

--- a/src/decimo/utility.mojo
+++ b/src/decimo/utility.mojo
@@ -56,3 +56,43 @@ def unsigned_counterpart[dtype: DType]() -> DType where dtype.is_integral():
             dtype.is_unsigned()
         ), "unsigned_counterpart: unexpected signed integral dtype"
         return dtype
+
+
+@always_inline
+def alias_as_immutable_source[
+    dtype: DType, //, o: Origin[mut=True]
+](pointer: Pointer[Scalar[dtype], o]) -> Pointer[
+    Scalar[dtype], ImmStaticOrigin
+]:
+    """Re-hands a mutable buffer pointer to a kernel as its own read source.
+
+    Several word kernels take one mutable destination and one or more
+    immutable sources, and are written so that the destination may be one of
+    those sources: each word is read before the same word is written, and the
+    tail copy is elided when the two pointers coincide. Handing the same
+    buffer to both parameters is still an exclusivity violation the compiler
+    rejects, because it cannot see that the overlap is exact rather than
+    partial.
+
+    This asserts precisely that, and nothing wider. The destination pointer
+    keeps its real origin and so keeps the buffer alive for the call; only the
+    duplicate handed in as a source loses its origin, and it never outlives the
+    call it is written into.
+
+    Do not use this to build a lasting pointer, to alias two *different*
+    buffers that happen to overlap, or on a kernel whose contract does not
+    already say the destination may alias a source.
+
+    Parameters:
+        dtype: The element dtype of the buffer.
+        o: The origin of the mutable pointer.
+
+    Args:
+        pointer: The mutable destination pointer to re-hand as a source.
+
+    Returns:
+        The same address, typed as an immutable pointer with no origin.
+    """
+    return pointer.unsafe_mut_cast[False]().unsafe_origin_cast[
+        ImmStaticOrigin
+    ]()


### PR DESCRIPTION
Small operands in this library are memory management, not arithmetic: ~4 ns of real work against ~33 ns per allocation, so an operation's speed is very nearly its allocation count. Several operations were allocating for nothing. Separately, all 63 uses of `List._data` — a private standard-library field — move to `unsafe_ptr()`.

All numbers are measured on my MacBook Pro M4 Pro.

## Small operations

Three causes, each worth watching for elsewhere:

- **`add()` / `subtract()` scaled both coefficients** to a common scale. But the target scale is by construction one of the two, so one call was always `multiply_by_power_of_ten(0)` — a whole coefficient allocated and memcpy'd to reproduce a value already in hand.
- **Allocate, then grow.** `add_slices_carry_select()` allocated exactly `n` words then reserved `n + 1`, which reallocates. `multiply()`'s single-word paths copied the other operand and then grew the copy.
- **A `debug_assert` building its message.** Three in the division paths used `"..." + String(n)`. Arguments are evaluated before the assert's `comptime if` can discard them, so those string allocations ran on every call *even with assertions compiled out*. This is why `floor_divide_by_power_of_ten_inplace()` cost 59 ns while allocating nothing of its own.

Minimum of seven rounds, before and after measured back to back in one session:

| | before | after | |
|---|---|---|---|
| `add` | 79.7 ns | 42.0 ns | 1.90× |
| `subtract` | 81.5 ns | 44.9 ns | 1.82× |
| `multiply` | 81.6 ns | 39.7 ns | 2.06× |
| `round` | 100.5 ns | 41.0 ns | 2.45× |
| `divide` | 249.9 ns | 144.7 ns | 1.73× |
| `BigUInt` add | 73.5 ns | 37.6 ns | 1.95× |

`from_string` (93 ns) is unchanged and was not investigated. `pi(100000)` is unchanged at 34 ms, as expected — nowhere near this regime.

The assert problem is an open upstream bug ([modular/modular#6439](https://github.com/modular/modular/issues/6439)), easy to reintroduce because the cost is invisible in a debug build and the code looks correct. `scripts/check_debug_assert_messages.py` scans for it as a pre-commit hook; the repository is clean, and the check is confirmed to fail on a reintroduced concatenation.

## `List._data` → `unsafe_ptr()`

`_data` is private to `List` and carries no origin, so we were both coupled to standard-library internals and giving up lifetime tracking — which had already cost one wrong-value bug on an append-built list. `unsafe_ptr()` returns the same address with an origin attached. No performance change.

Restoring origins made the compiler notice twelve call sites that hand one buffer to a word kernel as both destination and source. The aliasing is deliberate — those kernels read each word before writing it, and elide their tail copy when the pointers coincide — but not something the compiler can verify. The kernels now take a mutable destination and immutable sources, so ordinary callers are checked and the twelve deliberate ones say so through `alias_as_immutable_source()`.

## Representation invariant

Written down for the first time on `BigUInt` and `BigInt`: non-empty words, no leading zero word except the single-word zero, and for `BigUInt` every word below the base. `assert_invariant()` checks it as a `debug_assert` — free in a normal build, live in the test suite. `remove_leading_empty_words()` carries it as a post-condition, covering all thirty repair sites at once.

Noted while instrumenting: fifteen of the thirty guard sites never fire across the whole suite. That is test coverage, not proof, so none were removed.

## One correction

`floor_divide_by_uint32()` hoisted raw pointers with a comment recording a stable +4–8% at ≥256 words. That was measured honestly at the time but no longer reproduces on Mojo 1.0.0 — re-benched on the real function at 256/1024/8192/65536 words, the two forms are within 1.6% and the indexed form is marginally ahead at the largest sizes. The loop runs at ~3.35 ns/word either way, which is the two 64-bit divides. It is back on the indexed form, which is shorter and bounds-checked under `-D ASSERT=all`. The comment and plan entry are corrected rather than deleted, since a compiler change invalidating a real measurement is worth recording.

## Verification

Full package precompile clean, 1043 mojo tests and 58 CLI tests green, `pre-commit run --all-files` clean. The new invariant assert is mutation-verified: appending a zero word before `power_of_10()` returns makes it fire with the correct context.

## Still open

Recorded in `internal_notes`: `true_divide_general()` allocates a whole product to test exactness when the remainder answers it for free (`floor_divide_by_uint32()` already computes and discards it); `subtract_inplace()` copies a coefficient to flip a sign; `from_string` at ~93 ns is unexamined.