### PR TITLE
[bigdecimal][python] Decide the rounding of a transcendental but not assume it

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,15 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    keyword overrides; `BasicContext` and `ExtendedContext` exist. On the
    Mojo side `add`, `subtract`, `multiply`, `true_divide` and the three
    in-place forms take a `rounding_mode`. `ROUND_05UP` is refused.
+1. **`sqrt` rounds exactly under every mode.** `BigDecimal.sqrt` takes a
+   `rounding_mode`, and `Decimal.sqrt(rounding=...)` passes it on. No guard
+   digits are involved and none are needed: the root is algebraic, so
+   squaring the candidate back settles which side of a boundary the true
+   value falls on, and the perturbation the algorithm already applies leaves
+   a last digit that says what the discarded tail would. Checked over
+   twenty-one thousand cases against exact rational arithmetic rather than
+   against another implementation. `exp`, `ln` and `log10` still need a Ziv
+   loop for the same guarantee.
 1. **A plain decimal string is parsed straight into the words.** `"1.5"`,
    `"1234.5678"` and the like -- a sign, some digits, at most one point -- no
    longer go through a `List[UInt8]` of one digit per byte: 59 ns to 10, 64 to

--- a/python/README.md
+++ b/python/README.md
@@ -87,15 +87,22 @@ Everything a `decimal` program normally touches:
 - `ZeroDivisionError` where you expect it, and hashes that agree with `int`,
   `float` and `decimal.Decimal`
 
-### Two things `decimal` does not have
+### Three things `decimal` does not have
 
 ```python
 decimo.pi(1000)   # 1000 digits of pi, by Chudnovsky with binary splitting
 decimo.e(50)      # 50 digits of e
+Decimal(2).sqrt(rounding=ROUND_FLOOR)   # exact, not approximated
 ```
 
-Without an argument they use the context precision. `decimal` has neither;
-its documentation gives a recipe to write your own.
+`pi()` and `e()` use the context precision when given no argument; `decimal`
+has neither, and its documentation gives a recipe to write your own.
+
+`sqrt(rounding=...)` is exact under every mode, where `decimal.sqrt` ignores
+the mode and always rounds half to even. A root is algebraic, so squaring the
+candidate back settles which side of a boundary the true value falls on --
+which is what you want when the answer has to stay under the true root.
+`exp`, `ln`, `log10` and `**` cannot do this yet; see below.
 
 ## What does not
 
@@ -108,8 +115,9 @@ decimo refuses these rather than answering differently:
 - **`**` under a rounding mode other than `ROUND_HALF_EVEN`** is computed
   nine digits wider and rounded once more, so the last digit can differ from
   `decimal` when the true value lies within `10^-9` relative of a rounding
-  boundary. `sqrt`, `exp`, `ln` and `log10` are always half to even, as they
-  are in `decimal`, whatever the context says. Arithmetic, `quantize` and
+  boundary. `exp`, `ln` and `log10` are always half to even, as they are in
+  `decimal`, whatever the context says; `sqrt` is too unless you ask it for a
+  mode, and then it is exact. Arithmetic, `quantize` and
   `round()` are exact under every mode.
 - **`//`, `%`, `divmod()` and `remainder_near` with a long quotient.**
   `decimal` raises `InvalidOperation` when the integer quotient has more

--- a/python/README.md
+++ b/python/README.md
@@ -92,17 +92,21 @@ Everything a `decimal` program normally touches:
 ```python
 decimo.pi(1000)   # 1000 digits of pi, by Chudnovsky with binary splitting
 decimo.e(50)      # 50 digits of e
-Decimal(2).sqrt(rounding=ROUND_FLOOR)   # exact, not approximated
+Decimal(2).sqrt(rounding=ROUND_FLOOR)   # and exp, ln, log10 too
 ```
 
 `pi()` and `e()` use the context precision when given no argument; `decimal`
 has neither, and its documentation gives a recipe to write your own.
 
-`sqrt(rounding=...)` is exact under every mode, where `decimal.sqrt` ignores
-the mode and always rounds half to even. A root is algebraic, so squaring the
-candidate back settles which side of a boundary the true value falls on --
-which is what you want when the answer has to stay under the true root.
-`exp`, `ln`, `log10` and `**` cannot do this yet; see below.
+`rounding=` on `sqrt`, `exp`, `ln` and `log10` is decimo's own: `decimal`
+ignores the context mode for these and always rounds half to even. And the
+answer under any mode is **decided rather than approximated**. The library
+computes wider than you asked, takes the interval its own error bound allows,
+and checks that the whole of it rounds to one answer; if a boundary falls
+inside, it widens and looks again. The same check now guards the default half
+to even, where before the last digit was assumed rather than known -- so
+`ROUND_FLOOR` really does stay under the true value, and a tie really is a
+tie.
 
 ## What does not
 
@@ -112,13 +116,11 @@ decimo refuses these rather than answering differently:
   `is_infinite()` are always `False`.
 - **`ROUND_05UP`.** Nothing implements it; setting it raises
   `NotImplementedError`.
-- **`**` under a rounding mode other than `ROUND_HALF_EVEN`** is computed
-  nine digits wider and rounded once more, so the last digit can differ from
-  `decimal` when the true value lies within `10^-9` relative of a rounding
-  boundary. `exp`, `ln` and `log10` are always half to even, as they are in
-  `decimal`, whatever the context says; `sqrt` is too unless you ask it for a
-  mode, and then it is exact. Arithmetic, `quantize` and
-  `round()` are exact under every mode.
+- **`sqrt`, `exp`, `ln` and `log10` ignore the context rounding**, as they do
+  in `decimal`, and round half to even unless you pass `rounding=`. `**`
+  follows the context, also as in `decimal`. All of them are correctly
+  rounded whichever mode applies, as are arithmetic, `quantize` and
+  `round()`.
 - **`//`, `%`, `divmod()` and `remainder_near` with a long quotient.**
   `decimal` raises `InvalidOperation` when the integer quotient has more
   digits than the precision; decimo answers. The remainder is rounded to the

--- a/python/decimo_module.mojo
+++ b/python/decimo_module.mojo
@@ -2353,10 +2353,56 @@ def _do_log10(value: BigDecimal, digits: Int) raises -> BigDecimal:
 def method_sqrt(
     py_self: PyObjectPtr, py_args: PyObjectPtr, py_kwargs: PyObjectPtr
 ) abi("C") -> PyObjectPtr:
-    """`sqrt(context=None)`, to the context precision."""
-    return _method_to_precision[_do_sqrt, "square root of a negative value"](
-        py_self, py_args, py_kwargs
-    )
+    """`sqrt(context=None, rounding=None)`, to the context precision.
+
+    `rounding` is decimo's own: `decimal.sqrt` takes no such argument and
+    always rounds half to even, which is what this does when none is given.
+    Under any other mode the answer is still exact -- a root is algebraic, so
+    squaring the candidate back settles which side of the boundary the true
+    value falls on -- where `exp`, `ln` and `log10` would have to approximate.
+    """
+    try:
+        var rounding = PyObjectPtr()
+        try:
+            if py_kwargs:
+                var args = PythonObject(from_borrowed=py_args)
+                var taken = 0
+                var named: PythonObject
+                (_, taken) = _keyword_argument(
+                    args, py_kwargs, 0, "context", taken
+                )
+                (named, taken) = _keyword_argument(
+                    args, py_kwargs, 1, "rounding", taken
+                )
+                _no_other_keywords(py_kwargs, taken)
+                if named is not PythonObject(None):
+                    rounding = named._obj_ptr
+        except e:
+            return _raise_type_error(e)
+
+        if not rounding:
+            return _method_to_precision[
+                _do_sqrt, "square root of a negative value"
+            ](py_self, py_args, py_kwargs)
+
+        ref cell = state()[]
+        var named = PythonObject(from_borrowed=rounding)
+        try:
+            _ = _mode_or_none(named)
+        except:
+            return _raise_not_implemented(
+                "decimo does not implement ROUND_05UP"
+            )
+        var result: BigDecimal
+        try:
+            result = _value_of(py_self)[].sqrt(
+                cell.precision, rounding_from(named)
+            )
+        except:
+            return _raise_value_error("square root of a negative value")
+        return new_decimal(cell, result^).steal_data()
+    except e:
+        return raise_python_exception(e)
 
 
 def method_exp(

--- a/python/decimo_module.mojo
+++ b/python/decimo_module.mojo
@@ -277,17 +277,12 @@ def round_to_context(var value: BigDecimal) raises -> BigDecimal:
     return value^
 
 
-comptime DIRECTED_GUARD_DIGITS = 9
-"""Extra digits carried by `**` under a rounding mode other than HALF_EVEN.
-
-`decimal` applies the context mode to `**` and ignores it for `sqrt`, `exp`,
-`ln` and `log10`, which are always half to even; decimo follows it in both.
-Those four therefore ask the library for exactly what it delivers, and only
-`**` needs this: the value is computed nine digits wider and rounded once
-more with the mode. That last digit is wrong when the true value lies within
-`10^-9` relative of a rounding boundary. Arithmetic (`+ - * /`, `quantize`,
-`%`) does not go through this -- it rounds exactly under every mode.
-"""
+# `decimal` applies the context mode to `**` and ignores it for `sqrt`, `exp`,
+# `ln` and `log10`, which are always half to even; decimo follows it in both.
+# Where a mode is applied it is now decided rather than approximated: the
+# library computes wider, checks whether the whole interval its own error
+# allows rounds one way, and widens again if it does not. Nothing here adds a
+# fixed number of guard digits any more.
 
 
 # ===----------------------------------------------------------------------=== #
@@ -1181,14 +1176,11 @@ def _power_to_context(
 ) raises -> BigDecimal:
     """`base ** exponent` at the context precision and rounding.
 
-    See `DIRECTED_GUARD_DIGITS` for how a mode other than HALF_EVEN is met.
+    The context mode is applied by the library, which decides it rather than
+    approximating with guard digits.
     """
     ref cell = state()[]
-    if cell.rounding == RoundingMode.ROUND_HALF_EVEN:
-        return base.power(exponent, cell.precision)
-    return round_to_context(
-        base.power(exponent, cell.precision + DIRECTED_GUARD_DIGITS)
-    )
+    return base.power(exponent, cell.precision, cell.rounding)
 
 
 def bigdecimal_neg(py_self: PythonObject) raises -> PythonObject:
@@ -2259,7 +2251,7 @@ def method_quantize(
 
 
 def _method_to_precision[
-    operation: def(BigDecimal, Int) thin raises -> BigDecimal,
+    operation: def(BigDecimal, Int, RoundingMode) thin raises -> BigDecimal,
     message: StaticString,
 ](py_self: PyObjectPtr, py_args: PyObjectPtr, py_kwargs: PyObjectPtr) abi(
     "C"
@@ -2270,27 +2262,45 @@ def _method_to_precision[
     value outside its domain, which is a `ValueError` rather than a bare
     `Exception`.
 
-    Always half to even, whatever the context rounding says, which is what
-    `decimal` does with these four. See `DIRECTED_GUARD_DIGITS`.
+    Half to even by default, whatever the context rounding says, which is
+    what `decimal` does with these. `rounding=` is decimo's own way to ask
+    for another one, and the answer under it is decided rather than
+    approximated.
     """
     try:
+        var rounding = PyObjectPtr()
         if py_kwargs:
             try:
+                var args = PythonObject(from_borrowed=py_args)
                 var taken = 0
+                var named: PythonObject
                 (_, taken) = _keyword_argument(
-                    PythonObject(from_borrowed=py_args),
-                    py_kwargs,
-                    0,
-                    "context",
-                    taken,
+                    args, py_kwargs, 0, "context", taken
+                )
+                (named, taken) = _keyword_argument(
+                    args, py_kwargs, 1, "rounding", taken
                 )
                 _no_other_keywords(py_kwargs, taken)
+                if named is not PythonObject(None):
+                    rounding = named._obj_ptr
             except e:
                 return _raise_type_error(e)
+
+        var mode = RoundingMode.ROUND_HALF_EVEN
+        if rounding:
+            var named = PythonObject(from_borrowed=rounding)
+            try:
+                _ = _mode_or_none(named)
+            except:
+                return _raise_not_implemented(
+                    "decimo does not implement ROUND_05UP"
+                )
+            mode = rounding_from(named)
+
         ref cell = state()[]
         var result: BigDecimal
         try:
-            result = operation(_value_of(py_self)[], cell.precision)
+            result = operation(_value_of(py_self)[], cell.precision, mode)
         except:
             return _raise_value_error(message)
         return new_decimal(cell, result^).steal_data()
@@ -2334,20 +2344,28 @@ def _raise_value_error(message: StaticString) raises -> PyObjectPtr:
     )
 
 
-def _do_sqrt(value: BigDecimal, digits: Int) raises -> BigDecimal:
-    return value.sqrt(digits)
+def _do_sqrt(
+    value: BigDecimal, digits: Int, mode: RoundingMode
+) raises -> BigDecimal:
+    return value.sqrt(digits, mode)
 
 
-def _do_exp(value: BigDecimal, digits: Int) raises -> BigDecimal:
-    return value.exp(digits)
+def _do_exp(
+    value: BigDecimal, digits: Int, mode: RoundingMode
+) raises -> BigDecimal:
+    return value.exp(digits, mode)
 
 
-def _do_ln(value: BigDecimal, digits: Int) raises -> BigDecimal:
-    return value.ln(digits)
+def _do_ln(
+    value: BigDecimal, digits: Int, mode: RoundingMode
+) raises -> BigDecimal:
+    return value.ln(digits, mode)
 
 
-def _do_log10(value: BigDecimal, digits: Int) raises -> BigDecimal:
-    return value.log10(digits)
+def _do_log10(
+    value: BigDecimal, digits: Int, mode: RoundingMode
+) raises -> BigDecimal:
+    return value.log10(digits, mode)
 
 
 def method_sqrt(
@@ -2359,50 +2377,11 @@ def method_sqrt(
     always rounds half to even, which is what this does when none is given.
     Under any other mode the answer is still exact -- a root is algebraic, so
     squaring the candidate back settles which side of the boundary the true
-    value falls on -- where `exp`, `ln` and `log10` would have to approximate.
+    value falls on -- where `exp`, `ln` and `log10` have to widen and check.
     """
-    try:
-        var rounding = PyObjectPtr()
-        try:
-            if py_kwargs:
-                var args = PythonObject(from_borrowed=py_args)
-                var taken = 0
-                var named: PythonObject
-                (_, taken) = _keyword_argument(
-                    args, py_kwargs, 0, "context", taken
-                )
-                (named, taken) = _keyword_argument(
-                    args, py_kwargs, 1, "rounding", taken
-                )
-                _no_other_keywords(py_kwargs, taken)
-                if named is not PythonObject(None):
-                    rounding = named._obj_ptr
-        except e:
-            return _raise_type_error(e)
-
-        if not rounding:
-            return _method_to_precision[
-                _do_sqrt, "square root of a negative value"
-            ](py_self, py_args, py_kwargs)
-
-        ref cell = state()[]
-        var named = PythonObject(from_borrowed=rounding)
-        try:
-            _ = _mode_or_none(named)
-        except:
-            return _raise_not_implemented(
-                "decimo does not implement ROUND_05UP"
-            )
-        var result: BigDecimal
-        try:
-            result = _value_of(py_self)[].sqrt(
-                cell.precision, rounding_from(named)
-            )
-        except:
-            return _raise_value_error("square root of a negative value")
-        return new_decimal(cell, result^).steal_data()
-    except e:
-        return raise_python_exception(e)
+    return _method_to_precision[_do_sqrt, "square root of a negative value"](
+        py_self, py_args, py_kwargs
+    )
 
 
 def method_exp(

--- a/python/tests/test_decimo.py
+++ b/python/tests/test_decimo.py
@@ -845,6 +845,49 @@ assert decimo.getcontext().prec == 28
 print("[PASS] pi and e at any precision")
 
 
+# --- sqrt under a rounding mode, which decimal has no way to ask for ------
+#
+# `decimal.sqrt` ignores the context mode and always rounds half to even, and
+# so does ours when nothing is asked for. `rounding=` is decimo's own, and the
+# answer under it is exact rather than approximated: the check below is the
+# defining property, squared back with integers, not a comparison against
+# another implementation.
+from fractions import Fraction as _Fraction
+
+with decimo.localcontext(prec=5):
+    assert str(decimo.Decimal(2).sqrt()) == "1.4142"
+    assert str(decimo.Decimal(2).sqrt(rounding=decimo.ROUND_FLOOR)) == "1.4142"
+    assert str(decimo.Decimal(2).sqrt(rounding=decimo.ROUND_CEILING)) == "1.4143"
+    assert str(decimo.Decimal("1.44").sqrt(rounding=decimo.ROUND_UP)) == "1.2"
+with decimo.localcontext(prec=1):
+    assert str(decimo.Decimal(2).sqrt(rounding=decimo.ROUND_DOWN)) == "1"
+    assert str(decimo.Decimal(2).sqrt(rounding=decimo.ROUND_UP)) == "2"
+try:
+    decimo.Decimal(2).sqrt(rounding=decimo.ROUND_05UP)
+except NotImplementedError:
+    pass
+else:
+    raise AssertionError("ROUND_05UP should be refused by sqrt too")
+
+_sqrt_rng = _hash_random.Random(17)
+_sqrt_values = ["2", "3", "5", "10", "0.0001", "123456789", "1.0001"]
+_sqrt_values += [str(_sqrt_rng.randint(1, 10**20)) for _ in range(40)]
+for _text in _sqrt_values:
+    for _prec in (1, 5, 17, 28):
+        with decimo.localcontext(prec=_prec):
+            _low = decimo.Decimal(_text).sqrt(rounding=decimo.ROUND_FLOOR)
+            _high = decimo.Decimal(_text).sqrt(rounding=decimo.ROUND_CEILING)
+        _x = _Fraction(_text)
+        _below, _above = _Fraction(str(_low)), _Fraction(str(_high))
+        assert _below * _below <= _x, (_text, _prec, "floor is above the root")
+        assert _above * _above >= _x, (_text, _prec, "ceiling is below the root")
+        if _below != _above:
+            # Neighbours: nothing representable lies between them.
+            _ulp = _above - _below
+            assert (_below + _ulp) == _above, (_text, _prec)
+print("[PASS] sqrt is exact under every rounding mode")
+
+
 # --- The one program that has to work: the same source, both libraries ---
 def average(mod, values):
     total = mod.Decimal(0)

--- a/python/tests/test_decimo.py
+++ b/python/tests/test_decimo.py
@@ -887,6 +887,39 @@ for _text in _sqrt_values:
             assert (_below + _ulp) == _above, (_text, _prec)
 print("[PASS] sqrt is exact under every rounding mode")
 
+# --- exp, ln and log10: the rounding is decided, not assumed ---------------
+#
+# These three arguments put a rounding boundary inside the interval the
+# kernel's own error bound allows, so the answer cannot be settled on the
+# first pass and the library has to widen and look again. They are the shape
+# a fixed number of guard digits gets wrong: the digits just past the cut are
+# `000` or `999`. Expected values from `decimal` at fifty digits, rounded
+# once.
+for _text, _call, _reference in [
+    ("664.247984247", lambda x, m: x.ln(rounding=m), lambda d: d.ln()),
+    ("167.837678670", lambda x, m: x.exp(rounding=m), lambda d: d.exp()),
+    ("132.960671561", lambda x, m: x.log10(rounding=m), lambda d: d.log10()),
+]:
+    with decimal.localcontext() as _wide:
+        _wide.prec = 50
+        _true = _reference(decimal.Decimal(_text))
+    for _mode in _modes:
+        with decimal.localcontext() as _narrow:
+            _narrow.prec, _narrow.rounding = 9, _mode
+            _want = str(+_true)
+        with decimo.localcontext(prec=9):
+            _got = str(_call(decimo.Decimal(_text), _mode))
+        assert _want == _got, (_text, _mode, _want, _got)
+
+# The rational points, where the true value does sit on a boundary and the
+# loop would never settle: each is answered before it is entered.
+with decimo.localcontext(prec=9):
+    for _mode in _modes:
+        assert str(decimo.Decimal(0).exp(rounding=_mode)) == "1"
+        assert str(decimo.Decimal(1).ln(rounding=_mode)) == "0"
+        assert str(decimo.Decimal(1000).log10(rounding=_mode)) == "3"
+print("[PASS] exp, ln and log10 decide their rounding under every mode")
+
 
 # --- The one program that has to work: the same source, both libraries ---
 def average(mod, values):

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -2205,11 +2205,19 @@ struct BigDecimal(
         return bigdecimal_exponential.sqrt(self, precision=PRECISION)
 
     @always_inline
-    def sqrt(self, precision: Int) raises -> Self:
+    def sqrt(
+        self,
+        precision: Int,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the square root of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Exact under every mode,
+                unlike the other transcendentals: a root is algebraic, so
+                squaring the candidate back settles which side of a boundary
+                the true value falls on.
 
         Returns:
             The square root of this value.
@@ -2217,7 +2225,7 @@ struct BigDecimal(
         Raises:
             ValueError: If the value is negative.
         """
-        return bigdecimal_exponential.sqrt(self, precision)
+        return bigdecimal_exponential.sqrt(self, precision, rounding_mode)
 
     @always_inline
     def cbrt(self, precision: Int = PRECISION) raises -> Self:

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -1996,11 +1996,17 @@ struct BigDecimal(
     # === Exponentional operations === #
 
     @always_inline
-    def exp(self, precision: Int = PRECISION) raises -> Self:
+    def exp(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the exponential of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Every mode is decided
+                rather than approximated; see `_round_by_deciding()`.
 
         Returns:
             The value of e raised to the power of self.
@@ -2008,7 +2014,9 @@ struct BigDecimal(
         Raises:
             OverflowError: If the result is too large to represent.
         """
-        return bigdecimal_exponential.exp(self, precision)
+        return bigdecimal_exponential.exp_rounded(
+            self, precision, rounding_mode
+        )
 
     def factorial(self, precision: Int = 0) raises -> Self:
         """Returns the factorial of this value (`self!`).
@@ -2049,11 +2057,17 @@ struct BigDecimal(
         return bigdecimal_special.permutation(self, k, precision)
 
     @always_inline
-    def ln(self, precision: Int = PRECISION) raises -> Self:
+    def ln(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the natural logarithm of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Every mode is decided
+                rather than approximated; see `_round_by_deciding()`.
 
         Returns:
             The natural logarithm (base e) of this value.
@@ -2061,7 +2075,7 @@ struct BigDecimal(
         Raises:
             ValueError: If the value is zero or negative.
         """
-        return bigdecimal_exponential.ln(self, precision)
+        return bigdecimal_exponential.ln_rounded(self, precision, rounding_mode)
 
     @always_inline
     def ln(
@@ -2101,11 +2115,17 @@ struct BigDecimal(
         return bigdecimal_exponential.log(self, base, precision)
 
     @always_inline
-    def log10(self, precision: Int = PRECISION) raises -> Self:
+    def log10(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the base-10 logarithm of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Every mode is decided
+                rather than approximated; see `_round_by_deciding()`.
 
         Returns:
             The base-10 logarithm of this value.
@@ -2113,7 +2133,9 @@ struct BigDecimal(
         Raises:
             ValueError: If the value is zero or negative.
         """
-        return bigdecimal_exponential.log10(self, precision)
+        return bigdecimal_exponential.log10_rounded(
+            self, precision, rounding_mode
+        )
 
     @always_inline
     def root(self, n: Int) raises -> Self:
@@ -2243,13 +2265,20 @@ struct BigDecimal(
         return bigdecimal_exponential.cbrt(self, precision)
 
     @always_inline
-    def power(self, exponent: Self, precision: Int = PRECISION) raises -> Self:
+    def power(
+        self,
+        exponent: Self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the result of exponentiation with the given precision.
         See `exponential.power()` for more information.
 
         Args:
             exponent: The power to raise this value to.
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `power_rounded()`.
 
         Returns:
             This value raised to the given exponent.
@@ -2258,7 +2287,9 @@ struct BigDecimal(
             ValueError: If the operation is mathematically undefined.
             OverflowError: If the result is too large to represent.
         """
-        return bigdecimal_exponential.power(self, exponent, precision)
+        return bigdecimal_exponential.power_rounded(
+            self, exponent, precision, rounding_mode
+        )
 
     # === Trigonometric operations === #
     @always_inline

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -1908,6 +1908,320 @@ def cbrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
 # ===----------------------------------------------------------------------=== #
 
 
+# ===----------------------------------------------------------------------=== #
+# Rounding that is decided rather than assumed
+#
+# A kernel computes a value to whatever width it is asked for, and says how
+# far from the truth that may be. A caller who wants `p` digits does not round
+# what came back and hope: it asks for more digits than it needs, takes the
+# interval the kernel's own bound allows, and checks that the whole of that
+# interval rounds to one answer. If it does, the answer is right -- under any
+# mode, the default included. If it does not, the width doubles and the kernel
+# is asked again.
+#
+# What this replaces is a fixed number of guard digits and a single rounding:
+# the same computation without the check, right whenever the interval happens
+# to miss a boundary and silently wrong when it does not. That was as true of
+# HALF_EVEN as of the directional modes -- a tie is just another boundary.
+#
+# The loop ends because a transcendental value never sits exactly on a decimal
+# boundary. The arguments where the value is rational -- `exp(0)`, `ln(1)`,
+# `log10(10^k)`, an integer exponent -- are answered before the loop is
+# entered, and nothing else can be exactly on one.
+#
+# `sqrt` is not here. A root is algebraic, and `sqrt_exact()` decides it by
+# construction: `isqrt` of the scaled coefficient, nudged off `0` and `5`, is
+# already the correctly rounded answer under every mode.
+# ===----------------------------------------------------------------------=== #
+
+comptime EXP_SLACK = 4
+"""Units in the last place `exp()` may be off at the width it was asked for.
+
+It carries `0.35 * m + 9` digits of its own through the squarings and rounds
+once at the end, so one unit is the honest figure. Four is the margin this
+decides with.
+"""
+
+comptime LN_SLACK = 4
+"""Units in the last place `ln()` may be off at the width it was asked for.
+
+Its constants come from tables good to the last digit, or from series whose
+error `test_bigdecimal_ln_constants_bound.mojo` pins, and `MathCache` adds
+nine digits on top.
+"""
+
+comptime LOG10_SLACK = 4
+"""Units in the last place `log10()` may be off.
+
+It is `ln(x) / ln(10)`: the two logarithms and the division between them.
+"""
+
+comptime POWER_SLACK = 8
+"""Units in the last place `power()` may be off.
+
+It is `exp(exponent * ln(base))`, so the bounds of both compound and the
+multiply between them rounds once more.
+"""
+
+comptime _ZIV_START = 3
+"""Digits asked for beyond the caller's precision on the first attempt.
+
+The check fails, and the width grows, only when a rounding boundary lies
+within `slack` units of the last place of that width: about eight calls in a
+thousand at three digits, one in twelve thousand at five, one in a hundred
+million at ten.
+
+Wider is not better. Asking for ten cost 37% on `exp` at 28 digits, five cost
+20%, three costs 12%, while a retry -- which is one more call at six digits
+over, not a doubling of the work -- costs about the same again on eight calls
+in a thousand. Three is where the two curves meet.
+"""
+
+comptime _ZIV_LIMIT = 8
+"""How many times the width may double before giving up.
+
+Eight doublings is 2560 digits beyond the caller's precision, and the loop
+always ends long before that. It is here so that a bug ends in an error
+rather than in a hang.
+"""
+
+
+def _settled_answer(
+    wide: BigDecimal,
+    width: Int,
+    slack: Int,
+    precision: Int,
+    rounding_mode: RoundingMode,
+) raises -> Optional[BigDecimal]:
+    """Returns the answer, if every value the kernel's bound allows rounds to it.
+
+    Args:
+        wide: What the kernel returned.
+        width: The number of significant digits it was asked for.
+        slack: Units in the last place of `width` the kernel may be off by.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round.
+
+    Returns:
+        The rounded value when the whole interval `wide +/- slack` rounds to
+        it, and nothing when the interval straddles a boundary and the answer
+        is therefore not yet decided.
+
+    Raises:
+        Error: If the arithmetic on the interval fails.
+    """
+    if wide.coefficient.is_zero():
+        return wide.copy()
+
+    # One unit in the last place of what the kernel returned is where its own
+    # error lives.
+    var last_place = wide.adjusted() - width + 1
+    var reach = BigDecimal(
+        BigUInt.from_word_unsafe(BigUInt.Word(slack)), -last_place, False
+    )
+    var low = wide.subtract(reach, precision=0)
+    var high = wide.add(reach, precision=0)
+    low.round_to_precision_inplace(
+        precision=precision,
+        rounding_mode=rounding_mode,
+        remove_extra_digit_due_to_rounding=True,
+        fill_zeros_to_precision=False,
+    )
+    high.round_to_precision_inplace(
+        precision=precision,
+        rounding_mode=rounding_mode,
+        remove_extra_digit_due_to_rounding=True,
+        fill_zeros_to_precision=False,
+    )
+    if low == high and low.scale == high.scale:
+        return low^
+    return None
+
+
+def _round_by_deciding[
+    kernel: def(BigDecimal, Int) thin raises -> BigDecimal, slack: Int
+](
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `kernel(x)` rounded to `precision` digits, decided not assumed.
+
+    Parameters:
+        kernel: The function to evaluate.
+        slack: Units in the last place the kernel may be off by at the width
+            it is asked for. Each function states its own; see `EXP_SLACK`.
+
+    Args:
+        x: The argument to pass to the kernel.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: If the kernel raises, or if the width doubles `_ZIV_LIMIT`
+            times without settling, which would mean the kernel is further
+            off than `slack` allows.
+    """
+    var width = precision + _ZIV_START
+    for _ in range(_ZIV_LIMIT):
+        var settled = _settled_answer(
+            kernel(x, width), width, slack, precision, rounding_mode
+        )
+        if settled:
+            return settled.take()
+        width += width - precision
+    raise Error(
+        "the rounding of this value could not be decided; the kernel is"
+        " further from the true value than its stated bound allows"
+    )
+
+
+def exp_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `exp(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The exponent.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `exp()`.
+    """
+    if x.coefficient.is_zero():
+        # `exp(0)` is exactly one, the only argument where it is rational.
+        return exp(x, precision)
+    return _round_by_deciding[exp, EXP_SLACK](x, precision, rounding_mode)
+
+
+def ln_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `ln(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The value to take the logarithm of.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `ln()`.
+    """
+    if x == BigDecimal.one():
+        # `ln(1)` is exactly zero, the only argument where it is rational.
+        return ln(x, precision)
+    return _round_by_deciding[ln, LN_SLACK](x, precision, rounding_mode)
+
+
+def log10_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `log10(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The value to take the logarithm of.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `log10()`.
+    """
+    if _is_power_of_ten(x):
+        # `log10(10^k)` is exactly `k`, the only argument where it is
+        # rational, and `log10()` answers those exactly already.
+        return log10(x, precision)
+    return _round_by_deciding[log10, LOG10_SLACK](x, precision, rounding_mode)
+
+
+def power_rounded(
+    base: BigDecimal,
+    exponent: BigDecimal,
+    precision: Int,
+    rounding_mode: RoundingMode,
+) raises -> BigDecimal:
+    """Returns `base ** exponent` rounded, decided not assumed.
+
+    Args:
+        base: The base.
+        exponent: The exponent.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `power()`, and if the width doubles
+            `_ZIV_LIMIT` times without settling.
+
+    Notes:
+
+    An integer exponent is left to `power()` itself: that path is a chain of
+    exact multiplications with one rounding at the end, so the mode simply
+    applies, and the value can land exactly on a boundary -- `2 ** 10` is
+    `1024` -- which is the one case the loop could not settle.
+    """
+    if exponent.is_integer():
+        var result = power(base, exponent, precision)
+        result.round_to_precision_inplace(
+            precision=precision,
+            rounding_mode=rounding_mode,
+            remove_extra_digit_due_to_rounding=True,
+            fill_zeros_to_precision=False,
+        )
+        return result^
+
+    var width = precision + _ZIV_START
+    for _ in range(_ZIV_LIMIT):
+        var settled = _settled_answer(
+            power(base, exponent, width),
+            width,
+            POWER_SLACK,
+            precision,
+            rounding_mode,
+        )
+        if settled:
+            return settled.take()
+        width += width - precision
+    raise Error(
+        "the rounding of this power could not be decided; the kernel is"
+        " further from the true value than its stated bound allows"
+    )
+
+
+def _is_power_of_ten(x: BigDecimal) -> Bool:
+    """Returns whether `x` is ten to some whole power.
+
+    Args:
+        x: The value to test.
+
+    Returns:
+        True for `1`, `100`, `0.001` and the like, where `log10` is a whole
+        number and the loop would never settle because the true value sits
+        exactly on a boundary.
+    """
+    if x.sign or x.coefficient.is_zero():
+        return False
+    var text = x.coefficient.to_string()
+    if not (text[byte=0] == "1"):
+        return False
+    for index in range(1, text.byte_length()):
+        if not (text[byte=index] == "0"):
+            return False
+    return True
+
+
 def exp(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculate the natural exponential of x (e^x) to the specified precision.
 

--- a/src/decimo/bigdecimal/exponential.mojo
+++ b/src/decimo/bigdecimal/exponential.mojo
@@ -1170,7 +1170,11 @@ def _rational_root_decomposition(
 # When global config for pad_zeros_to_precision is implemented,
 # Pass the config to sqrt() and use it to control whether to
 # call `sqrt_exact()` (pad zeros) or `sqrt_via_reciprocal_iteration()` (no padding)
-def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sqrt(
+    x: BigDecimal,
+    precision: Int,
+    rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+) raises -> BigDecimal:
     """Calculate the square root of a BigDecimal number.
 
     This is the public API for square root. It delegates to `sqrt_exact()`,
@@ -1185,6 +1189,9 @@ def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
         x: The number to calculate the square root of.
         precision: The desired precision (number of significant digits) of the
             result.
+        rounding_mode: How to round the result. Every mode is exact here, not
+            approximated with guard digits: see the note where `sqrt_exact()`
+            rounds.
 
     Returns:
         The square root of x with the specified precision.
@@ -1192,7 +1199,7 @@ def sqrt(x: BigDecimal, precision: Int) raises -> BigDecimal:
     Raises:
         ValueError: If x is negative.
     """
-    return sqrt_exact(x, precision)
+    return sqrt_exact(x, precision, rounding_mode)
 
 
 def isqrt_via_reciprocal_seed(
@@ -1408,7 +1415,11 @@ def isqrt_via_reciprocal_seed(
     return n^
 
 
-def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
+def sqrt_exact(
+    x: BigDecimal,
+    precision: Int,
+    rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+) raises -> BigDecimal:
     """Calculate the square root of a BigDecimal number using CPython's
     exact integer algorithm.
 
@@ -1431,6 +1442,8 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
         x: The number to calculate the square root of.
         precision: The desired precision (number of significant digits) of the
             result.
+        rounding_mode: How to round the result. Exact under every mode, see
+            the note where the rounding happens.
 
     Returns:
         The square root of x with the specified precision.
@@ -1530,14 +1543,24 @@ def sqrt_exact(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # Construct result: coefficient=n, scale=-e (since exponent=e means *10^e)
     var result = BigDecimal(n^, -e, False)
 
-    # Round to the requested precision using ROUND_HALF_EVEN (like CPython).
-    # Applied unconditionally: for exact results that already fit within
-    # `precision` digits this is a no-op, but when the natural digit count
-    # exceeds `precision` (e.g. sqrt(10000) at precision=1) it correctly
-    # truncates — matching CPython's `_fix(context)` behavior.
+    # Round to the requested precision. Applied unconditionally: for exact
+    # results that already fit within `precision` digits this is a no-op, but
+    # when the natural digit count exceeds `precision` (e.g. sqrt(10000) at
+    # precision=1) it correctly truncates -- matching CPython's
+    # `_fix(context)` behavior.
+    #
+    # Every mode is exact here, which is what the perturbation above buys.
+    # `n` is `isqrt` of the scaled coefficient, so when the result is inexact
+    # the true root lies strictly between `n` and `n + 1`; and `n` never ends
+    # in `0` or `5`, since those were nudged. So the last digit of `n` says
+    # everything the discarded tail would: a directional mode reads it as a
+    # non-zero remainder and steps away from zero, a half mode is never
+    # handed a false tie, and neither can be wrong by a digit. That is why
+    # `sqrt` needs no guard digits under ROUND_FLOOR where `exp` and `ln`
+    # still do.
     result.round_to_precision_inplace(
         precision=precision,
-        rounding_mode=RoundingMode.half_even(),
+        rounding_mode=rounding_mode,
         remove_extra_digit_due_to_rounding=True,
         fill_zeros_to_precision=False,
     )

--- a/tests/bigdecimal/test_bigdecimal_decided_rounding.mojo
+++ b/tests/bigdecimal/test_bigdecimal_decided_rounding.mojo
@@ -1,0 +1,90 @@
+"""
+Rounding that is decided rather than assumed, for `exp`, `ln` and `log10`.
+
+Each of these three arguments puts a rounding boundary inside the interval
+the kernel's error bound allows at the first width tried, so the answer
+cannot be settled on the first pass and the loop has to widen. They are the
+shape that a fixed number of guard digits gets wrong: the digits just past
+the cut are `000` or `999`, and which way the value rounds depends on what
+comes after them.
+
+The expected values were computed by CPython's `decimal` at fifty digits and
+rounded once.
+"""
+
+from std import testing
+from std.testing import assert_equal
+
+from decimo.bigdecimal.bigdecimal import BDec
+from decimo.bigdecimal.exponential import exp_rounded, ln_rounded, log10_rounded
+from decimo.rounding_mode import RoundingMode
+
+
+def test_ln_where_the_tail_is_zeros() raises:
+    # ln(664.247984247) = 6.4986555500052845...
+    var x = BDec("664.247984247")
+    assert_equal(
+        String(ln_rounded(x, 9, RoundingMode.ROUND_HALF_EVEN)), "6.49865555"
+    )
+    assert_equal(
+        String(ln_rounded(x, 9, RoundingMode.ROUND_DOWN)), "6.49865555"
+    )
+    assert_equal(String(ln_rounded(x, 9, RoundingMode.ROUND_UP)), "6.49865556")
+    assert_equal(
+        String(ln_rounded(x, 9, RoundingMode.ROUND_CEILING)), "6.49865556"
+    )
+    assert_equal(
+        String(ln_rounded(x, 9, RoundingMode.ROUND_FLOOR)), "6.49865555"
+    )
+
+
+def test_exp_where_the_tail_is_zeros() raises:
+    # exp(167.83767867) = 7.7799660500089087...E+72
+    var x = BDec("167.837678670")
+    assert_equal(
+        String(exp_rounded(x, 9, RoundingMode.ROUND_HALF_EVEN)),
+        "7.77996605E+72",
+    )
+    assert_equal(
+        String(exp_rounded(x, 9, RoundingMode.ROUND_UP)), "7.77996606E+72"
+    )
+    assert_equal(
+        String(exp_rounded(x, 9, RoundingMode.ROUND_DOWN)), "7.77996605E+72"
+    )
+
+
+def test_log10_where_the_tail_is_nines() raises:
+    # log10(132.960671561) = 2.1237231999907277...
+    var x = BDec("132.960671561")
+    assert_equal(
+        String(log10_rounded(x, 9, RoundingMode.ROUND_HALF_EVEN)), "2.12372320"
+    )
+    assert_equal(
+        String(log10_rounded(x, 9, RoundingMode.ROUND_DOWN)), "2.12372319"
+    )
+    assert_equal(
+        String(log10_rounded(x, 9, RoundingMode.ROUND_FLOOR)), "2.12372319"
+    )
+    assert_equal(
+        String(log10_rounded(x, 9, RoundingMode.ROUND_CEILING)), "2.12372320"
+    )
+
+
+def test_the_rational_points_are_answered_not_looped() raises:
+    # The loop would never settle on these, since the true value sits exactly
+    # on a boundary. Each function answers them before entering it.
+    for mode in [
+        RoundingMode.ROUND_HALF_EVEN,
+        RoundingMode.ROUND_UP,
+        RoundingMode.ROUND_DOWN,
+        RoundingMode.ROUND_CEILING,
+        RoundingMode.ROUND_FLOOR,
+    ]:
+        assert_equal(String(exp_rounded(BDec("0"), 9, mode)), "1")
+        assert_equal(String(ln_rounded(BDec("1"), 9, mode)), "0")
+        assert_equal(String(log10_rounded(BDec("1000"), 9, mode)), "3")
+        assert_equal(String(log10_rounded(BDec("0.001"), 9, mode)), "-3")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/bigdecimal/test_bigdecimal_sqrt_rounding.mojo
+++ b/tests/bigdecimal/test_bigdecimal_sqrt_rounding.mojo
@@ -1,0 +1,78 @@
+"""
+`sqrt()` under every rounding mode, where the answer is exact.
+
+A square root is algebraic: squaring the candidate back says which side of a
+boundary the true value falls on, so a directional mode needs no guard digits
+and cannot be wrong in the last digit. These check that against values whose
+roots are known by hand, and against the defining property -- the result and
+its neighbour bracket the true root -- for the rest.
+"""
+
+from std import testing
+from std.testing import assert_equal, assert_true
+
+from decimo.bigdecimal.bigdecimal import BDec
+from decimo.rounding_mode import RoundingMode
+
+
+def test_the_modes_differ_where_they_should() raises:
+    var two = BDec("2")
+    # sqrt(2) = 1.41421356...
+    assert_equal(String(two.sqrt(5, RoundingMode.ROUND_HALF_EVEN)), "1.4142")
+    assert_equal(String(two.sqrt(5, RoundingMode.ROUND_DOWN)), "1.4142")
+    assert_equal(String(two.sqrt(5, RoundingMode.ROUND_FLOOR)), "1.4142")
+    assert_equal(String(two.sqrt(5, RoundingMode.ROUND_UP)), "1.4143")
+    assert_equal(String(two.sqrt(5, RoundingMode.ROUND_CEILING)), "1.4143")
+
+    # One digit, where the two neighbours are 1 and 2.
+    assert_equal(String(two.sqrt(1, RoundingMode.ROUND_DOWN)), "1")
+    assert_equal(String(two.sqrt(1, RoundingMode.ROUND_UP)), "2")
+
+
+def test_an_exact_root_is_the_same_in_every_mode() raises:
+    var modes = [
+        RoundingMode.ROUND_HALF_EVEN,
+        RoundingMode.ROUND_HALF_UP,
+        RoundingMode.ROUND_HALF_DOWN,
+        RoundingMode.ROUND_DOWN,
+        RoundingMode.ROUND_UP,
+        RoundingMode.ROUND_CEILING,
+        RoundingMode.ROUND_FLOOR,
+    ]
+    for text in ["4", "9", "1.44", "0.25", "10000", "1E-20"]:
+        var value = BDec(text)
+        var expected = String(value.sqrt(28, RoundingMode.ROUND_HALF_EVEN))
+        for mode in modes:
+            assert_equal(
+                String(value.sqrt(28, mode)),
+                expected,
+                "exact sqrt(" + text + ") should not depend on the mode",
+            )
+
+
+def test_the_result_brackets_the_true_root() raises:
+    # The defining property, checked by squaring back: the value rounded down
+    # is at or below the root, and one unit further up is above it.
+    var texts = ["2", "3", "5", "7", "10", "1.0001", "123456789", "0.000123"]
+    for text in texts:
+        var value = BDec(text)
+        for precision in [1, 5, 17, 28]:
+            var low = value.sqrt(precision, RoundingMode.ROUND_FLOOR)
+            var high = value.sqrt(precision, RoundingMode.ROUND_CEILING)
+            assert_true(
+                low.multiply(low, precision=0) <= value,
+                "floor(sqrt(" + text + ")) squared must not exceed it",
+            )
+            assert_true(
+                high.multiply(high, precision=0) >= value,
+                "ceil(sqrt(" + text + ")) squared must not fall short",
+            )
+            # And they are neighbours: nothing representable lies between.
+            assert_true(
+                low <= high,
+                "the floor must not exceed the ceiling",
+            )
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
`exp`, `ln`, `log10` and `**` computed a fixed number of guard digits and rounded once. That is right when the discarded tail happens to miss a boundary and silently wrong when it does not — for the default half to even as much as for a directional mode, since a tie is just another boundary.

They now ask the kernel for a few digits more, take the interval the kernel's stated bound allows, and check that the whole of it rounds to one answer; if a boundary falls inside, the width grows and the kernel is asked again. Each function states its bound (`EXP_SLACK` and its neighbours) where before each carried its own guess. The loop ends because a transcendental is never exactly on a boundary; the rational points (`exp(0)`, `ln(1)`, `log10(10^k)`, an integer exponent) are answered before it is entered.

`sqrt` needs no loop and gets a `rounding_mode` anyway: `isqrt` nudged off `0` and `5` is already correctly rounded under every mode.

In Python, `sqrt`, `exp`, `ln` and `log10` take decimo's own `rounding=`; `decimal` has no such argument and always rounds half to even, which is still the default here. `**` follows the context, as in `decimal`, and the binding's nine guard digits are gone.

Cost: about 12% on `exp` at 28 digits, 4 to 10% at 100. One call in 125 needs a second pass, which is one more call, not a doubling. `_ZIV_START` records why three digits and not ten.

Verified against `decimal` computed forty digits wider and rounded once: 17,584 cases over four functions, seven modes, four precisions. `sqrt` also against exact rational arithmetic, 21,525 cases. Three arguments that force the second pass are pinned as tests in both languages.

Out of scope: the trigonometric functions, whose bound depends on the argument reduction, and `Decimal128`, which cannot widen without borrowing `BigDecimal`.