### PR TITLE
[biguint] Name the base

### DIFF
--- a/docs/internal/internal_notes.md
+++ b/docs/internal/internal_notes.md
@@ -957,7 +957,7 @@ in one session, three pairs:
   inlined the whole thing.
 - **Padding the dividend by digits instead of whole words.** Saves a quotient
   word -- 36 digits of padding where 30 will do -- and costs more than it
-  saves, because `multiply_by_power_of_billion` only prepends zero words while
+  saves, because `multiply_by_power_of_base` only prepends zero words while
   `multiply_by_power_of_ten` walks the whole number. 112.5 -> 117 ns.
 - **Hoisting the quotient estimator's invariants** out of the loop, so the
   divisor's top two words and the running pointer are read once rather than

--- a/docs/internal/todo.md
+++ b/docs/internal/todo.md
@@ -318,11 +318,11 @@ they are the first three.
    in the wide Comba path are not calls. Marginal cost measured against an
    empty loop, arm64:
 
-   | operation                        | ns   |
-   | -------------------------------- | ---- |
-   | `UInt64 // 10^9`, constant       | 0.06 |
-   | `UInt128 // 10^9`, constant      | 0.32 |
-   | `UInt128 // 10^18`, constant     | 0.40 |
+   | operation                                      | ns   |
+   | ---------------------------------------------- | ---- |
+   | `UInt64 // 10^9`, constant                     | 0.06 |
+   | `UInt128 // 10^9`, constant                    | 0.32 |
+   | `UInt128 // 10^18`, constant                   | 0.40 |
    | `UInt128 // 10^18`, Moller-Granlund reciprocal | 0.50 |
 
    The hand-rolled reciprocal is *slower* than what the compiler emits for a

--- a/docs/internal/todo.md
+++ b/docs/internal/todo.md
@@ -6,7 +6,7 @@ enhancement plans in `docs/plans/` carry the detail and the reasoning, and
 ranking. There were four such lists in August 2026 and they had already
 drifted apart, so there is now one.
 
-Last reviewed 2026-08-28 (fifth pass).
+Last reviewed 2026-08-28 (sixth pass).
 
 ## Goal, round one: met (20260826)
 
@@ -277,7 +277,7 @@ they are the first three.
    Knuth D over five quotient words, ~15 rounding and construction. Four
    things were tried and did not help -- calling Knuth D without the second
    dispatch (neutral; the compiler had already inlined it), padding by digits
-   instead of whole words (worse, because `multiply_by_power_of_billion` only
+   instead of whole words (worse, because `multiply_by_power_of_base` only
    prepends zero words while `multiply_by_power_of_ten` walks the number),
    hoisting the estimator's invariants (neutral), and raising the inline
    capacity past ten (no gain). What is left is either Newton reciprocal
@@ -309,8 +309,24 @@ they are the first three.
 8. **Audit the remaining `UInt128` and `UInt256` uses.** Three of the day's
    biggest wins were removing one. The rule: 128-bit as an *accumulator* is
    fine, because a 64x64 multiply is one instruction; 128-bit or 256-bit as
-   the *left side of a divide* is a call to a software helper, 20-40 ns.
-   Known remaining: `decimal128/`, `rational/`, `bigint/exponential.mojo`.
+   the *left side of a divide by a variable* is a call to a software helper,
+   20-40 ns. Known remaining: `decimal128/`, `rational/`,
+   `bigint/exponential.mojo`.
+
+   **A constant divisor is not in that class** (20260828). LLVM expands
+   `UInt128 // <constant>` into multiply-high, so the `% BASE` and `// BASE`
+   in the wide Comba path are not calls. Marginal cost measured against an
+   empty loop, arm64:
+
+   | operation                        | ns   |
+   | -------------------------------- | ---- |
+   | `UInt64 // 10^9`, constant       | 0.06 |
+   | `UInt128 // 10^9`, constant      | 0.32 |
+   | `UInt128 // 10^18`, constant     | 0.40 |
+   | `UInt128 // 10^18`, Moller-Granlund reciprocal | 0.50 |
+
+   The hand-rolled reciprocal is *slower* than what the compiler emits for a
+   constant. Reach for it only when the divisor is a runtime value.
 9. **Base 10^18 for `BigUInt`.** The honest answer to "why is division still
    behind": for a 28-digit value libmpdec holds two words and decimo holds
    four, so every loop runs twice as long. Nothing above closes that.
@@ -328,9 +344,40 @@ they are the first three.
 
    `BigUInt` is a smaller job -- base 10^18 is still a decimal base, so the
    conversion paths do not move -- but every partial product needs 128-bit
-   accumulation, and `% BASE` on a `UInt128` is the thing that was slow
-   everywhere else. Worth measuring on a prototype before believing either
-   way. The payoff is the four rows still behind CPython's `decimal`.
+   accumulation.
+
+   **Measured on a prototype (20260828), and it is worth doing.** The two
+   bases written the same way, same digit count, results cross-checked
+   against each other. Ratios are 10^9 over 10^18, so above 1.00 means the
+   wider word wins:
+
+   | digits | add   | Comba multiply | Knuth D multiply-subtract |
+   | ------ | ----- | -------------- | ------------------------- |
+   | 18     | 1.26x | 0.52x          | 0.71x                     |
+   | 36     | 1.19x | 0.94x          | 1.46x                     |
+   | 72-90  | 1.43x | 1.24x          | 1.58x                     |
+   | 288    | 1.15x | 2.41x          | 1.66x                     |
+   | 1 000  | 1.49x | 2.59x          | 1.67x                     |
+   | 9 000  | 1.48x | ~3.0x          | 1.69x                     |
+   | 10^6   | 1.10x | (transform)    | --                        |
+
+   Three things the numbers say that the model did not. Multiply passes 2x
+   and keeps going, because base 10^9's wide path pays a 128-bit *add* per
+   partial product and there are four times as many of them. Add gains from
+   the second pass of `_add_words_vectorized`, which walks every word
+   serially and so halves; the SIMD pass moves the same bytes either way, and
+   at 10^6 the whole thing is memory-bound and the gain falls to 1.10x. And
+   the wider word *loses* below about 36 digits, where the existing narrow
+   `UInt64` column path is strong and base 10^18 has no equivalent -- a
+   partial product is `10^36` and needs 128 bits whatever the operands are.
+   That is exactly where item 1 lives, so small-operand paths would have to
+   be written by hand rather than inherited.
+
+   Ground laid (20260828): `DIGITS_PER_WORD` now names the digits in a word,
+   `BASE` and friends are derived from it, `*_power_of_billion` is
+   `*_power_of_base`, and the `BigUInt` docstring lists what a base change
+   still has to rewrite by hand. A guard-digit count of 9 is not a word width
+   and was deliberately left alone.
 10. ~~**`floor_divide()` 2n-by-n scaling** in `BigUInt`~~ -- answered below.
 
 ## Blocked on the language

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -58,7 +58,8 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 | 20260223 | BigDecimal `multiply_inplace`, `add_inplace`, `subtract_inplace`                      |
 | 20260223 | `__iadd__` / `__isub__` / `__imul__` route through inplace versions                   |
 | 20260224 | Toom-3 helpers: `_exact_divide_by_{2,3,6}_inplace` (carry-based, no BigUInt division) |
-| 20260828 | `BigUInt.DIGITS_PER_WORD` names the digits in a word; `BASE`/`BASE_MAX`/`BASE_HALF` derived from it, `*_power_of_billion` renamed `*_power_of_base`. No behaviour change. |
+| 20260828 | `BigUInt.DIGITS_PER_WORD` names the digits in a word; `BASE`/`BASE_MAX`/`BASE_HALF`   |
+|          | derived from it, `*_power_of_billion` renamed `*_power_of_base`. No behaviour change. |
 
 ### 2.3 Performance — arithmetic & analytic ops
 

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -58,6 +58,7 @@ Dated by report file under `benches/bigdecimal/reports/`. Append-only.
 | 20260223 | BigDecimal `multiply_inplace`, `add_inplace`, `subtract_inplace`                      |
 | 20260223 | `__iadd__` / `__isub__` / `__imul__` route through inplace versions                   |
 | 20260224 | Toom-3 helpers: `_exact_divide_by_{2,3,6}_inplace` (carry-based, no BigUInt division) |
+| 20260828 | `BigUInt.DIGITS_PER_WORD` names the digits in a word; `BASE`/`BASE_MAX`/`BASE_HALF` derived from it, `*_power_of_billion` renamed `*_power_of_base`. No behaviour change. |
 
 ### 2.3 Performance — arithmetic & analytic ops
 
@@ -445,8 +446,8 @@ P1 — Add/Sub small-precision target (currently 4.7× / 3.6× py → target ≤
   (20260606).** The inplace variant
   [`multiply_by_power_of_ten_inplace`](../../src/decimo/biguint/arithmetics.mojo)
   exists, uses `words.resize(unsafe_uninit_length=...)` (O(1) capacity + memset,
-  not O(n) memcpy), and has a multiple-of-9 fast path that delegates to
-  `multiply_by_power_of_billion_inplace`. The hot mutating callers
+  not O(n) memcpy), and has a whole-word fast path that delegates to
+  `multiply_by_power_of_base_inplace`. The hot mutating callers
   (`add_inplace`, `subtract_inplace` in `bigdecimal/arithmetics.mojo`, plus the
   new `bigdecimal.mojo:2562` site) already use the inplace form. Residual: the
   public `add`/`subtract` at `bigdecimal/arithmetics.mojo:94-95,176-177` still
@@ -622,7 +623,7 @@ P3 — Divide all precisions (5× py → target ≤2×)
   vs general 303 ns (−73)** and noise elsewhere. Root cause: the
   digit-granular `multiply_by_power_of_ten(118)` buffer does a partial-
   word multiply + word insertion, costing more than the general path's
-  word-granular `multiply_by_power_of_billion` (a whole-word zero
+  word-granular `multiply_by_power_of_base` (a whole-word zero
   prepend) — buffer construction outweighs the few saved quotient
   digits, and high-precision non-terminating quotients (the typical
   "repeating decimal" divide) regress. No BigDecimal-level headroom.
@@ -1071,6 +1072,11 @@ some ops < 1.0×):
 |        |                                            |        |          | auto-cache blocked on Mojo                              |
 | T-L3   | AGM ln for p ≥ 1000 (T3g)                  | XL     | **WAIT** | gated on NTT (heavy per-iter sqrt);                     |
 |        |                                            |        |          | far-from-1 ln now addressed by T-3e                     |
+| T-B1   | Name the base: `DIGITS_PER_WORD`, derived  | M      | **DONE** | 20260828; groundwork for T-B2, no perf change           |
+|        | `BASE*`, `*_power_of_base`                 |        |          |                                                         |
+| T-B2   | Move `BigUInt` to base 10^18               | XL     | **OPEN** | prototype: add 1.1-1.5x, Comba 1.2-3.0x above           |
+|        |                                            |        |          | 72 digits, Knuth D 1.5-1.7x above 36; loses             |
+|        |                                            |        |          | below 36. See `docs/internal/todo.md` item 9            |
 | T-IO1  | `from_string` digit batching               | M      | **DONE** | batching already present;                               |
 |        |                                            |        |          | slice removed, 1.4×→1.2×                                |
 | T-IO2  | `to_string` right-aligned InlineArray      | M      | **DONE** | hybrid exact-size direct-write;                         |

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -564,8 +564,8 @@ def true_divide_fast(
     # We need to ensure that a * 10^s // b has more significant digits than p.
     # A quicker way is to add whole empty words to the dividend.
     # Let n_diff = len(a.words) - len(b.words).
-    # We add ceil(precision // 9) + 1 - n_diff empty words to the dividend.
-    # This ensures that we always have at least 9 extra digits in the dividend.
+    # We add ceil(precision / DIGITS_PER_WORD) + 1 - n_diff empty words to the
+    # dividend, which leaves at least one whole word of extra digits there.
 
     debug_assert[assert_mode="none"](
         minimum_precision > 0,
@@ -579,7 +579,9 @@ def true_divide_fast(
     # Early-return to avoid extra copies on the common (small-operand) path.
     comptime TRUNCATION_GUARD = 4
     var needed_divisor_words = (
-        math.ceildiv(minimum_precision, 9) + 2 + TRUNCATION_GUARD
+        math.ceildiv(minimum_precision, BigUInt.DIGITS_PER_WORD)
+        + 2
+        + TRUNCATION_GUARD
     )
 
     if len(y.coefficient.words) > needed_divisor_words:
@@ -589,16 +591,20 @@ def true_divide_fast(
 
     # --- Standard path (no truncation, no extra copies) ---
     var diff_n_words = len(x.coefficient.words) - len(y.coefficient.words)
-    var extra_words = math.ceildiv(minimum_precision, 9) + 2 - diff_n_words
-    var extra_digits = extra_words * 9
+    var extra_words = (
+        math.ceildiv(minimum_precision, BigUInt.DIGITS_PER_WORD)
+        + 2
+        - diff_n_words
+    )
+    var extra_digits = extra_words * BigUInt.DIGITS_PER_WORD
 
     var coef_x: BigUInt
     if extra_words > 0:
-        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_base(
             x.coefficient, extra_words
         )
     elif extra_words < 0:
-        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_base(
             x.coefficient, -extra_words
         )
     else:
@@ -626,30 +632,36 @@ def _true_divide_fast_truncated(
     )
     var y_only_remove = total_y_remove - common_remove
 
-    var y_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+    var y_coef_tr = biguint_arithmetics.floor_divide_by_power_of_base(
         y.coefficient, total_y_remove
     )
     var x_coef_tr: BigUInt
     if common_remove > 0:
-        x_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+        x_coef_tr = biguint_arithmetics.floor_divide_by_power_of_base(
             x.coefficient, common_remove
         )
     else:
         x_coef_tr = x.coefficient.copy()
 
-    var scale_adjust_digits = y_only_remove * 9
+    var scale_adjust_digits = y_only_remove * BigUInt.DIGITS_PER_WORD
 
     var diff_n_words = len(x_coef_tr.words) - len(y_coef_tr.words)
-    var extra_words = math.ceildiv(minimum_precision, 9) + 2 - diff_n_words
-    var extra_digits = extra_words * 9 + scale_adjust_digits
+    var extra_words = (
+        math.ceildiv(minimum_precision, BigUInt.DIGITS_PER_WORD)
+        + 2
+        - diff_n_words
+    )
+    var extra_digits = (
+        extra_words * BigUInt.DIGITS_PER_WORD + scale_adjust_digits
+    )
 
     var coef_x: BigUInt
     if extra_words > 0:
-        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_base(
             x_coef_tr, extra_words
         )
     elif extra_words < 0:
-        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_base(
             x_coef_tr, -extra_words
         )
     else:
@@ -714,7 +726,9 @@ def true_divide_general(
     # with relative error < 10^(-9*remaining_words), well below precision+guard.
     # Early-return to avoid extra copies on the common (small-operand) path.
     comptime TRUNCATION_GUARD = 4
-    var needed_divisor_words = math.ceildiv(precision, 9) + 2 + TRUNCATION_GUARD
+    var needed_divisor_words = (
+        math.ceildiv(precision, BigUInt.DIGITS_PER_WORD) + 2 + TRUNCATION_GUARD
+    )
 
     if len(y.coefficient.words) > needed_divisor_words:
         return _true_divide_general_truncated(
@@ -728,7 +742,8 @@ def true_divide_general(
     # padding with `s` zeros guarantees at least `dx + s - dy`. We want
     # `precision` significant digits plus a couple to round on.
     #
-    # This used to be counted in whole words -- `ceildiv(precision, 9) + 2`
+    # This used to be counted in whole words -- `ceildiv(precision,
+    # DIGITS_PER_WORD) + 2`
     # words, ignoring how many digits the operands actually had. At the default
     # precision of 28 that padded a four-word dividend out to ten words and
     # produced a 54-digit quotient to keep 28 of, roughly twice the necessary
@@ -738,9 +753,9 @@ def true_divide_general(
     var digits_x = x.coefficient.number_of_digits()
     var digits_y = y.coefficient.number_of_digits()
     var extra_words = math.ceildiv(
-        precision + GUARD_DIGITS - digits_x + digits_y, 9
+        precision + GUARD_DIGITS - digits_x + digits_y, BigUInt.DIGITS_PER_WORD
     )
-    var extra_digits = extra_words * 9
+    var extra_digits = extra_words * BigUInt.DIGITS_PER_WORD
 
     var coef_x: BigUInt
     # Whether anything was thrown away below the digits we kept. It is not the
@@ -748,7 +763,7 @@ def true_divide_general(
     # both -- see the sticky digit below.
     var dropped_something = False
     if extra_words > 0:
-        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_base(
             x.coefficient, extra_words
         )
     elif extra_words < 0:
@@ -761,7 +776,7 @@ def true_divide_general(
             if x.coefficient.words[index] != 0:
                 dropped_something = True
                 break
-        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_base(
             x.coefficient, -extra_words
         )
     else:
@@ -842,30 +857,34 @@ def _true_divide_general_truncated(
     )
     var y_only_remove = total_y_remove - common_remove
 
-    var y_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+    var y_coef_tr = biguint_arithmetics.floor_divide_by_power_of_base(
         y.coefficient, total_y_remove
     )
     var x_coef_tr: BigUInt
     if common_remove > 0:
-        x_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+        x_coef_tr = biguint_arithmetics.floor_divide_by_power_of_base(
             x.coefficient, common_remove
         )
     else:
         x_coef_tr = x.coefficient.copy()
 
-    var scale_adjust_digits = y_only_remove * 9
+    var scale_adjust_digits = y_only_remove * BigUInt.DIGITS_PER_WORD
 
     var diff_n_words = len(x_coef_tr.words) - len(y_coef_tr.words)
-    var extra_words = math.ceildiv(precision, 9) + 2 - diff_n_words
-    var extra_digits = extra_words * 9 + scale_adjust_digits
+    var extra_words = (
+        math.ceildiv(precision, BigUInt.DIGITS_PER_WORD) + 2 - diff_n_words
+    )
+    var extra_digits = (
+        extra_words * BigUInt.DIGITS_PER_WORD + scale_adjust_digits
+    )
 
     var coef_x: BigUInt
     if extra_words > 0:
-        coef_x = biguint_arithmetics.multiply_by_power_of_billion(
+        coef_x = biguint_arithmetics.multiply_by_power_of_base(
             x_coef_tr, extra_words
         )
     elif extra_words < 0:
-        coef_x = biguint_arithmetics.floor_divide_by_power_of_billion(
+        coef_x = biguint_arithmetics.floor_divide_by_power_of_base(
             x_coef_tr, -extra_words
         )
     else:
@@ -969,7 +988,9 @@ def true_divide_inexact(
     # --- Truncation optimization for oversized operands ---
     comptime TRUNCATION_GUARD = 4
     var needed_divisor_words = (
-        math.ceildiv(number_of_significant_digits, 9) + 2 + TRUNCATION_GUARD
+        math.ceildiv(number_of_significant_digits, BigUInt.DIGITS_PER_WORD)
+        + 2
+        + TRUNCATION_GUARD
     )
 
     if len(x2.coefficient.words) > needed_divisor_words:
@@ -1029,18 +1050,18 @@ def _true_divide_inexact_truncated(
     )
     var y_only_remove = total_y_remove - common_remove
 
-    var x2_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+    var x2_coef_tr = biguint_arithmetics.floor_divide_by_power_of_base(
         x2.coefficient, total_y_remove
     )
     var x1_coef_tr: BigUInt
     if common_remove > 0:
-        x1_coef_tr = biguint_arithmetics.floor_divide_by_power_of_billion(
+        x1_coef_tr = biguint_arithmetics.floor_divide_by_power_of_base(
             x1.coefficient, common_remove
         )
     else:
         x1_coef_tr = x1.coefficient.copy()
 
-    var scale_adjust_digits = y_only_remove * 9
+    var scale_adjust_digits = y_only_remove * BigUInt.DIGITS_PER_WORD
 
     var x1_digits = x1_coef_tr.number_of_digits()
     var x2_digits = x2_coef_tr.number_of_digits()

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -23,6 +23,7 @@ operation dunders, and other dunders that implement traits, as well as
 mathematical methods that do not implement a trait.
 """
 
+from std import math
 from std.memory import Pointer
 from std.python import PythonObject
 from std import testing
@@ -485,9 +486,9 @@ struct BigDecimal(
         var sign: Bool = _tuple[2]
 
         var number_of_digits = len(coef)
-        var number_of_words = number_of_digits // 9
-        if number_of_digits % 9 != 0:
-            number_of_words += 1
+        var number_of_words = math.ceildiv(
+            number_of_digits, BigUInt.DIGITS_PER_WORD
+        )
 
         # Packed straight into the coefficient. Filling a `List[UInt32]` and
         # handing it to `raw_words=` allocated once for the list and again to
@@ -496,8 +497,8 @@ struct BigDecimal(
 
         var end: Int = number_of_digits
         var start: Int
-        while end >= 9:
-            start = end - 9
+        while end >= BigUInt.DIGITS_PER_WORD:
+            start = end - BigUInt.DIGITS_PER_WORD
             var word: UInt32 = 0
             for i in range(start, end):
                 word = word * 10 + UInt32(coef[i])
@@ -605,17 +606,17 @@ struct BigDecimal(
                 )
 
             # Build coefficient from digits
-            var number_of_words = num_digits // 9
-            if num_digits % 9 != 0:
-                number_of_words += 1
+            var number_of_words = math.ceildiv(
+                num_digits, BigUInt.DIGITS_PER_WORD
+            )
 
             var coefficient_words = List[UInt32](capacity=number_of_words)
 
-            # Process digits from right to left, grouping into 9-digit words
+            # Process digits from right to left, one word of digits at a time
             var end = num_digits
             var start: Int
-            while end >= 9:
-                start = end - 9
+            while end >= BigUInt.DIGITS_PER_WORD:
+                start = end - BigUInt.DIGITS_PER_WORD
                 var word: UInt32 = 0
                 for i in range(start, end):
                     var digit = Int(py=digits_tuple[i])
@@ -2881,7 +2882,9 @@ struct BigDecimal(
             result += label + String(" ") * (col - label.byte_length())
             result += (
                 decimo_str.rjust(
-                    String(self.coefficient.words[i]), 9, fillchar="0"
+                    String(self.coefficient.words[i]),
+                    BigUInt.DIGITS_PER_WORD,
+                    fillchar="0",
                 )
                 + "\n"
             )
@@ -3021,9 +3024,11 @@ struct BigDecimal(
 
         var number_of_digits_to_remove = self.number_of_trailing_zeros()
 
-        var number_of_words_to_remove = number_of_digits_to_remove // 9
+        var number_of_words_to_remove = (
+            number_of_digits_to_remove // BigUInt.DIGITS_PER_WORD
+        )
         var number_of_remaining_digits_to_remove = (
-            number_of_digits_to_remove % 9
+            number_of_digits_to_remove % BigUInt.DIGITS_PER_WORD
         )
 
         var kept = len(self.coefficient.words) - number_of_words_to_remove
@@ -3082,7 +3087,10 @@ struct BigDecimal(
             last_non_zero_word = last_non_zero_word // UInt32(10)
             number_of_trailing_zeros += 1
 
-        return number_of_zero_words * 9 + number_of_trailing_zeros
+        return (
+            number_of_zero_words * BigUInt.DIGITS_PER_WORD
+            + number_of_trailing_zeros
+        )
 
     def number_of_digits(self) -> Int:
         """Returns the total number of digits in the coefficient.

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -2534,12 +2534,16 @@ def compute_ln2(working_precision: Int) raises -> BigDecimal:
 
     var max_terms = Int(Float64(working_precision) * 2.5) + 1
 
-    var number_of_words = working_precision // 9 + 1
+    var number_of_words = working_precision // BigUInt.DIGITS_PER_WORD + 1
     var words = List[UInt32](capacity=number_of_words)
+    # A word of all threes, whatever the word width: (BASE - 1) / 3.
+    comptime WORD_OF_THREES = UInt32(BigUInt.BASE_MAX // 3)
     for _ in range(number_of_words):
-        words.append(UInt32(333_333_333))
+        words.append(WORD_OF_THREES)
     var x = BigDecimal(
-        BigUInt(raw_words=words^), number_of_words * 9, False
+        BigUInt(raw_words=words^),
+        number_of_words * BigUInt.DIGITS_PER_WORD,
+        False,
     )  # x = 1/3
 
     var result = BigDecimal(BigUInt.zero(), 0, False)
@@ -2608,12 +2612,16 @@ def compute_ln1d25(precision: Int) raises -> BigDecimal:
     var working_precision = precision
     var max_terms = Int(Float64(working_precision) * 1.2) + 10
 
-    var number_of_words = working_precision // 9 + 1
+    var number_of_words = working_precision // BigUInt.DIGITS_PER_WORD + 1
     var words = List[UInt32](capacity=number_of_words)
+    # A word of all ones, whatever the word width: (BASE - 1) / 9.
+    comptime WORD_OF_ONES = UInt32(BigUInt.BASE_MAX // 9)
     for _ in range(number_of_words):
-        words.append(UInt32(111_111_111))
+        words.append(WORD_OF_ONES)
     var x = BigDecimal(
-        BigUInt(raw_words=words^), number_of_words * 9, False
+        BigUInt(raw_words=words^),
+        number_of_words * BigUInt.DIGITS_PER_WORD,
+        False,
     )  # x = 1/9
 
     var result = BigDecimal(BigUInt.zero(), 0, False)

--- a/src/decimo/bigfloat/bigfloat.mojo
+++ b/src/decimo/bigfloat/bigfloat.mojo
@@ -33,6 +33,7 @@ Design:
     - RAII: destructor frees MPFR handle via `mpfrw_clear`
 """
 
+from std import math
 from std.ffi import external_call, c_char
 from std.memory import Pointer
 
@@ -368,14 +369,12 @@ struct BigFloat(Comparable, Movable, Rootable, Writable):
         # e.g. digits "31415" with exp=1 → 3.1415 → scale = 5 - 1 = 4
         var scale = num_digits - exp
 
-        # 4. Pack ASCII bytes directly into base-10⁹ words
-        var number_of_words = num_digits // 9
-        if num_digits % 9 != 0:
-            number_of_words += 1
+        # 4. Pack ASCII bytes directly into the coefficient's words
+        var number_of_words = math.ceildiv(num_digits, BigUInt.DIGITS_PER_WORD)
         var words = List[UInt32](capacity=number_of_words)
         var end = num_digits
-        while end >= 9:
-            var start = end - 9
+        while end >= BigUInt.DIGITS_PER_WORD:
+            var start = end - BigUInt.DIGITS_PER_WORD
             var word: UInt32 = 0
             for j in range(start, end):
                 word = word * 10 + UInt32(

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -258,7 +258,7 @@ struct BigInt10(
 
         # Check if the words are valid
         for word in words:
-            if word > UInt32(999_999_999):
+            if word > UInt32(BigUInt.BASE_MAX):
                 raise ValueError(
                     message="Word value exceeds maximum value of 999_999_999",
                     function="BigInt10.__init__()",
@@ -780,7 +780,7 @@ struct BigInt10(
             other: The right-hand side operand.
         """
         # Optimize the case `i += 1`
-        if (self >= 0) and (other >= 0) and (other <= 999_999_999):
+        if (self >= 0) and (other >= 0) and (other <= BigUInt.BASE_MAX):
             biguint_arithmetics.add_by_uint32_inplace(
                 self.magnitude, UInt32(other)
             )
@@ -1221,7 +1221,9 @@ struct BigInt10(
             result += label + String(" ") * (col - label.byte_length())
             result += (
                 decimo_str.rjust(
-                    String(self.magnitude.words[i]), 9, fillchar="0"
+                    String(self.magnitude.words[i]),
+                    BigUInt.DIGITS_PER_WORD,
+                    fillchar="0",
                 )
                 + "\n"
             )

--- a/src/decimo/bigint10/bigint10.mojo
+++ b/src/decimo/bigint10/bigint10.mojo
@@ -260,7 +260,10 @@ struct BigInt10(
         for word in words:
             if word > UInt32(BigUInt.BASE_MAX):
                 raise ValueError(
-                    message="Word value exceeds maximum value of 999_999_999",
+                    message=(
+                        "Word value exceeds maximum value of "
+                        + String(BigUInt.BASE_MAX)
+                    ),
                     function="BigInt10.__init__()",
                 )
             else:
@@ -465,9 +468,7 @@ struct BigInt10(
 
         var value: Int128 = 0
         for i in range(len(self.magnitude.words)):
-            value += (
-                Int128(self.magnitude.words[i]) * Int128(1_000_000_000) ** i
-            )
+            value += Int128(self.magnitude.words[i]) * Int128(BigUInt.BASE) ** i
 
         value = -value if self.sign else value
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -4174,8 +4174,8 @@ def floor_divide_slices_two_by_one(
     debug_assert[assert_mode="none"](
         b.words[len(b.words) - 1] >= BigUInt.BASE_HALF,
         (
-            "floor_divide_slices_two_by_one(): b[-1] must be at least half"
-            " the\n base"
+            "floor_divide_slices_two_by_one(): b[-1] must be at least"
+            " half the base"
         ),
     )
 

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -116,7 +116,7 @@ the 112-word row, is the one being tuned for.
 # multiply_slices_toom3(x: BigUInt, y: BigUInt, bounds_x: Tuple[Int, Int], bounds_y: Tuple[Int, Int]) -> BigUInt
 # multiply_by_uint32_inplace(x: BigUInt, y: UInt32) -> None
 # multiply_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt
-# multiply_by_power_of_billion_inplace(mut x: BigUInt, n: Int)
+# multiply_by_power_of_base_inplace(mut x: BigUInt, n: Int)
 # exact_divide_by_2_inplace(mut x: BigUInt)
 # exact_divide_by_3_inplace(mut x: BigUInt)
 #
@@ -128,8 +128,8 @@ the 112-word row, is the one being tuned for.
 # floor_divide_by_2_inplace(x: BigUInt) -> None
 # floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt
 # floor_divide_by_power_of_ten_inplace(x: BigUInt, n: Int) -> None
-# floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt
-# floor_divide_by_power_of_billion_inplace(x: BigUInt, n: Int) -> None
+# floor_divide_by_power_of_base(x: BigUInt, n: Int) -> BigUInt
+# floor_divide_by_power_of_base_inplace(x: BigUInt, n: Int) -> None
 #
 # truncate_divide(x1: BigUInt, x2: BigUInt) -> BigUInt
 # ceil_divide(x1: BigUInt, x2: BigUInt) -> BigUInt
@@ -1791,7 +1791,7 @@ def multiply_slices_karatsuba(
         )
         # z2 = 0
 
-        z1.multiply_by_power_of_billion_inplace(m)
+        z1.multiply_by_power_of_base_inplace(m)
         z1 += z0
         z1.remove_leading_empty_words()
         return z1^
@@ -1819,7 +1819,7 @@ def multiply_slices_karatsuba(
             cutoff_number_of_words,
         )
         # z2 = 0
-        z1.multiply_by_power_of_billion_inplace(m)
+        z1.multiply_by_power_of_base_inplace(m)
         z1 += z0
         z1.remove_leading_empty_words()
         return z1^
@@ -1876,8 +1876,8 @@ def multiply_slices_karatsuba(
         subtract_no_check_inplace(z1, z0)
 
         # z2*9^(m * 2) + z1*9^m + z0
-        z2.multiply_by_power_of_billion_inplace(2 * m)
-        z1.multiply_by_power_of_billion_inplace(m)
+        z2.multiply_by_power_of_base_inplace(2 * m)
+        z1.multiply_by_power_of_base_inplace(m)
         z2 += z1
         z2 += z0
 
@@ -2321,8 +2321,8 @@ def multiply_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
         )
         return BigUInt.zero()  # Multiplying zero by anything is still zero
 
-    var number_of_zero_words = n // 9
-    var number_of_remaining_digits = n % 9
+    var number_of_zero_words = n // BigUInt.DIGITS_PER_WORD
+    var number_of_remaining_digits = n % BigUInt.DIGITS_PER_WORD
 
     var result = BigUInt(
         uninitialized_capacity=number_of_zero_words + len(x.words) + 1
@@ -2398,13 +2398,13 @@ def multiply_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
         # No need to add zeros, it will still be zero
         return
 
-    var number_of_zero_words = n // 9
-    var number_of_remaining_digits = n % 9
+    var number_of_zero_words = n // BigUInt.DIGITS_PER_WORD
+    var number_of_remaining_digits = n % BigUInt.DIGITS_PER_WORD
 
     # SPECIAL CASE: If n is a multiple of 9
     if number_of_remaining_digits == 0:
         # If n is a multiple of 9, we just need to add zero words
-        x.multiply_by_power_of_billion_inplace(number_of_zero_words)
+        x.multiply_by_power_of_base_inplace(number_of_zero_words)
         return
 
     else:  # number_of_remaining_digits > 0
@@ -2459,13 +2459,13 @@ def multiply_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
         return
 
 
-def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
-    """Multiplies a BigUInt by (10^9)^n (n >= 0).
-    This equals to adding 9n zeros (n words) to the end of the number.
+def multiply_by_power_of_base(x: BigUInt, n: Int) -> BigUInt:
+    """Multiplies a BigUInt by `BASE^n` (n >= 0).
+    This equals to appending `n` zero words to the end of the number.
 
     Args:
         x: The BigUInt value to multiply.
-        n: The power of 10^9 to multiply by. Should be non-negative.
+        n: The power of `BASE` to multiply by. Should be non-negative.
 
     Notes:
 
@@ -2477,7 +2477,7 @@ def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     """
     debug_assert[assert_mode="none"](
         n >= 0,
-        "multiply_by_power_of_billion(): n must be non-negative, got ",
+        "multiply_by_power_of_base(): n must be non-negative, got ",
         n,
     )
 
@@ -2487,7 +2487,7 @@ def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     if x.is_zero():
         debug_assert[assert_mode="none"](
             len(x.words) == 1,
-            "multiply_by_power_of_billion_inplace(): leading zero words",
+            "multiply_by_power_of_base_inplace(): leading zero words",
         )
         # If x is zero, we can just return
         # No need to add zeros, it will still be zero
@@ -2507,13 +2507,13 @@ def multiply_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     return res^
 
 
-def multiply_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
-    """Multiplies a BigUInt in-place by (10^9)^n (n >= 0).
-    This equals to adding 9n zeros (n words) to the end of the number.
+def multiply_by_power_of_base_inplace(mut x: BigUInt, n: Int):
+    """Multiplies a BigUInt in-place by `BASE^n` (n >= 0).
+    This equals to appending `n` zero words to the end of the number.
 
     Args:
         x: The BigUInt value to multiply.
-        n: The power of 10^9 to multiply by. Should be non-negative.
+        n: The power of `BASE` to multiply by. Should be non-negative.
 
     Notes:
 
@@ -2522,7 +2522,7 @@ def multiply_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
     """
     debug_assert[assert_mode="none"](
         n >= 0,
-        "multiply_by_power_of_billion_inplace(): n must be non-negative, got ",
+        "multiply_by_power_of_base_inplace(): n must be non-negative, got ",
         n,
     )
 
@@ -2532,7 +2532,7 @@ def multiply_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
     if x.is_zero():
         debug_assert[assert_mode="none"](
             len(x.words) == 1,
-            "multiply_by_power_of_billion_inplace(): leading zero words",
+            "multiply_by_power_of_base_inplace(): leading zero words",
         )
         # If x is zero, we can just return
         # No need to add zeros, it will still be zero
@@ -2599,11 +2599,12 @@ def exact_divide_by_3_inplace(mut x: BigUInt):
     `d` and `m` depend only on `word`, so the one division left is off the
     chain. See `bigint.arithmetics._exact_divide_by_3_inplace()`, which uses
     the same identity in base 2^32 — both bases happen to be `1 mod 3`.
+    Every power of ten is, so this survives a change of `DIGITS_PER_WORD`.
 
     Args:
         x: The `BigUInt` value to divide, modified in place.
     """
-    comptime BASE_OVER_THREE = UInt32(333_333_333)  # (10^9 - 1) / 3
+    comptime BASE_OVER_THREE = UInt32(BigUInt.BASE_MAX // 3)  # 333_333_333
 
     var carry = UInt32(0)  # 0, 1 or 2
     var xp = x.words.unsafe_ptr()
@@ -3443,8 +3444,8 @@ def floor_divide_by_2_inplace(mut x: BigUInt) -> None:
     x.remove_leading_empty_words()
 
 
-# TODO: If n % 9 == 0, the in-place version can be optimized by
-# delegating to `floor_divide_by_power_of_billion_inplace` directly.
+# TODO: If `n` is a multiple of `DIGITS_PER_WORD`, the in-place version can
+# be optimized by delegating to `floor_divide_by_power_of_base_inplace`.
 def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     """Floor divides a BigUInt by 10^n (n>=0).
     It is equal to removing the last n digits of the number.
@@ -3480,8 +3481,8 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     if n <= 0:
         return x.copy()
 
-    var word_shift = n // 9
-    var digit_shift = n % 9
+    var word_shift = n // BigUInt.DIGITS_PER_WORD
+    var digit_shift = n % BigUInt.DIGITS_PER_WORD
 
     # If we need to drop more words than exists, the result is zero.
     if word_shift >= len(x.words):
@@ -3489,7 +3490,7 @@ def floor_divide_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
 
     # Whole-word divide: delegate to the cheaper specialised path.
     if digit_shift == 0:
-        return floor_divide_by_power_of_billion(x, word_shift)
+        return floor_divide_by_power_of_base(x, word_shift)
 
     # Drop the low `word_shift` words via memcpy, then sub-word shift.
     var keep = len(x.words) - word_shift
@@ -3517,9 +3518,9 @@ def floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
 
     No-op when `n <= 0`. When `n` is at least the current decimal
     width, `x` becomes the canonical zero (a single word holding 0).
-    Delegates to `floor_divide_by_power_of_billion_inplace` whenever
-    `n` is a multiple of 9, which is the common case for word-aligned
-    truncation. In debug mode, asserts that `n` is non-negative.
+    Delegates to `floor_divide_by_power_of_base_inplace` whenever
+    `n` is a multiple of `DIGITS_PER_WORD`, which is the common case for
+    word-aligned truncation. In debug mode, asserts that `n` is non-negative.
     """
     debug_assert[assert_mode="none"](
         n >= 0,
@@ -3531,8 +3532,8 @@ def floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
     if n <= 0:
         return
 
-    var word_shift = n // 9
-    var digit_shift = n % 9
+    var word_shift = n // BigUInt.DIGITS_PER_WORD
+    var digit_shift = n % BigUInt.DIGITS_PER_WORD
 
     if word_shift >= len(x.words):
         x.words.shrink(0)
@@ -3540,7 +3541,7 @@ def floor_divide_by_power_of_ten_inplace(mut x: BigUInt, n: Int):
         return
 
     if digit_shift == 0:
-        floor_divide_by_power_of_billion_inplace(x, word_shift)
+        floor_divide_by_power_of_base_inplace(x, word_shift)
         return
 
     if word_shift > 0:
@@ -3628,8 +3629,8 @@ def floor_modulo_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     if n <= 0:
         return BigUInt.zero()
 
-    var word_count = n // 9
-    var digit_count = n % 9
+    var word_count = n // BigUInt.DIGITS_PER_WORD
+    var digit_count = n % BigUInt.DIGITS_PER_WORD
 
     # Asking for more digits than the number has keeps all of them.
     if word_count >= len(x.words):
@@ -3662,13 +3663,13 @@ def floor_modulo_by_power_of_ten(x: BigUInt, n: Int) -> BigUInt:
     return result^
 
 
-def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
-    """Floor divides a BigUInt by (10^9)^n (n>=0).
+def floor_divide_by_power_of_base(x: BigUInt, n: Int) -> BigUInt:
+    """Floor divides a BigUInt by `BASE^n` (n>=0).
     This function is equivalent to removing the last n words of the number.
 
     Args:
         x: The BigUInt value to divide.
-        n: The power of 10^9 to divide by. Should be non-negative.
+        n: The power of `BASE` to divide by. Should be non-negative.
 
     Returns:
         A new BigUInt containing the result of the division.
@@ -3682,7 +3683,7 @@ def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
     debug_assert[assert_mode="none"](
         n >= 0,
         (
-            "biguint.arithmetics.floor_divide_by_power_of_billion(): n must be"
+            "biguint.arithmetics.floor_divide_by_power_of_base(): n must be"
             " non-negative but got "
         ),
         n,
@@ -3705,14 +3706,14 @@ def floor_divide_by_power_of_billion(x: BigUInt, n: Int) -> BigUInt:
         return result^
 
 
-def floor_divide_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
-    """In-place version of `floor_divide_by_power_of_billion`. Drops
-    the `n` lowest base-10^9 words of `x` directly inside its `words`
+def floor_divide_by_power_of_base_inplace(mut x: BigUInt, n: Int):
+    """In-place version of `floor_divide_by_power_of_base`. Drops
+    the `n` lowest words of `x` directly inside its `words`
     storage, avoiding an allocation.
 
     Args:
         x: The BigUInt value to divide in place.
-        n: The power of 10^9 to divide by. Should be non-negative.
+        n: The power of `BASE` to divide by. Should be non-negative.
 
     Notes:
 
@@ -3724,7 +3725,7 @@ def floor_divide_by_power_of_billion_inplace(mut x: BigUInt, n: Int):
     debug_assert[assert_mode="none"](
         n >= 0,
         (
-            "biguint.arithmetics.floor_divide_by_power_of_billion_inplace(): n"
+            "biguint.arithmetics.floor_divide_by_power_of_base_inplace(): n"
             " must be non-negative but got "
         ),
         n,
@@ -3823,13 +3824,13 @@ def floor_divide_modulo_burnikel_ziegler(
     # STEP 1:
     # Normalize the divisor b to n words so that
     # (1) it is of the form j*2^k and
-    # (2) the most significant word is at least 500_000_000.
+    # (2) the most significant word is at least `BASE_HALF`.
 
     var normalized_b = b.copy()
     var normalized_a = a.copy()
     var ndigits_to_shift: Int
 
-    if normalized_b.words[len(normalized_b.words) - 1] < 500_000_000:
+    if normalized_b.words[len(normalized_b.words) - 1] < BigUInt.BASE_HALF:
         ndigits_to_shift = calculate_ndigits_for_normalization(
             normalized_b.words[len(normalized_b.words) - 1]
         )
@@ -3856,15 +3857,15 @@ def floor_divide_modulo_burnikel_ziegler(
 
     var n_digits_to_scale_up = (
         n - len(normalized_b.words)
-    ) * 9 + ndigits_to_shift
+    ) * BigUInt.DIGITS_PER_WORD + ndigits_to_shift
 
     multiply_by_power_of_ten_inplace(normalized_b, n_digits_to_scale_up)
     multiply_by_power_of_ten_inplace(normalized_a, n_digits_to_scale_up)
 
-    # The normalized_b is now 9 digits, but may still be smaller than 500_000_000.
+    # normalized_b is now one word wide, but may still be below BASE_HALF.
     var gap_ratio: UInt32
     if (
-        normalized_b.words[len(normalized_b.words) - 1] >= 500_000_000
+        normalized_b.words[len(normalized_b.words) - 1] >= BigUInt.BASE_HALF
     ):  # Already normalized
         gap_ratio = 1
     elif (
@@ -3885,10 +3886,10 @@ def floor_divide_modulo_burnikel_ziegler(
     var t = math.ceildiv(len(normalized_a.words), n)
     if len(normalized_a.words) == t * n:
         # If the number of words in the dividend is already a multiple of n
-        # We check if the most significant word is >= 500_000_000.
+        # We check if the most significant word is >= `BASE_HALF`.
         # If it is, we need to add one more block to the dividend.
         # This ensures that the most significant word of the dividend
-        # is smaller than 500_000_000.
+        # is smaller than `BASE_HALF`.
         # In this sense, the first 2-by-1 division will generate a quotient
         # of either 0 or 1, which would otherwise exceed n-word capacity.
         #
@@ -3897,7 +3898,7 @@ def floor_divide_modulo_burnikel_ziegler(
         # power of ten as the divisor, so it is usually the longer of the two:
         # `len(a.words)` and `t * n` could only agree by accident. `BigInt`'s
         # copy of this algorithm has always tested the normalized length.
-        if normalized_a.words[len(normalized_a.words) - 1] >= 500_000_000:
+        if normalized_a.words[len(normalized_a.words) - 1] >= BigUInt.BASE_HALF:
             t += 1
 
     var z = BigUInt.zero()  # Remainder of the division
@@ -3939,11 +3940,11 @@ def floor_divide_modulo_burnikel_ziegler(
                 remainder=next_z,
             )
             z = next_z^
-            multiply_by_power_of_billion_inplace(q, n)
+            multiply_by_power_of_base_inplace(q, n)
             q += q_i
 
         if i > 0:
-            multiply_by_power_of_billion_inplace(z, n)
+            multiply_by_power_of_base_inplace(z, n)
             # z = r + a[(i - 1) * n : i * n]
             add_by_slice_inplace(
                 z,
@@ -3996,7 +3997,7 @@ def floor_divide_two_by_one(
     Args:
         a: The dividend as a BigUInt.
         b: The divisor as a BigUInt. The most significant word must be at least
-           500_000_000.
+           `BASE_HALF`.
         n: The number of words in the divisor.
         cut_off: The minimum number of words for the recursive division.
 
@@ -4012,8 +4013,8 @@ def floor_divide_two_by_one(
         Error: If an arithmetic error occurs during computation.
     """
     debug_assert[assert_mode="none"](
-        b.words[len(b.words) - 1] >= 500_000_000,
-        "b[-1] must be at least 500_000_000",
+        b.words[len(b.words) - 1] >= BigUInt.BASE_HALF,
+        "b[-1] must be at least half the base",
     )
 
     if (n & 1 == 1) or (n <= cut_off):
@@ -4047,7 +4048,7 @@ def floor_divide_two_by_one(
         var s = _tuple[1].copy()  # s is the final remainder
 
         # q -> q1q0
-        multiply_by_power_of_billion_inplace(q, n // 2)
+        multiply_by_power_of_base_inplace(q, n // 2)
         q += q0
 
         return (q^, s^)
@@ -4093,19 +4094,19 @@ def floor_divide_three_by_two(
         a2a1 = a1.copy()
     else:
         a2a1 = a2.copy()
-        multiply_by_power_of_billion_inplace(a2a1, n)
+        multiply_by_power_of_base_inplace(a2a1, n)
         a2a1 += a1
     # TODO: Refine this when Mojo support move values of unpacked tuples
     var _tuple = floor_divide_two_by_one(a2a1, b1, n, cut_off)
     var q = _tuple[0].copy()
     ref c = _tuple[1]  # c is the carry
     var d = q * b0
-    multiply_by_power_of_billion_inplace(c, n)
+    multiply_by_power_of_base_inplace(c, n)
     var r = c + a0
 
     if r < d:
         var b = b1.copy()
-        multiply_by_power_of_billion_inplace(b, n)
+        multiply_by_power_of_base_inplace(b, n)
         b += b0
         q -= BigUInt.one()
         r += b
@@ -4139,7 +4140,7 @@ def floor_divide_slices_two_by_one(
         b: The divisor.
         bounds_a: The range of words in the dividend to consider [start, end).
         bounds_b: The range of words in the divisor to consider [start, end).
-            The most significant word must be at least 500_000_000.
+            The most significant word must be at least `BASE_HALF`.
         n: The number of words in the divisor.
         cut_off: The minimum number of words for the recursive division.
         remainder: Set to the remainder of the division on return.
@@ -4171,8 +4172,11 @@ def floor_divide_slices_two_by_one(
     """
 
     debug_assert[assert_mode="none"](
-        b.words[len(b.words) - 1] >= 500_000_000,
-        "floor_divide_slices_two_by_one(): b[-1] must be at least 500_000_000",
+        b.words[len(b.words) - 1] >= BigUInt.BASE_HALF,
+        (
+            "floor_divide_slices_two_by_one(): b[-1] must be at least half"
+            " the\n base"
+        ),
     )
 
     if (n & 1 == 1) or (n <= cut_off):
@@ -4215,7 +4219,7 @@ def floor_divide_slices_two_by_one(
             a, b, bounds_a1a3, bounds_b, n // 2, cut_off, r
         )  # q is q1
 
-        multiply_by_power_of_billion_inplace(r, n // 2)
+        multiply_by_power_of_base_inplace(r, n // 2)
         add_by_slice_inplace(r, a, (bounds_a[0], bounds_a[0] + n // 2))
         # The final remainder is written straight into the caller's argument.
         var q0 = floor_divide_slices_three_by_two(
@@ -4223,7 +4227,7 @@ def floor_divide_slices_two_by_one(
         )
 
         # q -> q1q0
-        multiply_by_power_of_billion_inplace(q, n // 2)
+        multiply_by_power_of_base_inplace(q, n // 2)
         q += q0
 
         return q^
@@ -4268,7 +4272,7 @@ def floor_divide_slices_three_by_two(
 
     # SPECIAL CASE:
     # If a2 is empty or zero, than it becomes a2a1 // b1b0
-    # Because the most significant word of b1 is at least 500_000_000,
+    # Because the most significant word of b1 is at least `BASE_HALF`,
     # The quotient will be either 1 or 0.
     if bounds_a[0] + 2 * n == bounds_a[1]:
         debug_assert[assert_mode="none"](
@@ -4297,7 +4301,7 @@ def floor_divide_slices_three_by_two(
     )
 
     var d = multiply_slices(q, b, (0, len(q.words)), bounds_b0)
-    multiply_by_power_of_billion_inplace(c, n)
+    multiply_by_power_of_base_inplace(c, n)
     var r = add_slices(c, a, bounds_x=(0, len(c.words)), bounds_y=bounds_a0)
 
     if r < d:
@@ -4328,7 +4332,7 @@ def floor_divide_three_by_two_uint32(
     a2: UInt32, a1: UInt32, a0: UInt32, b1: UInt32, b0: UInt32
 ) raises -> Tuple[UInt32, UInt32, UInt32]:
     """Divides a 3-word number by a 2-word number.
-    b1 must be at least 500_000_000.
+    b1 must be at least `BASE_HALF`.
 
     Args:
         a2: The most significant word of the dividend.
@@ -4344,16 +4348,16 @@ def floor_divide_three_by_two_uint32(
         (3) the least significant word of the remainder (as UInt32).
 
     Raises:
-        ValueError: If b1 < 500_000_000.
+        ValueError: If b1 < `BASE_HALF`.
 
     Notes:
 
     a = a2 * BASE^2 + a1 * BASE + a0.
     b = b1 * BASE + b0.
     """
-    if b1 < 500_000_000:
+    if b1 < BigUInt.BASE_HALF:
         raise ValueError(
-            message="b1 must be at least 500_000_000",
+            message="b1 must be at least half the base",
             function="floor_divide_three_by_two_uint32()",
         )
 
@@ -4405,12 +4409,12 @@ def floor_divide_four_by_two_uint32(
         (4) the least significant word of the remainder (as UInt32).
 
     Raises:
-        ValueError: If b1 < 500_000_000 or a >= b * 10^18.
+        ValueError: If b1 < `BASE_HALF` or a >= b * 10^18.
     """
 
-    if b1 < 500_000_000:
+    if b1 < BigUInt.BASE_HALF:
         raise ValueError(
-            message="b1 must be at least 500_000_000",
+            message="b1 must be at least half the base",
             function="floor_divide_four_by_two_uint32()",
         )
     if a3 > b1:
@@ -4843,58 +4847,62 @@ def normalize_carries_lt_4_bases(mut x: BigUInt):
     # Yuhao ZHU:
     # By construction, the words of x are in the range [0, BASE*4).
     # Thus, the carry can only be 0, 1, 2, or 3.
+    #
+    # Every bound below is `k * BASE - carry`, written that way so a change of
+    # base moves the whole table at once.
+    comptime BASE = UInt32(BigUInt.BASE)
     var carry: UInt32 = 0
     for ref word in x.words:
         if carry == 0:
-            if word <= UInt32(999_999_999):
+            if word <= (BASE - 1):
                 pass  # carry = 0
-            elif word <= UInt32(1_999_999_999):
-                word -= UInt32(1_000_000_000)
+            elif word <= (2 * BASE - 1):
+                word -= BASE
                 carry = 1
-            elif word <= UInt32(2_999_999_999):
-                word -= UInt32(2_000_000_000)
+            elif word <= (3 * BASE - 1):
+                word -= 2 * BASE
                 carry = 2
-            else:  # 3_000_000_000 <= word <= 3_999_999_996
-                word -= UInt32(3_000_000_000)
+            else:  # 3 * BASE <= word <= 4 * BASE - 4
+                word -= 3 * BASE
                 carry = 3
         elif carry == 1:
-            if word <= UInt32(999_999_998):
+            if word <= (BASE - 2):
                 word += 1
                 carry = 0
-            elif word <= UInt32(1_999_999_998):
-                word = word + 1 - UInt32(1_000_000_000)
+            elif word <= (2 * BASE - 2):
+                word = word + 1 - (BASE)
                 carry = 1
-            elif word <= UInt32(2_999_999_998):
-                word = word + 1 - UInt32(2_000_000_000)
+            elif word <= (3 * BASE - 2):
+                word = word + 1 - (2 * BASE)
                 carry = 2
-            else:  # 2_999_999_999 <= word <= 3_999_999_996
-                word = word + 1 - UInt32(3_000_000_000)
+            else:  # 3 * BASE - 1 <= word <= 4 * BASE - 4
+                word = word + 1 - (3 * BASE)
                 carry = 3
         elif carry == 2:
-            if word <= UInt32(999_999_997):
+            if word <= (BASE - 3):
                 word += 2
                 carry = 0
-            elif word <= UInt32(1_999_999_997):
-                word = word + 2 - UInt32(1_000_000_000)
+            elif word <= (2 * BASE - 3):
+                word = word + 2 - (BASE)
                 carry = 1
-            elif word <= UInt32(2_999_999_997):
-                word = word + 2 - UInt32(2_000_000_000)
+            elif word <= (3 * BASE - 3):
+                word = word + 2 - (2 * BASE)
                 carry = 2
-            else:  # 2_999_999_998 <= word <= 3_999_999_996
-                word = word + 2 - UInt32(3_000_000_000)
+            else:  # 3 * BASE - 2 <= word <= 4 * BASE - 4
+                word = word + 2 - (3 * BASE)
                 carry = 3
         else:  # carry == 3
-            if word <= UInt32(999_999_996):
+            if word <= (BASE - 4):
                 word += 3
                 carry = 0
-            elif word <= UInt32(1_999_999_996):
-                word = word + 3 - UInt32(1_000_000_000)
+            elif word <= (2 * BASE - 4):
+                word = word + 3 - (BASE)
                 carry = 1
-            elif word <= UInt32(2_999_999_996):
-                word = word + 3 - UInt32(2_000_000_000)
+            elif word <= (3 * BASE - 4):
+                word = word + 3 - (2 * BASE)
                 carry = 2
-            else:  # 2_999_999_997 <= word <= 3_999_999_996
-                word = word + 3 - UInt32(3_000_000_000)
+            else:  # 3 * BASE - 3 <= word <= 4 * BASE - 4
+                word = word + 3 - (3 * BASE)
                 carry = 3
     if carry > 0:
         # If there is still a carry, we need to add a new word
@@ -4924,19 +4932,19 @@ def power_of_10(n: Int) raises -> BigUInt:
         return BigUInt.one()
 
     # Handle small powers directly
-    if n < 9:
+    if n < BigUInt.DIGITS_PER_WORD:
         var value: UInt32 = 1
         for _ in range(n):
             value *= 10
         return BigUInt.from_uint32_unsafe(value)
 
-    # For larger powers, split into groups of 9 digits
-    var words = n // 9
-    var remainder = n % 9
+    # For larger powers, split into whole words
+    var words = n // BigUInt.DIGITS_PER_WORD
+    var remainder = n % BigUInt.DIGITS_PER_WORD
 
     var result = BigUInt.zero()
 
-    # Add leading zeros for full power-of-billion words
+    # Add leading zeros for the whole words below the highest one
     for _ in range(words):
         result.words.append(0)
 

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -103,6 +103,15 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
     - `ntt.mojo`'s packing, which cuts *two* words into three six-digit
       coefficients because two words are 18 digits.
     - `MAX_UINT64` and `MAX_UINT128` here, which spell their words out.
+    - Every place that packs a *pair* of words into one machine integer, and
+      so is bound to the width rather than to the base: the SIMD lane vectors
+      in `to_uint64()`, `to_uint128()` and `to_int128()` here, the same shape
+      in `biguint.exponential.sqrt()`, `to_uint64_with_2_words()` and
+      `to_uint128_with_2_words()` in `arithmetics.mojo`, and
+      `floor_divide_three_by_two_uint32()` and its four-by-two sibling. These
+      keep their literals on purpose: a word of 18 digits does not fit a
+      `UInt64` at all, so a named constant here would let the code compile and
+      silently overflow where a literal makes someone look.
 
     A guard-digit count is not a word width. `BUFFER_DIGITS`, `GUARD_DIGITS`
     and the like happen to be 9 and stay 9: they say how many extra digits to
@@ -413,7 +422,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
                     message=(
                         "Word value "
                         + String(word)
-                        + " exceeds maximum value of 999_999_999"
+                        + " exceeds maximum value of "
+                        + String(Self.BASE_MAX)
                     ),
                     function="BigUInt.from_list()",
                 )
@@ -477,7 +487,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
                     message=(
                         "Word value "
                         + String(word)
-                        + " exceeds maximum value of 999_999_999"
+                        + " exceeds maximum value of "
+                        + String(Self.BASE_MAX)
                     ),
                     function="BigUInt.from_words()",
                 )
@@ -994,7 +1005,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
 
         var value: Int128 = 0
         for i in range(len(self.words)):
-            value += Int128(self.words[i]) * Int128(1_000_000_000) ** i
+            value += Int128(self.words[i]) * Int128(Self.BASE) ** i
 
         if value > Int128(Int.MAX):
             raise OverflowError(

--- a/src/decimo/biguint/biguint.mojo
+++ b/src/decimo/biguint/biguint.mojo
@@ -23,6 +23,7 @@ operation dunders, and other dunders that implement traits, as well as
 mathematical methods that do not implement a trait.
 """
 
+from std import math
 from std.memory import Pointer, unsafe_memcpy, memcmp
 from std.sys import size_of
 
@@ -85,6 +86,27 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
 
     Call `assert_invariant()` to check the first two. It is a `debug_assert`,
     so it costs nothing in a normal build and fires in the test suite.
+
+    Changing the base:
+
+    `DIGITS_PER_WORD` is the one number that decides the representation, and
+    `BASE`, `BASE_MAX` and `BASE_HALF` are derived from it. Code that converts
+    between a digit position and a word position divides by it rather than by
+    a literal. What is *not* mechanical, and has to be rewritten by hand:
+
+    - `WordList`'s word type and `INLINE_WORDS`, and every `UInt32` in the
+      arithmetic kernels. A word of 18 digits does not fit a `UInt32`.
+    - The Comba accumulator in `multiply_slices_schoolbook`. Its narrow path
+      sums a column in `UInt64` because a partial product is below `10^18`;
+      a wider word puts the product itself past 64 bits.
+    - Knuth D's quotient estimate, for the same reason.
+    - `ntt.mojo`'s packing, which cuts *two* words into three six-digit
+      coefficients because two words are 18 digits.
+    - `MAX_UINT64` and `MAX_UINT128` here, which spell their words out.
+
+    A guard-digit count is not a word width. `BUFFER_DIGITS`, `GUARD_DIGITS`
+    and the like happen to be 9 and stay 9: they say how many extra digits to
+    carry, not how many fit in a word.
     """
 
     var words: WordList[]
@@ -99,11 +121,21 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
     # ===------------------------------------------------------------------=== #
 
     # TODO: Make these constants global, e.g., decimo.biguint.BASE
-    comptime BASE = 1_000_000_000
+    comptime DIGITS_PER_WORD = 9
+    """How many decimal digits one word holds.
+
+    The base is `10 ** DIGITS_PER_WORD`, so this is the one number that decides
+    the internal representation. Everything else here is derived from it, and
+    code that converts between a digit position and a word position divides by
+    it. Write `DIGITS_PER_WORD` rather than a literal `9` wherever the `9`
+    means "digits in a word" -- a literal reads the same as an unrelated nine
+    and does not move when the base does.
+    """
+    comptime BASE = 10**Self.DIGITS_PER_WORD
     """The base used for the BigUInt representation."""
-    comptime BASE_MAX = 999_999_999
+    comptime BASE_MAX = Self.BASE - 1
     """The maximum value of a single word in the BigUInt representation."""
-    comptime BASE_HALF = 500_000_000
+    comptime BASE_HALF = Self.BASE // 2
     """Half of the base used for the BigUInt representation."""
     comptime VECTOR_WIDTH = 4
     """The width of the SIMD vector used for arithmetic operations (128-bit)."""
@@ -376,7 +408,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
 
         # Check if the words are valid
         for word in words:
-            if word > UInt32(999_999_999):
+            if word > UInt32(Self.BASE_MAX):
                 raise OverflowError(
                     message=(
                         "Word value "
@@ -440,7 +472,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
 
         # Check if the words are valid
         for word in words:
-            if word > UInt32(999_999_999):
+            if word > UInt32(Self.BASE_MAX):
                 raise OverflowError(
                     message=(
                         "Word value "
@@ -680,9 +712,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             # decimal digits; 30103/100000 is log10(2) rounded up, which is
             # exact for every width in use (up to 256 bits).
             comptime decimal_digits = value_bits * 30103 // 100000 + 1
-            comptime number_of_words = (
-                decimal_digits + 8
-            ) // 9  # Trick to round up division by the 9 digits per word
+            comptime number_of_words = math.ceildiv(
+                decimal_digits, Self.DIGITS_PER_WORD
+            )
 
             var result = Self(uninitialized_capacity=number_of_words)
             var remainder: Scalar[dtype] = value
@@ -834,9 +866,9 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             scale = 0
 
         var number_of_digits = len(coef) - scale
-        var number_of_words = number_of_digits // 9
-        if number_of_digits % 9 != 0:
-            number_of_words += 1
+        var number_of_words = math.ceildiv(
+            number_of_digits, Self.DIGITS_PER_WORD
+        )
 
         var result_words = List[UInt32](capacity=number_of_words)
 
@@ -844,8 +876,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             # This is a true integer
             var end: Int = number_of_digits
             var start: Int
-            while end >= 9:
-                start = end - 9
+            while end >= Self.DIGITS_PER_WORD:
+                start = end - Self.DIGITS_PER_WORD
                 var word: UInt32 = 0
                 for i in range(start, end):
                     word = word * 10 + UInt32(coef[i])
@@ -861,8 +893,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
 
         else:  # scale < 0
             # This is a true integer with postive exponent
-            var number_of_trailing_zero_words = -scale // 9
-            var remaining_trailing_zero_digits = -scale % 9
+            var number_of_trailing_zero_words = -scale // Self.DIGITS_PER_WORD
+            var remaining_trailing_zero_digits = -scale % Self.DIGITS_PER_WORD
 
             for _ in range(number_of_trailing_zero_words):
                 result_words.append(UInt32(0))
@@ -874,8 +906,8 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
                 number_of_digits + scale + remaining_trailing_zero_digits
             )
             var start: Int
-            while end >= 9:
-                start = end - 9
+            while end >= Self.DIGITS_PER_WORD:
+                start = end - Self.DIGITS_PER_WORD
                 var word: UInt32 = 0
                 for i in range(start, end):
                     word = word * 10 + UInt32(coef[i])
@@ -1190,15 +1222,17 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             # or concatenation needed.
             result = String(self.words[0])
         elif n_words < _BUFFER_PATH_MIN_WORDS:
-            # Reserve the exact upper-bound capacity (9 digits per word) so the
-            # `+=` concatenations never reallocate.
-            result = String(capacity=9 * n_words)
+            # Reserve the exact upper-bound capacity -- one word of digits
+            # each -- so the `+=` concatenations never reallocate.
+            result = String(capacity=Self.DIGITS_PER_WORD * n_words)
             for i in range(n_words - 1, -1, -1):
                 if i == n_words - 1:
                     result += String(self.words[i])
                 else:
                     result += decimo_str.rjust(
-                        String(self.words[i]), width=9, fillchar="0"
+                        String(self.words[i]),
+                        width=Self.DIGITS_PER_WORD,
+                        fillchar="0",
                     )
         else:
             # Count the digits of the most-significant word (no zero-padding).
@@ -1219,7 +1253,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             # The tight `//10` loop beats a per-word `String(UInt32)` + memcpy
             # (benchmarked ~2x slower at 23 words due to per-word allocation
             # and call overhead).
-            var total_len = (n_words - 1) * 9 + msb_len
+            var total_len = (n_words - 1) * Self.DIGITS_PER_WORD + msb_len
             var buf = List[UInt8](unsafe_uninit_length=total_len)
             var p = buf.unsafe_ptr()
             var pos = total_len
@@ -1228,7 +1262,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             # written right-to-left.
             for ci in range(n_words - 1):
                 var val = self.words[ci]
-                for _ in range(9):
+                for _ in range(Self.DIGITS_PER_WORD):
                     pos -= 1
                     p[unsafe_offset=pos] = UInt8(val % 10) + 48
                     val //= 10
@@ -1944,14 +1978,14 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         return biguint_arithmetics.floor_divide_by_power_of_ten(self, n)
 
     @always_inline
-    def multiply_by_power_of_billion_inplace(mut self, n: Int):
-        """Multiplies a BigUInt in-place by (10^9)^n if n > 0.
-        This equals to adding 9n zeros (n words) to the end of the number.
+    def multiply_by_power_of_base_inplace(mut self, n: Int):
+        """Multiplies a BigUInt in-place by `BASE^n` if n > 0.
+        This equals to appending `n` zero words to the end of the number.
 
         Args:
-            n: The power of 10^9 to multiply by. Should be non-negative.
+            n: The power of `BASE` to multiply by. Should be non-negative.
         """
-        biguint_arithmetics.multiply_by_power_of_billion_inplace(self, n)
+        biguint_arithmetics.multiply_by_power_of_base_inplace(self, n)
 
     def power(self, exponent: Int) raises -> Self:
         """Returns the result of raising this number to the power of `exponent`.
@@ -2104,7 +2138,10 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             var label = "word " + String(i) + ":"
             result += label + String(" ") * (col - label.byte_length())
             result += (
-                decimo_str.rjust(String(self.words[i]), 9, fillchar="0") + "\n"
+                decimo_str.rjust(
+                    String(self.words[i]), Self.DIGITS_PER_WORD, fillchar="0"
+                )
+                + "\n"
             )
 
         result += sep_line
@@ -2310,10 +2347,10 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
                     + "Consider using a non-negative index."
                 ),
             )
-        if i >= len(self.words) * 9:
+        if i >= len(self.words) * Self.DIGITS_PER_WORD:
             return 0
-        var word_index = i // 9
-        var digit_index = i % 9
+        var word_index = i // Self.DIGITS_PER_WORD
+        var digit_index = i % Self.DIGITS_PER_WORD
         if word_index >= len(self.words):
             return 0
         var word = self.words[word_index]
@@ -2336,7 +2373,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
             debug_assert(len(self.words) == 1, "There are leading zero words.")
             return 1
 
-        var result: Int = (len(self.words) - 1) * 9
+        var result: Int = (len(self.words) - 1) * Self.DIGITS_PER_WORD
         var last_word = self.words[len(self.words) - 1]
         while last_word > 0:
             result += 1
@@ -2360,7 +2397,7 @@ struct BigUInt(Absable, Copyable, IntableRaising, Movable, Rootable, Writable):
         var result: Int = 0
         for i in range(len(self.words)):
             if self.words[i] == 0:
-                result += 9
+                result += Self.DIGITS_PER_WORD
             else:
                 var word = self.words[i]
                 while word % 10 == 0:

--- a/src/decimo/biguint/exponential.mojo
+++ b/src/decimo/biguint/exponential.mojo
@@ -188,8 +188,8 @@ def sqrt_initial_guess(x: BigUInt) -> BigUInt:
 
     # Some additional adjustments based on the next significant word
     nsw //= 2 * msw_sqrt  # The next word contributes to the guess
-    if nsw > 999_999_999:  # Cap at max word value
-        nsw = 999_999_999
+    if nsw > BigUInt.BASE_MAX:  # Cap at max word value
+        nsw = BigUInt.BASE_MAX
 
     var result = BigUInt(unsafe_uninit_length=n_words + 1)
     unsafe_memset_zero(ptr=result.words.unsafe_ptr(), count=n_words + 1)

--- a/src/decimo/biguint/ntt.mojo
+++ b/src/decimo/biguint/ntt.mojo
@@ -177,8 +177,8 @@ def unpack_coefficients(
     #
     # An individual convolution coefficient can be close to the prime, and
     # therefore an intermediate carry can reach ~10^13. The *final* carry
-    # cannot. The product is below `10^(9 * number_of_words)`, and
-    # `6 * number_of_coefficients` is within six digits of that exponent, so
+    # cannot. The product is below `10^(DIGITS_PER_WORD * number_of_words)`,
+    # and `6 * number_of_coefficients` is within six digits of that exponent, so
     # what is left after carrying through every coefficient cannot reach
     # `10^6`. The second slot exists only so the reconstruction loop can read
     # `k + 2` without a bounds test.


### PR DESCRIPTION
BigUInt had its base written out by hand all over the place. BASE, BASE_MAX and BASE_HALF were three separate literals. The number of digits in a word was a bare 9 in about sixty places. Four functions had "billion" in the name. None of that hurts while the base stays 10^9, but the BigInt move to base 2^64 in #286 found five bugs the type checker was perfectly happy with, and every one of them was a literal that described the old width and didn't move.

So this cleans it up before anything actually changes. DIGITS_PER_WORD is now the one number that decides the representation, BASE / BASE_MAX / BASE_HALF are derived from it, `*_power_of_billion` is `*_power_of_base`, and anything turning a digit position into a word position divides by the constant.

A few base dependencies were hiding. The all-threes and all-ones words that ln(2) and ln(1.25) build their 1/3 and 1/9 from are now (BASE - 1) / 3 and (BASE - 1) / 9, which is a repunit at any width. Toom-3's BASE_OVER_THREE is derived the same way. The twenty-four thresholds in normalize_carries_lt_4_bases are written as `k * BASE - carry` instead of magic numbers -- that table is the worst place in the file to get a base change wrong, because a wrong bound gives a wrong answer rather than a crash. And the 500_000_000 that appeared twenty-one times as the normalisation threshold is BASE_HALF.

Guard digits are deliberately untouched. BUFFER_DIGITS, GUARD_DIGITS and FACTORIAL_GUARD_DIGITS happen to be 9 and should stay 9 -- they say how many spare digits to carry, not how many fit in a word, so rewriting them to 18 would quietly double the guard. The rule throughout is to replace a 9 only where the base moving would make it wrong. Comments that say "base-10^9" are left alone too: they are true today, and the migration has to look at each one properly anyway.

The BigUInt docstring gains a short section on what a base change still has to do by hand -- WordList's word type and INLINE_WORDS, Comba's narrow column path, Knuth D's quotient estimate, ntt.mojo's packing (it cuts *two* words into three six-digit coefficients because two words are 18 digits), and the two MAX_UINT* constants that spell their words out.

Nothing behaves differently and nothing got slower. Parse at 9, 28 and 1000 digits lands inside the run-to-run spread on both sides. 1076 Mojo tests, 58 CLI tests and the Python binding tests pass. On top of that, 1392 randomised checks against CPython -- add, subtract, multiply, floor divide, modulo, square, at sizes that straddle the Karatsuba, Toom-3 and NTT cutoffs, and with divisors whose top word sits either side of BASE_HALF -- pass under both ASSERT=none and ASSERT=all. ln, log10, exp and sqrt agree with CPython to all 60 digits asked for.

This is groundwork for moving BigUInt to base 10^18, which measured well on a prototype: add 1.1-1.5x, Comba multiply 1.2-3.0x above 72 digits, Knuth D 1.5-1.7x above 36 digits, and a loss below 36 where the existing narrow UInt64 column path is strong. The table is in docs/internal/todo.md item 9, along with a correction: UInt128 divided by a *constant* is not a software helper, LLVM expands it, so the wide Comba path was never paying for a call.
