### PR TITLE
[biguint][bigint][bigdecimal][bigfloat] Fix Burnikel-Ziegler on three-part dividends + assert the schoolbook column bound

### DIFF
--- a/src/decimo/bigdecimal/constants.mojo
+++ b/src/decimo/bigdecimal/constants.mojo
@@ -119,19 +119,13 @@ def pi(precision: Int) raises -> BigDecimal:
             message="Precision must be non-negative", function="pi()"
         )
 
-    # TODO: When global variables are supported,
-    # we can check if we have a cached value for the requested precision.
-    # if precision <= 1024:
-    #     var result = PI_1024
-    #     result.round_to_precision_inplace(
-    #         precision,
-    #         RoundingMode.ROUND_HALF_EVEN,
-    #         remove_extra_digit_due_to_rounding=True,
-    #         fill_zeros_to_precision=False,
-    #     )
-    #     return result^
-
-    # Use Chudnovsky with binary splitting for maximum speed
+    # `PI_1024` could answer everything up to 1024 digits by rounding, and
+    # it has been verified to do so exactly: rounding the table to any
+    # precision up to its own gives what Chudnovsky computes, pinned in
+    # `test_the_1024_digit_table_matches_the_algorithm`. It is not used yet
+    # because Chudnovsky is already 0.05 ms at a thousand digits, so the win
+    # is small here; the same table-first idea matters for `ln(2)` and
+    # `ln(1.25)`, whose series are milliseconds, and it belongs in that change.
     return pi_chudnovsky_binary_split(precision)
 
 
@@ -478,7 +472,15 @@ def chudnovsky_split(a: Int, b: Int) raises -> _ChudnovskyPartialSum:
 
 
 def pi_machin(precision: Int) raises -> BigDecimal:
-    """Fallback π calculation using Machin's formula.
+    """π by Machin's formula, kept as an independent check on Chudnovsky.
+
+    Nothing in the library calls this. `pi()` always takes
+    `pi_chudnovsky_binary_split()`, which is 250 to 2500 times faster over
+    the first thousand digits. This is a different series with a different
+    convergence argument, and the two agreeing to a thousand digits checks
+    each other in a way no table can -- see
+    `test_the_two_pi_algorithms_agree_with_each_other`. Dead in the
+    dispatcher, alive in the tests; do not delete it as unused.
 
     Args:
         precision: The number of significant digits to compute.

--- a/src/decimo/bigfloat/bigfloat.mojo
+++ b/src/decimo/bigfloat/bigfloat.mojo
@@ -151,6 +151,11 @@ struct BigFloat(Comparable, Movable, Rootable, Writable):
             RuntimeError: If MPFR is not available or handle pool is exhausted.
             ConversionError: If the string is not a valid number.
         """
+        if precision < 0:
+            raise ValueError(
+                message="Precision must be non-negative",
+                function="BigFloat.__init__()",
+            )
         if not mpfrw_available():
             raise RuntimeError(
                 message=(
@@ -810,6 +815,11 @@ struct BigFloat(Comparable, Movable, Rootable, Writable):
         Raises:
             RuntimeError: If MPFR is not available or handle allocation fails.
         """
+        if precision < 0:
+            raise ValueError(
+                message="Precision must be non-negative",
+                function="BigFloat.pi()",
+            )
         if not mpfrw_available():
             raise RuntimeError(
                 message=(

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -2034,7 +2034,14 @@ def _divmod_burnikel_ziegler(
         t = 2
 
     if len_norm_a == t * n:
-        if len_norm_a > 0 and (norm_a[len_norm_a - 1] & 0x80000000) != 0:
+        # The top limb must be below half the base for the first quotient
+        # block to fit in `n` limbs; if it is not, the dividend gets one more
+        # block. The mask was `0x80000000`, bit 31, from the 32-bit limbs this
+        # was written for. At 64 bits that is a bit in the middle of the limb,
+        # so the test passed for values it should have caught -- a top limb of
+        # exactly `2^63` has bit 63 set and bit 31 clear -- and the padding it
+        # guards did not happen.
+        if len_norm_a > 0 and (norm_a[len_norm_a - 1] >> 63) != 0:
             t += 1
 
     # Pad norm_a to exactly t * n words.
@@ -2135,7 +2142,12 @@ def _bz_two_by_one_slices(
 
     # If a3 (top quarter, words n+half..2n) is zero or empty, the dividend
     # fits in 3*half words — use a single 3-by-2 division directly.
-    if len(a) <= n + half or _is_zero_slice(a[n + half :]):
+    # Strictly fewer than three parts only. Three parts, or four with a zero
+    # top, are below `b * B^n` but not below `b * B^half`, and need both
+    # quotient halves from the general path below -- see the same branch in
+    # `BigUInt`'s copy. There the shape raised; here it returned a wrong
+    # quotient.
+    if len(a) < n + half:
         return _bz_three_by_two_slices(a, b, half, cutoff, remainder)
 
     # First 3-by-2: divide a[half:] (= a3a2a1, 3*half words)

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -45,6 +45,24 @@ product, which makes the quadratic kernel fast enough that Karatsuba's extra
 Re-swept after the move to eighteen digits a word (20260828) and left where
 the base change put it: 128 is best or tied against 64 and 256 at every size
 from 32 to 1024 words.
+
+It has a hard ceiling as well as a measured optimum: the schoolbook kernel it
+hands off to sums a whole column of partial products in a `UInt128`, which
+holds `SCHOOLBOOK_MAX_COLUMN` of them. The kernel asserts it.
+"""
+
+comptime SCHOOLBOOK_MAX_COLUMN = Int(
+    UInt128.MAX // (UInt128(BigUInt.BASE_MAX) * UInt128(BigUInt.BASE_MAX))
+)
+"""The longest column the schoolbook accumulator can sum without overflow.
+
+A partial product is below `BASE^2`, and the product-scanning kernel adds a
+column of them -- one per word of the shorter operand -- into a `UInt128`
+before reducing. That is `2^128 / 10^36`, which is 340 words at eighteen
+digits a word. It was a number in a comment; it is a constant with an assert
+now, because 341 by 341 words of nines through the kernel gives a wrong
+product with no error, and `CUTOFF_KARATSUBA` is the only thing keeping the
+kernel below it. Derived, so it follows the base and the word type.
 """
 comptime CUTOFF_TOOM3 = 512
 """The cutoff number of words for using Toom-3 multiplication.
@@ -1589,6 +1607,20 @@ def multiply_slices_schoolbook(
     var n_words_x_slice = bounds_x[1] - bounds_x[0]
     var n_words_y_slice = bounds_y[1] - bounds_y[0]
 
+    # The column accumulator overflows past `SCHOOLBOOK_MAX_COLUMN` products,
+    # and a column is as long as the shorter operand. The dispatchers keep
+    # this far below the limit through `CUTOFF_KARATSUBA`; the assert is here
+    # so that raising the cutoff past the limit fails loudly rather than
+    # returning a wrong product.
+    debug_assert[assert_mode="none"](
+        min(n_words_x_slice, n_words_y_slice) <= SCHOOLBOOK_MAX_COLUMN,
+        "biguint.arithmetics.multiply_slices_schoolbook(): ",
+        "a column of more than SCHOOLBOOK_MAX_COLUMN partial products ",
+        "overflows the accumulator; the shorter operand has ",
+        min(n_words_x_slice, n_words_y_slice),
+        " words",
+    )
+
     # CASE: One of the operands is zero or one
     if n_words_x_slice == 1:
         var x_word = x.words[bounds_x[0]]
@@ -1629,8 +1661,8 @@ def multiply_slices_schoolbook(
     # result, because `(10^9)^2` fit; writing it that way at eighteen digits a
     # word wraps before the cast ever happens, and every type in the
     # expression is still correct. A column of `k` such products needs
-    # `k < 2^128 / 10^36`, about 340, and Karatsuba takes over long before a
-    # column is that long. The column is unrolled over four independent
+    # `k <= SCHOOLBOOK_MAX_COLUMN`, asserted at the entry above; Karatsuba
+    # takes over long before. The column is unrolled over four independent
     # accumulators because a single one serialises on the 128-bit add.
     comptime BASE = UInt128(BigUInt.BASE)
 
@@ -1647,9 +1679,9 @@ def multiply_slices_schoolbook(
     # of at most sixteen products in a `UInt64`, because a partial product was
     # below `(10^9)^2 < 10^18`. A partial product is now below `(10^18)^2`,
     # which is 120 bits, so every column needs the accumulator below whatever
-    # its length. That accumulator holds `2^128 / 10^36` -- about 340 --
-    # products before it can overflow, and Karatsuba takes over long before a
-    # column is that long.
+    # its length. That accumulator holds `SCHOOLBOOK_MAX_COLUMN` products
+    # before it can overflow, and Karatsuba takes over long before a column is
+    # that long.
 
     # `carry` is the part of the column sum at or above BASE, which belongs to
     # the next column. The last column leaves it holding the top word.

--- a/src/decimo/biguint/arithmetics.mojo
+++ b/src/decimo/biguint/arithmetics.mojo
@@ -3970,13 +3970,30 @@ def floor_divide_slices_two_by_one(
         var b_slice = BigUInt.from_slice(b, bounds_b)
         return floor_divide_modulo_schoolbook(a_slice, b_slice, remainder)
 
-    elif (bounds_a[0] + n + n // 2 >= bounds_a[1]) or a.is_zero_in_bounds(
-        bounds=(bounds_a[0] + n + n // 2, bounds_a[1])
-    ):
-        # If a3 is empty or zero
-        # We just need to use three-by-two division once: a2a1a0 // b1b0
-        # Note that the condition must be short-circuited to avoid slicing
-        # an empty BigUInt.
+    elif bounds_a[0] + n + n // 2 > bounds_a[1]:
+        # Fewer than three parts, so `a3` is absent and `a2` is short or
+        # absent too: `a < b * B^(n/2)`, and one three-by-two division at the
+        # half size is the whole job.
+        #
+        # This used to take any dividend of three parts or fewer, and any
+        # dividend whose fourth part was present but zero. Both are wrong for
+        # the same reason. `two_by_one` is a `2n`-by-`n` division whose
+        # quotient can be `n` words; `three_by_two(n/2)` produces `n/2`. A
+        # dividend of exactly three parts, or of four with a zero top, is
+        # still below `b * B^n` but not below `b * B^(n/2)`, so its quotient
+        # needs both halves -- `q1` from `a3a2a1` with `a3 = 0`, which the
+        # general branch handles, and `q0` from the remainder. Sent to a
+        # single `three_by_two` instead, the inner quotient came back a word
+        # too wide, the two-step correction could not bring it down, and
+        # `r -= d` raised.
+        #
+        # Every division of more than one block reaches this: the second
+        # block is the previous remainder, below `b`, shifted up by `n` and
+        # joined to the next block, which is four parts wide with a zero top
+        # more often than not. All nines, 48 words over a 32-word divisor
+        # whose top word is `BASE_HALF`, did it at
+        # `BURNIKEL_ZIEGLER_BLOCK_WORDS = 16`; 33 and 64 over 32 were fine,
+        # which is why nothing had hit it.
         return floor_divide_slices_three_by_two(
             a, b, bounds_a, bounds_b, n // 2, cut_off, remainder
         )

--- a/tests/bigdecimal/test_bigdecimal_constants.mojo
+++ b/tests/bigdecimal/test_bigdecimal_constants.mojo
@@ -9,6 +9,9 @@
 # systematic error in one cannot hide in the other.
 
 from std import testing
+
+import decimo.bigdecimal.constants as decimo_constants
+from decimo.rounding_mode import RoundingMode
 from decimo.bigdecimal.bigdecimal import BigDecimal
 
 
@@ -121,6 +124,55 @@ def test_pi_negative_precision_raises() raises:
     except:
         raised = True
     testing.assert_true(raised, "pi(-1) should raise")
+
+
+def test_the_two_pi_algorithms_agree_with_each_other() raises:
+    """Chudnovsky against Machin, which is what Machin is kept for.
+
+    `pi()` always takes Chudnovsky with binary splitting; `pi_machin()` has
+    no caller in the library. It stays because it is an independent
+    derivation -- a different series, a different convergence argument -- and
+    two algorithms that agree to a thousand digits check each other in a way
+    no table can. Chudnovsky is 250 to 2500 times faster over this range
+    (0.05 ms against 133 ms at 1000 digits), which is why it is the path and
+    Machin is the check. Machin is 7.5 s at 2000 digits, so this stops at
+    1000.
+    """
+    for precision in [1, 2, 7, 28, 100, 500, 1000]:
+        var chudnovsky = decimo_constants.pi_chudnovsky_binary_split(precision)
+        var machin = decimo_constants.pi_machin(precision)
+        testing.assert_true(
+            chudnovsky == machin,
+            "Chudnovsky and Machin disagree at "
+            + String(precision)
+            + " digits",
+        )
+
+
+def test_the_1024_digit_table_matches_the_algorithm() raises:
+    """`PI_1024` is a literal; a wrong digit in it would be wrong forever.
+
+    The table was checked once against an independent 1100-digit Machin
+    computation in Python's `decimal` and matched to its full length. This
+    pins the cheaper half of that: at every precision up to its own, rounding
+    the table gives exactly what `pi()` computes, so the table is a valid
+    cache should it ever be switched back on.
+    """
+    var table = materialize[decimo_constants.PI_1024]()
+    for precision in [1, 5, 28, 100, 500, 1000, 1023, 1024]:
+        var rounded = table.copy()
+        rounded.round_to_precision_inplace(
+            precision,
+            RoundingMode.half_even(),
+            remove_extra_digit_due_to_rounding=True,
+            fill_zeros_to_precision=False,
+        )
+        testing.assert_true(
+            rounded == BigDecimal.pi(precision),
+            "the table rounded to "
+            + String(precision)
+            + " digits differs from pi()",
+        )
 
 
 def main() raises:

--- a/tests/bigfloat/test_bigfloat.mojo
+++ b/tests/bigfloat/test_bigfloat.mojo
@@ -261,6 +261,40 @@ def test_rootable_conformance() raises:
     print("OK  sqrt(2) through Rootable =", result, " sqrt(-4) = nan")
 
 
+def test_negative_precision_is_refused() raises:
+    """A negative precision is an error here as it is on `BigDecimal`.
+
+    It used to be accepted and stored: `BigFloat("2", precision=-1)` gave a
+    value that printed and computed as if the precision were 1, because the
+    bit conversion floors at MPFR's minimum and `mpfr_get_str` treats a
+    non-positive digit count as "choose for me". No wrong result came of it,
+    but `BigDecimal.sqrt(-1)` raises and this did not. Zero stays accepted on
+    both types.
+    """
+    print("test_negative_precision_is_refused ... ", end="")
+    var raised = 0
+    try:
+        _ = BigFloat("2", precision=-1)
+    except e:
+        raised += 1
+    try:
+        _ = BigFloat(2, precision=-1)
+    except e:
+        raised += 1
+    try:
+        _ = BigFloat.pi(-1)
+    except e:
+        raised += 1
+    if raised != 3:
+        raise Error(
+            "FAIL test_negative_precision_is_refused: only "
+            + String(raised)
+            + " of 3 raised"
+        )
+    _ = BigFloat("2", precision=0)
+    print("OK")
+
+
 def main() raises:
     test_mpfr_available()
     test_construct_from_string()
@@ -277,4 +311,5 @@ def main() raises:
     test_neg_and_abs()
     test_high_precision_sqrt()
     test_rootable_conformance()
+    test_negative_precision_is_refused()
     print("\nAll BigFloat smoke tests completed.")

--- a/tests/bigint/test_bigint_burnikel_ziegler_shapes.mojo
+++ b/tests/bigint/test_bigint_burnikel_ziegler_shapes.mojo
@@ -1,0 +1,78 @@
+"""
+Pins two Burnikel-Ziegler shapes that `BigInt` got wrong.
+
+`BigInt` carries its own copy of the algorithm, in base 2^64, and it had the
+same short-dividend branch defect as `BigUInt`'s: a dividend of exactly three
+parts, or four with a zero top, was sent to a single `three_by_two` at half
+the block size, which can only produce half the quotient. `BigUInt` raised on
+the shape; this copy returned a wrong quotient and no error at all.
+
+It also had a second, independent defect in the block-count guard: the test
+for "top limb at or above half the base" used the mask `0x80000000` -- bit 31,
+left over from the 32-bit limbs this was written for. At 64 bits that is a bit
+in the middle of the limb, so a top limb of exactly `2^63` passed the test,
+the padding it guards did not happen, and under `ASSERT=all` the division
+crashed on an out-of-bounds write in the accumulator. Under `ASSERT=none` it
+would have written past the end silently.
+
+Both are pinned with the algebraic oracle `q * y + r == x`, `0 <= r < y`, on
+operands built just past `CUTOFF_BURNIKEL_ZIEGLER` so the transform path is
+the one taken.
+"""
+
+from std import testing
+from std.testing import assert_true
+
+from decimo.bigint.bigint import BigInt
+from decimo.bigint import arithmetics as bigint_arithmetics
+
+
+def assert_divmod_invariant(x: BigInt, y: BigInt, context: String) raises:
+    var q = x // y
+    var r = x % y
+    assert_true(
+        r >= BigInt("0") and r < y,
+        context + ": remainder is not in [0, y)",
+    )
+    assert_true(q * y + r == x, context + ": q * y + r != x")
+
+
+def all_ones(limbs: Int) raises -> BigInt:
+    return (BigInt("1") << (64 * limbs)) - BigInt("1")
+
+
+def top_limb_half_base(limbs: Int) raises -> BigInt:
+    """`2^63` in the top limb, all ones below it."""
+    var value = BigInt("1") << (64 * limbs - 1)
+    return value + all_ones(limbs - 1)
+
+
+def test_a_dividend_of_exactly_three_parts() raises:
+    """The shape the short-dividend branch used to mishandle."""
+    comptime CUTOFF = bigint_arithmetics.CUTOFF_BURNIKEL_ZIEGLER
+    for block in [CUTOFF, CUTOFF + 32]:
+        var divisor_limbs = 2 * block
+        var y = top_limb_half_base(divisor_limbs)
+        for extra in [block - 1, block, block + 1, 2 * block]:
+            var x = all_ones(divisor_limbs + extra)
+            assert_divmod_invariant(
+                x,
+                y,
+                String(divisor_limbs + extra)
+                + " over "
+                + String(divisor_limbs)
+                + " limbs",
+            )
+
+
+def test_a_top_limb_of_exactly_two_to_the_63() raises:
+    """Bit 63 set, bit 31 clear: the 32-bit mask missed this and did not pad."""
+    comptime CUTOFF = bigint_arithmetics.CUTOFF_BURNIKEL_ZIEGLER
+    var k = 2 * CUTOFF
+    var y = BigInt("1") << (64 * k - 1)
+    var x = (BigInt("1") << (64 * 2 * k - 1)) + (BigInt("1") << 20)
+    assert_divmod_invariant(x, y, "top limb 2^63, exact block multiple")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/biguint/test_biguint_burnikel_ziegler_shapes.mojo
+++ b/tests/biguint/test_biguint_burnikel_ziegler_shapes.mojo
@@ -1,0 +1,174 @@
+"""
+Sweeps Burnikel-Ziegler division over the operand shapes its recursion
+handles specially.
+
+The existing tests pin named cases against CPython, and the schoolbook and
+Burnikel-Ziegler paths against each other, on operands of hundreds to
+thousands of words. What the recursion has that the schoolbook does not is a
+set of shape decisions -- how the divisor is padded to the block grid, how the
+dividend is cut into blocks, when a short dividend takes one three-by-two
+division instead of two -- and none of the named cases sat on those seams.
+
+One of them was wrong. `two_by_one` sent any dividend of three parts or fewer,
+or of four parts with a zero top, to a single `three_by_two` at half the block
+size. A `2n`-by-`n` quotient can be `n` words; `three_by_two(n/2)` gives
+`n/2`. So a dividend below `b * B^n` but not below `b * B^(n/2)` -- which is
+what the second block of every multi-block division looks like, the previous
+remainder shifted up and joined to the next block -- came back a word too
+wide from the inner recursion, the two-step correction could not bring it
+down, and `r -= d` raised. All nines, 48 words over a 32-word divisor whose
+top word is `BASE_HALF`, at `BURNIKEL_ZIEGLER_BLOCK_WORDS = 16`. 33 and 64
+over 32 were fine, which is why nothing had ever hit it. `BigInt`'s copy of
+the algorithm had the same branch and returned a wrong quotient rather than
+raising.
+
+The oracle needs nothing external: `q * y + r == x` and `0 <= r < y`, with the
+multiply and the comparison well covered elsewhere. The shapes are chosen so
+the block count of the divisor, the number of dividend blocks and the size of
+the top block each take every residue that matters, and the digit patterns
+are the two that push the estimate hardest -- all nines, and a one followed
+by zeros with a one at the bottom.
+"""
+
+from std import testing
+from std.testing import assert_true
+
+from decimo.biguint.biguint import BigUInt
+from decimo.biguint import arithmetics as biguint_arithmetics
+
+
+def repeated(digit: String, count: Int) -> String:
+    var out = String("")
+    for _ in range(count):
+        out += digit
+    return out^
+
+
+def one_zeros_one(count: Int) -> String:
+    """`1 000...0 1` with `count` digits in total, at least two."""
+    return "1" + repeated("0", count - 2) + "1"
+
+
+def assert_divmod_invariant(x: BigUInt, y: BigUInt, context: String) raises:
+    var remainder = BigUInt()
+    var quotient = biguint_arithmetics.floor_divide_modulo(x, y, remainder)
+    assert_true(remainder < y, context + ": remainder is not below the divisor")
+    var back = quotient * y + remainder
+    assert_true(back == x, context + ": q * y + r != x")
+    # And the quotient-only entry agrees with the tuple form.
+    assert_true(
+        biguint_arithmetics.floor_divide(x, y) == quotient,
+        context + ": floor_divide disagrees with floor_divide_modulo",
+    )
+
+
+def test_every_residue_of_the_block_size() raises:
+    """Divisor word counts around each multiple of the block size.
+
+    The divisor is padded up to a multiple of `BURNIKEL_ZIEGLER_BLOCK_WORDS`,
+    so the count just below a multiple, at it, and just above are the three
+    that exercise different amounts of padding.
+    """
+    comptime BLOCK = biguint_arithmetics.BURNIKEL_ZIEGLER_BLOCK_WORDS
+    comptime DIGITS = BigUInt.DIGITS_PER_WORD
+    for multiple in [2, 3, 4]:
+        for offset in [-1, 0, 1]:
+            var divisor_words = multiple * BLOCK + offset
+            for dividend_extra in [1, BLOCK - 1, BLOCK, BLOCK + 1, 2 * BLOCK]:
+                var dividend_words = divisor_words + dividend_extra
+                var y = BigUInt(repeated("9", divisor_words * DIGITS))
+                var x = BigUInt(repeated("9", dividend_words * DIGITS))
+                assert_divmod_invariant(
+                    x,
+                    y,
+                    "nines, "
+                    + String(dividend_words)
+                    + " over "
+                    + String(divisor_words)
+                    + " words",
+                )
+                var y2 = BigUInt(one_zeros_one(divisor_words * DIGITS))
+                var x2 = BigUInt(one_zeros_one(dividend_words * DIGITS))
+                assert_divmod_invariant(
+                    x2,
+                    y2,
+                    "1..01, "
+                    + String(dividend_words)
+                    + " over "
+                    + String(divisor_words)
+                    + " words",
+                )
+
+
+def test_a_short_top_block_and_a_one_word_quotient() raises:
+    """The dividend's top block need not be full, and the quotient can be one.
+    """
+    comptime BLOCK = biguint_arithmetics.BURNIKEL_ZIEGLER_BLOCK_WORDS
+    comptime DIGITS = BigUInt.DIGITS_PER_WORD
+    var divisor_words = 3 * BLOCK
+    var y = BigUInt(repeated("9", divisor_words * DIGITS))
+    # Dividends from just over the divisor to a few digits into the next word.
+    for extra_digits in [1, 2, DIGITS - 1, DIGITS, DIGITS + 1, 2 * DIGITS]:
+        var x = BigUInt(repeated("9", divisor_words * DIGITS + extra_digits))
+        assert_divmod_invariant(
+            x, y, "short top block, " + String(extra_digits) + " extra digits"
+        )
+    # x == y, x == y + 1, x == 2y - 1: quotients of exactly 1, 1 and 1.
+    assert_divmod_invariant(y, y, "x == y")
+    assert_divmod_invariant(y + BigUInt.one(), y, "x == y + 1")
+    var twice_less_one = y + y - BigUInt.one()
+    assert_divmod_invariant(twice_less_one, y, "x == 2y - 1")
+    assert_divmod_invariant(y + y, y, "x == 2y")
+
+
+def test_a_dividend_of_exactly_three_parts() raises:
+    """The shape that took the wrong branch, and its neighbours.
+
+    A divisor whose top word is `BASE_HALF` -- the smallest a normalised
+    divisor can be -- against a dividend of all nines makes every inner
+    quotient as large as it can be. At `divisor + BLOCK` words the second
+    block is exactly three parts wide and used to be sent to a single
+    `three_by_two`; one word either side it was not, and passed.
+    """
+    comptime BLOCK = biguint_arithmetics.BURNIKEL_ZIEGLER_BLOCK_WORDS
+    comptime DIGITS = BigUInt.DIGITS_PER_WORD
+    var half = String(BigUInt.BASE_HALF)
+    for divisor_words in [2 * BLOCK, 2 * BLOCK + 1, 3 * BLOCK - 1]:
+        # top word exactly BASE_HALF, then nines
+        var y = BigUInt(half + repeated("9", (divisor_words - 1) * DIGITS))
+        for dividend_words in [
+            divisor_words + 1,
+            divisor_words + BLOCK,
+            2 * divisor_words,
+        ]:
+            var x = BigUInt(repeated("9", dividend_words * DIGITS))
+            assert_divmod_invariant(
+                x,
+                y,
+                "half-word divisor, "
+                + String(dividend_words)
+                + " over "
+                + String(divisor_words),
+            )
+
+
+def test_just_either_side_of_the_cutoff() raises:
+    """The hand-off to the schoolbook, at the word count that decides it."""
+    comptime CUTOFF = biguint_arithmetics.CUTOFF_BURNIKEL_ZIEGLER
+    comptime DIGITS = BigUInt.DIGITS_PER_WORD
+    for divisor_words in [CUTOFF - 1, CUTOFF, CUTOFF + 1]:
+        var y = BigUInt(repeated("9", divisor_words * DIGITS))
+        for dividend_words in [divisor_words + 1, 2 * divisor_words + 3]:
+            var x = BigUInt(one_zeros_one(dividend_words * DIGITS))
+            assert_divmod_invariant(
+                x,
+                y,
+                "cutoff, "
+                + String(dividend_words)
+                + " over "
+                + String(divisor_words),
+            )
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/biguint/test_biguint_ntt.mojo
+++ b/tests/biguint/test_biguint_ntt.mojo
@@ -17,19 +17,30 @@ def build_digits(count: Int, seed: Int) -> String:
     return out^
 
 
-def assert_matches_schoolbook(digits_x: Int, digits_y: Int) raises:
-    """Checks one product of the transform against schoolbook multiplication.
+def assert_matches_toom3(digits_x: Int, digits_y: Int) raises:
+    """Checks one product of the transform against Toom-3.
 
-    The reference is `multiply_slices_schoolbook()` and not the `multiply()`
+    The reference is `multiply_slices_toom3()` and not the `multiply()`
     dispatcher, because `multiply()` routes large operands to the transform.
     Comparing against it would compare the transform with itself.
+
+    It used to be `multiply_slices_schoolbook()`, which is wrong for this job:
+    the schoolbook kernel sums a column of partial products in a `UInt128`,
+    which holds `SCHOOLBOOK_MAX_COLUMN` of them -- 340 at eighteen digits a
+    word -- and a column is as long as the shorter operand. At 4072 words the
+    digit pattern below happened to keep the column under the limit; at 9000
+    it did not, and the reference was wrong while the transform was right.
+    The unequal-operand cases only passed because their short side was 9 or
+    100 words. The kernel asserts its limit now, which is how this surfaced.
+    Toom-3 is the algorithm the dispatcher uses just below the transform, so
+    it is the right thing to hold the transform against.
     """
     var x = BigUInt(build_digits(digits_x, 7))
     var y = BigUInt(build_digits(digits_y, 5))
     var bounds_x = (0, len(x.words))
     var bounds_y = (0, len(y.words))
 
-    var expected = biguint_arithmetics.multiply_slices_schoolbook(
+    var expected = biguint_arithmetics.multiply_slices_toom3(
         x, y, bounds_x, bounds_y
     )
     var got = biguint_ntt.multiply_slices_ntt(x, y, bounds_x, bounds_y)
@@ -37,7 +48,7 @@ def assert_matches_schoolbook(digits_x: Int, digits_y: Int) raises:
     testing.assert_equal(
         String(got),
         String(expected),
-        "transform disagrees with schoolbook for "
+        "transform disagrees with Toom-3 for "
         + String(digits_x)
         + " by "
         + String(digits_y)
@@ -45,15 +56,15 @@ def assert_matches_schoolbook(digits_x: Int, digits_y: Int) raises:
     )
 
 
-def test_ntt_matches_schoolbook_on_small_operands() raises:
+def test_ntt_matches_toom3_on_small_operands() raises:
     """The transform must be correct at every size, not only large ones."""
     var sizes = [1, 2, 3, 8, 9, 10, 17, 18, 19, 100]
     for i in range(len(sizes)):
         for j in range(len(sizes)):
-            assert_matches_schoolbook(sizes[i], sizes[j])
+            assert_matches_toom3(sizes[i], sizes[j])
 
 
-def test_ntt_matches_schoolbook_on_odd_word_counts() raises:
+def test_ntt_matches_toom3_on_odd_word_counts() raises:
     """A word pair packs into three coefficients, a lone word into two.
 
     Odd word counts take the second path, so they are worth their own case.
@@ -61,28 +72,27 @@ def test_ntt_matches_schoolbook_on_odd_word_counts() raises:
     var word_counts = [1, 3, 5, 7, 33, 101]
     for i in range(len(word_counts)):
         for j in range(len(word_counts)):
-            assert_matches_schoolbook(
+            assert_matches_toom3(
                 word_counts[i] * BigUInt.DIGITS_PER_WORD,
                 word_counts[j] * BigUInt.DIGITS_PER_WORD,
             )
 
 
-def test_ntt_matches_schoolbook_on_unequal_operands() raises:
+def test_ntt_matches_toom3_on_unequal_operands() raises:
     """Very unequal operand lengths exercise the shorter packing loop."""
-    assert_matches_schoolbook(9, 9000)
-    assert_matches_schoolbook(9000, 9)
-    assert_matches_schoolbook(100, 20000)
-    assert_matches_schoolbook(20000, 100)
+    assert_matches_toom3(9, 9000)
+    assert_matches_toom3(9000, 9)
+    assert_matches_toom3(100, 20000)
+    assert_matches_toom3(20000, 100)
 
 
-def test_ntt_matches_schoolbook_above_the_dispatch_cutoff() raises:
+def test_ntt_matches_toom3_above_the_dispatch_cutoff() raises:
     """Checks the sizes that `multiply()` actually routes to the transform.
 
     If the dispatcher stops choosing the transform at these sizes, this test
     would silently cover nothing, so the routing is asserted first.
     """
-    # Above the measured crossover, and no larger than the schoolbook
-    # reference can afford to check.
+    # Above the measured crossover.
     var word_counts = [4072, 5000]
     for i in range(len(word_counts)):
         var count = word_counts[i]
@@ -94,7 +104,7 @@ def test_ntt_matches_schoolbook_above_the_dispatch_cutoff() raises:
                 + " words through the transform, so this test covers nothing"
             ),
         )
-        assert_matches_schoolbook(
+        assert_matches_toom3(
             count * BigUInt.DIGITS_PER_WORD, count * BigUInt.DIGITS_PER_WORD
         )
 
@@ -170,7 +180,7 @@ def test_multiply_routes_large_operands_through_the_transform() raises:
     """End to end: `multiply()` must stay correct once it starts using it."""
     var x = BigUInt(build_digits(2100 * BigUInt.DIGITS_PER_WORD, 7))
     var y = BigUInt(build_digits(2100 * BigUInt.DIGITS_PER_WORD, 5))
-    var expected = biguint_arithmetics.multiply_slices_schoolbook(
+    var expected = biguint_arithmetics.multiply_slices_toom3(
         x, y, (0, len(x.words)), (0, len(y.words))
     )
     testing.assert_equal(

--- a/tests/biguint/test_biguint_toom3_shapes.mojo
+++ b/tests/biguint/test_biguint_toom3_shapes.mojo
@@ -1,0 +1,97 @@
+"""
+Sweeps `BigUInt`'s Toom-3 over the shapes its three-way split produces.
+
+`multiply_slices_toom3` had no test of its own. It splits the longer operand
+into three parts of `ceil(n_max / 3)` words and the shorter one into whatever
+that leaves -- possibly a short or empty top part -- and then interpolates
+through five products. The shapes worth sitting on are the residue of the
+longer length modulo three, and the shorter length at each part boundary.
+
+The oracle is the inverse operation: `(x * y) // y == x` with a zero
+remainder, through the public operators. `BigUInt`'s division is well covered
+and was itself just repaired on a shape this sweep would have hit.
+
+A note on what not to use as the oracle here. The first version of this sweep
+compared Toom-3 against `multiply_slices_schoolbook` called directly, and
+reported 24 mismatches. Every one was the schoolbook: its column accumulator
+holds `SCHOOLBOOK_MAX_COLUMN` products, 340 at eighteen digits a word, and a
+341-word column overflows it. The dispatchers never send it that much, so the
+kernel is correct in its contract -- and now asserts the contract -- but it
+cannot be called on operands wider than the cutoff and trusted.
+"""
+
+from std import testing
+from std.testing import assert_true
+
+from decimo.biguint.biguint import BigUInt
+from decimo.biguint import arithmetics as biguint_arithmetics
+
+
+def repeated(digit: String, count: Int) -> String:
+    var out = String("")
+    for _ in range(count):
+        out += digit
+    return out^
+
+
+def assert_product_inverts(x: BigUInt, y: BigUInt, context: String) raises:
+    var product = x * y
+    var remainder = BigUInt()
+    var back = biguint_arithmetics.floor_divide_modulo(product, y, remainder)
+    assert_true(remainder.is_zero(), context + ": (x * y) % y != 0")
+    assert_true(back == x, context + ": (x * y) // y != x")
+
+
+def test_every_residue_of_the_three_way_split() raises:
+    comptime KARATSUBA = biguint_arithmetics.CUTOFF_KARATSUBA
+    comptime TOOM3 = biguint_arithmetics.CUTOFF_TOOM3
+    comptime DIGITS = BigUInt.DIGITS_PER_WORD
+    for n_max in [TOOM3 + 1, TOOM3 + 2, TOOM3 + 3, 3 * 200, 3 * 200 + 1]:
+        var m = (n_max + 2) // 3
+        # The shorter operand at each boundary of the split: just past the
+        # Karatsuba guard, one part, two parts, and equal, each a word either
+        # side.
+        for n_min in [
+            KARATSUBA + 1,
+            m - 1,
+            m,
+            m + 1,
+            2 * m - 1,
+            2 * m,
+            2 * m + 1,
+            n_max,
+        ]:
+            if n_min > n_max or n_min <= KARATSUBA:
+                continue
+            for pattern in [String("9"), String("1")]:
+                var x = BigUInt(repeated(pattern, n_max * DIGITS))
+                var y = BigUInt(repeated(pattern, n_min * DIGITS))
+                assert_product_inverts(
+                    x,
+                    y,
+                    pattern
+                    + "s, "
+                    + String(n_max)
+                    + " by "
+                    + String(n_min)
+                    + " words",
+                )
+
+
+def test_the_schoolbook_column_bound_is_where_the_comment_said() raises:
+    """`SCHOOLBOOK_MAX_COLUMN` is derived; this pins that it derives to 340.
+
+    If the base or the word type changes, the bound moves and this test says
+    so -- which is the point, since the dispatch cutoffs would need looking at
+    too.
+    """
+    testing.assert_equal(biguint_arithmetics.SCHOOLBOOK_MAX_COLUMN, 340)
+    testing.assert_true(
+        biguint_arithmetics.CUTOFF_KARATSUBA
+        < biguint_arithmetics.SCHOOLBOOK_MAX_COLUMN,
+        "the Karatsuba cutoff must stay below the schoolbook column bound",
+    )
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Update the code base and fix bugs: the division and multiplication kernels, pi, and the MPFR wrapper. Two wrong-result bugs and one silent memory write, all in code the suite had never put on the seam.

Burnikel-Ziegler division was wrong in both copies, `BigUInt`'s in base 10^18 and `BigInt`'s in base 2^64. `two_by_one` sent a dividend of exactly three parts to a single half-size `three_by_two`, which can only produce half the quotient. That shape is the second block of every multi-block division, so it is common; it went unnoticed because the existing tests use hundreds to thousands of words and never sat at `divisor + block`. `BigUInt` raised on it. `BigInt` returned a wrong quotient with no error. `BigInt`'s copy had a second, independent defect in the same function: its block-count guard still masked the top limb with `0x80000000`, bit 31, from the 32-bit limbs it was written for, so a top limb of exactly 2^63 skipped the padding and wrote past the accumulator. Present at `origin/main`, not introduced by this branch.

The schoolbook multiply sums a column of partial products in a `UInt128`, which holds 340 of them at eighteen digits a word. That number lived in a comment. It is a derived constant with an assert now, and the assert immediately found a caller: the NTT tests used the schoolbook as their oracle at 4072 to 20000 words, past the bound. Against CPython the transform was right at every size and the schoolbook reference was wrong at 9000; the existing tests only passed because their short operand was 9 or 100 words, which is what sets the column length. The oracle is Toom-3 now.

Toom-3 itself is correct in both copies, checked on 80 `BigUInt` shapes and 48 `BigInt` shapes across every residue of the three-way split. `BigUInt`'s had no test of its own before this.

`pi()` is correct. Chudnovsky and Machin agree from 1 to 2000 digits and the 1024-digit table matches an independent reference to its full length. `pi_machin` has no caller and is kept on purpose as the one check on Chudnovsky that no table gives; its docstring now says so.

`BigFloat` accepted a negative precision and computed as if it were 1. It raises now, matching `BigDecimal`. The rest of the wrapper needs nothing: the bit conversion over-provisions, the C side caps and pins rounding, and `mpfr_get_str` rounds correctly with no second truncation.

Also examined and clean, with nothing to commit: `numerals` (101000 readings against an independent reference built from the module's own rules) and the trait conformances.

One method note from the Burnikel-Ziegler fix, since it cost several wrong turns: three diagnoses reasoned from reading the code were each wrong, and tracing every recursion level's bounds and inner-quotient width located it in one run. The commit message records the sequence.