### PR TITLE
[ci] Bring the actions up to their current majors

### DIFF
--- a/.github/actions/setup-decimo/action.yml
+++ b/.github/actions/setup-decimo/action.yml
@@ -4,7 +4,7 @@ description: Install pixi (cached), activate the Mojo environment, restore the M
 runs:
   using: composite
   steps:
-    - uses: prefix-dev/setup-pixi@v0.9.5
+    - uses: prefix-dev/setup-pixi@v0.10.2
       with:
         activate-environment: true
 
@@ -21,7 +21,7 @@ runs:
     # Keyed per job. Each test job compiles a different set of test files,
     # and a shared key would have every job racing to save the same entry.
     - name: Restore the Mojo compilation cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: .pixi/envs/default/share/max/cache/.mojo_cache
         key: mojo-cache-${{ runner.os }}-${{ hashFiles('pixi.lock') }}-${{ github.job }}-${{ github.sha }}
@@ -57,7 +57,7 @@ runs:
         echo "we cache        : $PWD/.pixi/envs/default/share/max/cache/.mojo_cache"
 
     - name: Download decimo.mojoc artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: decimo-mojoc
         path: .

--- a/.github/workflows/release_cli.yaml
+++ b/.github/workflows/release_cli.yaml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-14          # Apple Silicon (arm64)
             target: darwin-arm64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install pixi
         run: curl -fsSL https://pixi.sh/install.sh | sh
@@ -228,7 +228,7 @@ jobs:
           shasum -a 256 "dist/${PKG}.tar.gz" | tee "dist/${PKG}.tar.gz.sha256"
 
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: decimo-${{ inputs.version }}-${{ matrix.target }}
           path: dist/decimo-${{ inputs.version }}-${{ matrix.target }}.tar.gz*

--- a/.github/workflows/release_python.yaml
+++ b/.github/workflows/release_python.yaml
@@ -70,7 +70,7 @@ jobs:
     outputs:
       version: ${{ steps.pick.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - id: pick
         run: |
           library=$(sed -n 's/^version = "\(.*\)"/\1/p' pixi.toml | head -1)
@@ -110,9 +110,9 @@ jobs:
         # it is.
         os: [macos-14]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: true
           environments: ${{ matrix.environment }}
@@ -155,7 +155,7 @@ jobs:
           print('decimo', decimo.__version__)
           "
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheel-${{ matrix.environment }}-${{ matrix.os }}
           path: python/dist/*.whl
@@ -177,7 +177,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheel-*
           path: dist

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -18,7 +18,7 @@ defaults:
 # `decimo.mojoc` build all run once. The package is uploaded as an
 # artifact so downstream test jobs can download it instead of rebuilding
 # (saves ~30s of `mojo precompile` per job × 10 jobs). The pixi environment
-# is cached by `prefix-dev/setup-pixi@v0.9.5`, so test jobs no longer
+# is cached by `prefix-dev/setup-pixi@v0.10.2`, so test jobs no longer
 # `curl | sh` and `pixi install` from scratch.
 
 jobs:
@@ -28,8 +28,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@v7
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: true
           activate-environment: true
@@ -37,7 +37,7 @@ jobs:
       # restored after `setup-pixi`. This job compiles the package itself, so
       # it wants its own entry rather than a test job's.
       - name: Restore the Mojo compilation cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .pixi/envs/default/share/max/cache/.mojo_cache
           key: mojo-cache-${{ runner.os }}-${{ hashFiles('pixi.lock') }}-build-${{ github.sha }}
@@ -98,7 +98,7 @@ jobs:
       - name: Verify decimo.mojoc was produced
         run: test -f decimo.mojoc
       - name: Upload decimo.mojoc artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: decimo-mojoc
           path: decimo.mojoc
@@ -112,7 +112,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -137,7 +137,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -162,7 +162,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -187,7 +187,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -212,7 +212,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -237,7 +237,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -262,7 +262,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -287,7 +287,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -315,7 +315,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -340,7 +340,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Install MPFR
         run: brew install mpfr
@@ -367,7 +367,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-decimo
       - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
@@ -395,8 +395,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@v7
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: true
           activate-environment: true
@@ -445,8 +445,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@v7
+      - uses: prefix-dev/setup-pixi@v0.10.2
         with:
           cache: true
           activate-environment: true


### PR DESCRIPTION
GitHub warns that Node 20 is deprecated and forces these onto Node 24. They were further behind than the warning suggests: `checkout` is on v7, `upload-artifact` on v7, `download-artifact` on v8, `cache` on v6, where the workflows pinned v4.

Every input the workflows pass still exists in the new majors, checked against each action's own `action.yml` rather than assumed: `name`, `path`, `if-no-files-found`, `retention-days` for the uploads, `pattern`, `path`, `merge-multiple` for the download, `key` and `restore-keys` for the cache. That check matters most for `download-artifact`, which only runs in the publish job and so is never exercised by a pull request -- a green PR would not have proved it.

`setup-pixi` moves from 0.9.5 to 0.10.2 in the same pass. If you would rather keep that one pinned, it is the one hunk to drop.