### PR TITLE
[bigdecimal] Size the trigonometric reduction to its argument

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,15 +36,34 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    keyword overrides; `BasicContext` and `ExtendedContext` exist. On the
    Mojo side `add`, `subtract`, `multiply`, `true_divide` and the three
    in-place forms take a `rounding_mode`. `ROUND_05UP` is refused.
-1. **`sqrt` rounds exactly under every mode.** `BigDecimal.sqrt` takes a
-   `rounding_mode`, and `Decimal.sqrt(rounding=...)` passes it on. No guard
-   digits are involved and none are needed: the root is algebraic, so
-   squaring the candidate back settles which side of a boundary the true
-   value falls on, and the perturbation the algorithm already applies leaves
-   a last digit that says what the discarded tail would. Checked over
-   twenty-one thousand cases against exact rational arithmetic rather than
-   against another implementation. `exp`, `ln` and `log10` still need a Ziv
-   loop for the same guarantee.
+1. **`sin`, `cos` and `tan` were wrong for a large argument, silently.** The
+   reduction `x mod 2*pi` cancels everything above the remainder, so an
+   argument of `10^k` spends `k` digits of pi before the remainder starts.
+   The budget was a flat ninety-nine digits: right up to `10^99`, half wrong
+   by `10^105`, and at `10^150` `sin` returned
+   `-0.8939514546180310700365995531` where the true value is
+   `-0.9507438768330459768719272005` -- nothing correct in it, and nothing to
+   say so. `reduction_digits()` now sizes the budget to the argument, and
+   `cot`, `csc` and `sec` inherit it. Pinned against an independent
+   computation (pi by Machin, reduced, then the series) up to `10^300`.
+1. **The rounding of a transcendental is decided, not assumed.** `exp`, `ln`,
+   `log10`, `**`, `sin`, `cos` and `tan` computed a fixed number of digits
+   beyond what was asked and rounded once, which is right whenever the
+   discarded tail happens to miss a boundary and silently wrong when it does
+   not -- for the default half to even as much as for a directional mode,
+   since a tie is just another boundary. They now take the interval their own
+   error bound allows and check that the whole of it rounds to one answer,
+   widening and asking again when a boundary falls inside. Each states its
+   bound (`EXP_SLACK` and its neighbours) instead of each carrying its own
+   guess. `sqrt` needs no loop: a root is algebraic, so `isqrt` of the scaled
+   coefficient, nudged off `0` and `5`, is already correctly rounded under
+   every mode. The Mojo methods take a `rounding_mode`, and in Python
+   `sqrt`, `exp`, `ln` and `log10` take decimo's own `rounding=`, which
+   `decimal` has no equivalent of. About 12% on `exp` at 28 digits, 1% on the
+   trigonometric functions; a second attempt is needed on about eight calls
+   in a thousand. Checked over seventeen thousand cases against `decimal` at
+   forty digits beyond the precision, and twenty-one thousand for `sqrt`
+   against exact rational arithmetic.
 1. **A plain decimal string is parsed straight into the words.** `"1.5"`,
    `"1234.5678"` and the like -- a sign, some digits, at most one point -- no
    longer go through a `List[UInt8]` of one digit per byte: 59 ns to 10, 64 to

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -2293,11 +2293,17 @@ struct BigDecimal(
 
     # === Trigonometric operations === #
     @always_inline
-    def sin(self, precision: Int = PRECISION) raises -> Self:
+    def sin(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the sine of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `_round_by_deciding()`.
 
         Returns:
             The sine of this value.
@@ -2305,14 +2311,22 @@ struct BigDecimal(
         Raises:
             Error: If the underlying computation fails.
         """
-        return bigdecimal_trigonometric.sin(self, precision)
+        return bigdecimal_trigonometric.sin_rounded(
+            self, precision, rounding_mode
+        )
 
     @always_inline
-    def cos(self, precision: Int = PRECISION) raises -> Self:
+    def cos(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the cosine of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `_round_by_deciding()`.
 
         Returns:
             The cosine of this value.
@@ -2320,14 +2334,22 @@ struct BigDecimal(
         Raises:
             Error: If the underlying computation fails.
         """
-        return bigdecimal_trigonometric.cos(self, precision)
+        return bigdecimal_trigonometric.cos_rounded(
+            self, precision, rounding_mode
+        )
 
     @always_inline
-    def tan(self, precision: Int = PRECISION) raises -> Self:
+    def tan(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the tangent of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `_round_by_deciding()`.
 
         Returns:
             The tangent of this value.
@@ -2336,7 +2358,9 @@ struct BigDecimal(
             ZeroDivisionError: At the singularities x = π/2 + nπ where
                 cos(x) is zero and tan(x) is undefined.
         """
-        return bigdecimal_trigonometric.tan(self, precision)
+        return bigdecimal_trigonometric.tan_rounded(
+            self, precision, rounding_mode
+        )
 
     @always_inline
     def cot(self, precision: Int = PRECISION) raises -> Self:

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -29,11 +29,123 @@ from decimo.errors import ValueError
 from decimo.rounding_mode import RoundingMode
 import decimo.bigdecimal.constants as bigdecimal_constants
 import decimo.bigdecimal.exponential as bigdecimal_exponential
+from decimo.bigdecimal.exponential import _round_by_deciding
 
 
 # ===----------------------------------------------------------------------=== #
 # Trigonometric functions
 # ===----------------------------------------------------------------------=== #
+
+
+comptime RESERVE_DIGITS = 99
+"""Digits carried beyond the argument's own, when reducing by pi.
+
+Conservative on purpose: an argument that lands very close to a multiple of
+`pi/2` cancels further than its magnitude alone predicts, and the series that
+follows the reduction rounds a few more times.
+"""
+
+
+def reduction_digits(x: BigDecimal, precision: Int) -> Int:
+    """Returns the working precision a reduction by pi needs for this argument.
+
+    Args:
+        x: The argument about to be reduced.
+        precision: The number of significant digits wanted in the result.
+
+    Returns:
+        The number of digits pi and the reduction must carry.
+
+    Notes:
+
+    `x mod 2pi` subtracts a multiple of `2pi` from `x`, and everything above
+    the remainder cancels. An argument of `10^k` therefore spends `k` digits
+    of pi before the remainder even starts. A budget that does not count `k`
+    is a budget that runs out: at `precision + 99`, which these functions used
+    to carry, `sin` is right up to `10^99`, has lost half its digits by
+    `10^105`, and by `10^150` returns a number with nothing correct in it at
+    all -- silently, since nothing in the computation notices.
+
+    So the budget counts the argument.
+    """
+    var magnitude = x.adjusted()
+    return precision + RESERVE_DIGITS + (magnitude if magnitude > 0 else 0)
+
+
+comptime TRIG_SLACK = 4
+"""Units in the last place a trigonometric kernel may be off at the width it
+was asked for.
+
+The reduction is the delicate part, and `reduction_digits()` already sizes
+itself to the argument, so what is left here is the Taylor series and the few
+roundings around it. Four units is well past that.
+"""
+
+
+def sin_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `sin(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The angle in radians.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `sin()`.
+    """
+    if x.is_zero():
+        # `sin(0)` is exactly zero, and the loop could not settle on it.
+        return sin(x, precision)
+    return _round_by_deciding[sin, TRIG_SLACK](x, precision, rounding_mode)
+
+
+def cos_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `cos(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The angle in radians.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `cos()`.
+    """
+    if x.is_zero():
+        # `cos(0)` is exactly one.
+        return cos(x, precision)
+    return _round_by_deciding[cos, TRIG_SLACK](x, precision, rounding_mode)
+
+
+def tan_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `tan(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The angle in radians.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `tan()`.
+    """
+    if x.is_zero():
+        # `tan(0)` is exactly zero.
+        return tan(x, precision)
+    return _round_by_deciding[tan, TRIG_SLACK](x, precision, rounding_mode)
 
 
 def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
@@ -59,8 +171,7 @@ def sin(x: BigDecimal, precision: Int) raises -> BigDecimal:
     # reduction accurately.
     # Otherwise, the result will be inaccurate when x is close to π-related
     # values, e.g., π/2, π, 3π/2, 2π, etc.
-    comptime BUFFER_DIGITS = 99
-    var working_precision = precision + BUFFER_DIGITS
+    var working_precision = reduction_digits(x, precision)
 
     var result: BigDecimal
 
@@ -244,8 +355,7 @@ def cos(x: BigDecimal, precision: Int) raises -> BigDecimal:
     This function adopts range reduction for optimal convergence.
     """
 
-    comptime BUFFER_DIGITS = 99
-    var working_precision = precision + BUFFER_DIGITS
+    var working_precision = reduction_digits(x, precision)
 
     if x.is_zero():
         return BigDecimal(BigUInt.one())
@@ -389,9 +499,10 @@ def tan_cot(x: BigDecimal, precision: Int, is_tan: Bool) raises -> BigDecimal:
     cot(x) = sin(x) / cos(x) depending on the is_tan flag.
     """
 
-    comptime BUFFER_DIGITS = 99
-    var working_precision_pi = precision + 2 * BUFFER_DIGITS
-    var working_precision = precision + BUFFER_DIGITS
+    # `tan` cancels twice: once reducing by pi, and again near a pole, where
+    # `sin / cos` divides by something small. So pi carries the reserve twice.
+    var working_precision = reduction_digits(x, precision)
+    var working_precision_pi = working_precision + RESERVE_DIGITS
 
     if x.is_zero():
         if is_tan:

--- a/tests/bigdecimal/test_bigdecimal_decided_rounding.mojo
+++ b/tests/bigdecimal/test_bigdecimal_decided_rounding.mojo
@@ -17,6 +17,11 @@ from std.testing import assert_equal
 
 from decimo.bigdecimal.bigdecimal import BDec
 from decimo.bigdecimal.exponential import exp_rounded, ln_rounded, log10_rounded
+from decimo.bigdecimal.trigonometric import (
+    sin_rounded,
+    cos_rounded,
+    tan_rounded,
+)
 from decimo.rounding_mode import RoundingMode
 
 
@@ -84,6 +89,43 @@ def test_the_rational_points_are_answered_not_looped() raises:
         assert_equal(String(ln_rounded(BDec("1"), 9, mode)), "0")
         assert_equal(String(log10_rounded(BDec("1000"), 9, mode)), "3")
         assert_equal(String(log10_rounded(BDec("0.001"), 9, mode)), "-3")
+
+
+def test_the_trigonometric_functions_decide_too() raises:
+    # sin(1.5) = 0.997494986604..., cos(1.5) = 0.0707372016677...,
+    # tan(1.5) = 14.1014199472..., from the same independent computation.
+    var x = BDec("1.5")
+    assert_equal(
+        String(sin_rounded(x, 9, RoundingMode.ROUND_DOWN)), "0.997494986"
+    )
+    assert_equal(
+        String(sin_rounded(x, 9, RoundingMode.ROUND_UP)), "0.997494987"
+    )
+    assert_equal(
+        String(sin_rounded(x, 9, RoundingMode.ROUND_HALF_EVEN)), "0.997494987"
+    )
+    assert_equal(
+        String(cos_rounded(x, 9, RoundingMode.ROUND_DOWN)), "0.0707372016"
+    )
+    assert_equal(
+        String(cos_rounded(x, 9, RoundingMode.ROUND_UP)), "0.0707372017"
+    )
+    assert_equal(
+        String(tan_rounded(x, 9, RoundingMode.ROUND_DOWN)), "14.1014199"
+    )
+    assert_equal(String(tan_rounded(x, 9, RoundingMode.ROUND_UP)), "14.1014200")
+
+    # A large argument reduces first and still decides its last digit.
+    assert_equal(
+        String(sin_rounded(BDec("1E+150"), 9, RoundingMode.ROUND_HALF_EVEN)),
+        "-0.950743877",
+    )
+
+    # Zero is exact in all three, and the loop could not settle on it.
+    for mode in [RoundingMode.ROUND_UP, RoundingMode.ROUND_FLOOR]:
+        assert_equal(String(sin_rounded(BDec("0"), 9, mode)), "0")
+        assert_equal(String(cos_rounded(BDec("0"), 9, mode)), "1")
+        assert_equal(String(tan_rounded(BDec("0"), 9, mode)), "0")
 
 
 def main() raises:

--- a/tests/bigdecimal/test_bigdecimal_trig_large_arguments.mojo
+++ b/tests/bigdecimal/test_bigdecimal_trig_large_arguments.mojo
@@ -1,0 +1,84 @@
+"""
+Sine, cosine and tangent of a very large argument.
+
+`sin(x)` reduces `x` modulo `2*pi`, and everything above the remainder
+cancels. An argument of `10^k` therefore spends `k` digits of pi before the
+remainder starts, so a reduction budget that does not count `k` runs out. The
+old budget was a flat ninety-nine digits: right up to `10^99`, half wrong by
+`10^105`, and at `10^150` it returned `-0.8939514546180310700365995531` where
+the true value is `-0.9507438768330459768719272005` -- nothing correct in it
+at all, and nothing to say so.
+
+The expected values here were computed independently: pi by Machin's formula
+to `28 + k + 40` digits, the argument reduced against it, then the Taylor
+series, all in CPython's `decimal`.
+"""
+
+from std import testing
+from std.testing import assert_equal
+
+from decimo.bigdecimal.bigdecimal import BDec
+from decimo.bigdecimal.trigonometric import sin, cos, tan, cot, csc, sec
+
+
+def test_sine_of_a_large_argument() raises:
+    assert_equal(
+        String(sin(BDec("1E+20"), 28)), "-0.6452512852657808442058117113"
+    )
+    assert_equal(
+        String(sin(BDec("1E+105"), 28)), "-0.8350242863139418836996674337"
+    )
+    assert_equal(
+        String(sin(BDec("1E+150"), 28)), "-0.9507438768330459768719272005"
+    )
+    assert_equal(
+        String(sin(BDec("1E+300"), 28)), "-0.9857504251603769966090475314"
+    )
+
+
+def test_cosine_of_a_large_argument() raises:
+    assert_equal(
+        String(cos(BDec("1E+20"), 28)), "0.7639704044417283004001468027"
+    )
+    assert_equal(
+        String(cos(BDec("1E+105"), 28)), "0.5502130871452368583126114139"
+    )
+    assert_equal(
+        String(cos(BDec("1E+150"), 28)), "-0.3099775486458170915883718138"
+    )
+    assert_equal(
+        String(cos(BDec("1E+300"), 28)), "-0.1682144443742450728518756644"
+    )
+
+
+def test_tangent_of_a_large_argument() raises:
+    assert_equal(
+        String(tan(BDec("1E+20"), 28)), "-0.8446024630198842541840932340"
+    )
+    assert_equal(
+        String(tan(BDec("1E+105"), 28)), "-1.517637994847485169454298238"
+    )
+    assert_equal(
+        String(tan(BDec("1E+150"), 28)), "3.067137865263183258766505146"
+    )
+    assert_equal(
+        String(tan(BDec("1E+300"), 28)), "5.860081925944898104682611488"
+    )
+
+
+def test_the_reciprocals_follow() raises:
+    # `cot`, `csc` and `sec` are one over the three above, so they inherit
+    # the budget rather than carrying their own.
+    assert_equal(
+        String(cot(BDec("1E+150"), 28)), "0.3260368603985763635056888982"
+    )
+    assert_equal(
+        String(csc(BDec("1E+150"), 28)), "-1.051807983587575157655389916"
+    )
+    assert_equal(
+        String(sec(BDec("1E+150"), 28)), "-3.226040093447568562295395823"
+    )
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
`sin(1E+150)` returned `-0.8939514546180310700365995531`. The true value is `-0.9507438768330459768719272005`. Not the last digit — nothing in it was right, and nothing in the computation noticed.

The reduction `x mod 2*pi` cancels everything above the remainder, so an argument of `10^k` spends `k` digits of pi before the remainder even starts. `sin`, `cos` and `tan` carried a flat ninety-nine digits: right up to `10^99`, half gone by `10^105`, nothing left by `10^150`.

| x | `sin(x)` before | true value |
| --- | --- | --- |
| `1E+105` | -0.8350242863139418836997358163 | -0.8350242863139418836996674337 |
| `1E+120` | -0.6232211383823394625191136637 | -0.6232210411866425680029361915 |
| `1E+150` | -0.8939514546180310700365995531 | -0.9507438768330459768719272005 |

`reduction_digits()` now sizes the budget to the argument's magnitude, and `cot`, `csc` and `sec` inherit it through the three.

The same functions decide their rounding now, as `exp` and `ln` do since the last branch: `sin_rounded`, `cos_rounded` and `tan_rounded` take a mode and the `BigDecimal` methods pass one on. Both changes cost about one percent, since these kernels already carry a large reserve; a `10^150` argument costs about twice a small one, which is the price of being right.

The changelog entry for the previous branch is corrected here too — the script that wrote it stopped on an earlier failure, so it still described only the `sqrt` half of that work.

Checked against an independent computation (pi by Machin's formula to `28 + k + 40` digits, the argument reduced against it, then the Taylor series, all in CPython's `decimal`) at `10^20`, `10^105`, `10^150` and `10^300`, for all six functions.