### PR TITLE
[python] Tag the wheel for macOS 11 so pixi can install it

### DIFF
--- a/.github/workflows/release_python.yaml
+++ b/.github/workflows/release_python.yaml
@@ -101,7 +101,10 @@ jobs:
       fail-fast: false
       matrix:
         environment: [py313, py314]
-        # macos-14 is the oldest arm64 runner, matching the 14.0 target.
+        # macos-14 is the oldest arm64 runner GitHub has. The wheel says
+        # macOS 11, which is what the Mojo runtime libraries inside it say,
+        # so 11 to 13 is reasoned rather than tested: the probe below proves
+        # it loads on 14.
         # Linux (ubuntu-22.04, glibc 2.35, manylinux_2_35 via auditwheel) is
         # written in build_wheel.py but not yet verified; add it here when
         # it is.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -64,8 +64,10 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    `main` publishes `<version>.devYYYYMMDDHHMMSS`, the second only once the
    repository variable `PUBLISH_DEV` is set. The wheel takes its version
    from the library's, so `pip show decimo` and the CLI's `--version` say
-   the same thing, and a tag that disagrees with `pixi.toml` stops the run. The extension is linked for macOS 14 and the
-   wheel is tagged so, instead of for the build machine's version. The Linux
+   the same thing, and a tag that disagrees with `pixi.toml` stops the run. The extension is linked for macOS 11 -- what the Mojo
+   runtime libraries in the wheel are built for -- and the wheel is tagged so,
+   instead of for the build machine's version, which no other machine accepts
+   and which pixi, resolving against macOS 13, refuses outright. The Linux
    path (`auditwheel`, `manylinux_2_35`) is written in `build_wheel.py` but
    not yet verified, so it is not in the matrix.
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -184,15 +184,21 @@ python = "3.14.*"
 
 # The tasks call `mojo` and `python` directly rather than through `pixi run`,
 # which would step back into the default environment and its interpreter.
-# `MACOSX_DEPLOYMENT_TARGET` makes the extension load on macOS 14 and later
-# rather than only on the version of the machine that built it; the wheel is
-# tagged to match (see `hatch_build.py`). Linux ignores it.
+# `MACOSX_DEPLOYMENT_TARGET` decides the oldest macOS the wheel says it runs
+# on, and the wheel is tagged to match (see `hatch_build.py`); without it the
+# tag is the build machine's own version and the wheel is refused everywhere
+# older. Eleven, because that is what the three Mojo runtime libraries the
+# wheel carries are built for (`otool -l` says `minos 11.0`), because the
+# extension itself calls nothing newer than `dlopen` and `stat`, and because
+# macOS 11 is where Apple silicon starts. A higher floor is not free: pixi
+# resolves PyPI wheels against macOS 13 by default, so a wheel tagged 14
+# cannot be installed by a pixi project at all. Linux ignores this.
 [feature.publish.tasks.release]
 cmd = """mojo precompile src/decimo -o tests/decimo.mojoc \
 && mojo build python/decimo_module.mojo --emit shared-lib -I tests -o python/src/decimo/_decimo.so \
 && python python/tests/test_decimo.py \
 && python python/build_wheel.py"""
-env = { MACOSX_DEPLOYMENT_TARGET = "14.0" }
+env = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 [environments]
 benchdoc = ["benchdoc"]

--- a/python/README.md
+++ b/python/README.md
@@ -9,7 +9,7 @@
 > ⚠️ **Development release.** The API is settled enough to use, but the
 > versions carry a timestamp: `0.14.0.devYYYYMMDDHHMMSS`, where `0.14.0` is
 > the version of the Mojo library the wheel packages. Wheels: macOS arm64
-> (14 and later), CPython 3.13 and 3.14. Everywhere else, build from source.
+> (11 and later), CPython 3.13 and 3.14. Everywhere else, build from source.
 
 Change one import and your program keeps working:
 
@@ -118,7 +118,7 @@ written against `decimal` still catch.
 pip install decimo
 ```
 
-Wheels are built for macOS arm64 (macOS 14 and later), for CPython 3.13 and
+Wheels are built for macOS arm64 (macOS 11 and later), for CPython 3.13 and
 3.14. On anything else -- Linux included, until its build is verified --
 build from source with [pixi](https://pixi.sh):
 

--- a/python/hatch_build.py
+++ b/python/hatch_build.py
@@ -8,7 +8,7 @@ happily install a macOS arm64 binary on a Linux box.
 The platform part is spelled out rather than inferred. Inferred, it is the
 version of macOS the build ran on -- `macosx_26_0` on a current machine --
 and pip then refuses the wheel on anything older. The extension is linked
-for `MACOSX_DEPLOYMENT_TARGET` (14.0, set by the `release` task), so that is
+for `MACOSX_DEPLOYMENT_TARGET` (11.0, set by the `release` task), so that is
 what the tag says. On Linux the tag is `linux_x86_64` here and `auditwheel`
 replaces it with the `manylinux` one after the build.
 """


### PR DESCRIPTION
pixi resolves PyPI wheels against macOS 13 by default, so our `macosx_14_0_arm64` wheel cannot be installed from a pixi project at all.

Fourteen was our floor, not the toolchain's: the Mojo runtime libraries in the wheel are built for macOS 11, and the extension links only libSystem. So the release task now targets 11.0 and the tag follows.

GitHub's oldest arm64 runner is macos-14, so 11 to 13 is reasoned rather than tested. Built locally and installed into a clean venv.