### PR TITLE
[bigdecimal] Correct the last digit of arctan, cot, csc and sec

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,12 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    keyword overrides; `BasicContext` and `ExtendedContext` exist. On the
    Mojo side `add`, `subtract`, `multiply`, `true_divide` and the three
    in-place forms take a `rounding_mode`. `ROUND_05UP` is refused.
+1. **`arctan`, `cot`, `csc` and `sec` decide their rounding too.** The
+   inverse and reciprocal functions were the last ones adding nine guard
+   digits and rounding once. An argument was built to catch that -- take a
+   value whose 29th digit is a 5, apply the inverse function to it -- and
+   `arctan` came back one unit low, `log10` one unit high. Both are correct
+   now, and the arguments are pinned as tests.
 1. **The trigonometric reduction budget is measured, not guessed.** An
    argument close to a multiple of `pi/2` loses digits to the subtraction
    there, by as much as it is close, and no constant can cover that: `sin` of

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -2363,11 +2363,17 @@ struct BigDecimal(
         )
 
     @always_inline
-    def cot(self, precision: Int = PRECISION) raises -> Self:
+    def cot(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the cotangent of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `_round_by_deciding()`.
 
         Returns:
             The cotangent of this value.
@@ -2377,14 +2383,22 @@ struct BigDecimal(
             ZeroDivisionError: At other singularities x = nπ (n != 0) where
                 sin(x) is zero.
         """
-        return bigdecimal_trigonometric.cot(self, precision)
+        return bigdecimal_trigonometric.cot_rounded(
+            self, precision, rounding_mode
+        )
 
     @always_inline
-    def csc(self, precision: Int = PRECISION) raises -> Self:
+    def csc(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the cosecant of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `_round_by_deciding()`.
 
         Returns:
             The cosecant of this value.
@@ -2394,14 +2408,22 @@ struct BigDecimal(
             ZeroDivisionError: At other singularities x = nπ (n != 0) where
                 sin(x) is zero.
         """
-        return bigdecimal_trigonometric.csc(self, precision)
+        return bigdecimal_trigonometric.csc_rounded(
+            self, precision, rounding_mode
+        )
 
     @always_inline
-    def sec(self, precision: Int = PRECISION) raises -> Self:
+    def sec(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the secant of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `_round_by_deciding()`.
 
         Returns:
             The secant of this value.
@@ -2410,14 +2432,22 @@ struct BigDecimal(
             ZeroDivisionError: At the singularities x = π/2 + nπ where
                 cos(x) is zero and sec(x) is undefined.
         """
-        return bigdecimal_trigonometric.sec(self, precision)
+        return bigdecimal_trigonometric.sec_rounded(
+            self, precision, rounding_mode
+        )
 
     @always_inline
-    def arctan(self, precision: Int = PRECISION) raises -> Self:
+    def arctan(
+        self,
+        precision: Int = PRECISION,
+        rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+    ) raises -> Self:
         """Returns the arctangent of the BigDecimal number.
 
         Args:
             precision: The number of significant digits for the result.
+            rounding_mode: How to round the result. Decided rather than
+                approximated; see `_round_by_deciding()`.
 
         Returns:
             The arctangent of this value in radians.
@@ -2425,7 +2455,9 @@ struct BigDecimal(
         Raises:
             Error: If the underlying computation fails.
         """
-        return bigdecimal_trigonometric.arctan(self, precision)
+        return bigdecimal_trigonometric.arctan_rounded(
+            self, precision, rounding_mode
+        )
 
     # === Arithmetic operations === #
 

--- a/src/decimo/bigdecimal/trigonometric.mojo
+++ b/src/decimo/bigdecimal/trigonometric.mojo
@@ -753,6 +753,106 @@ def sec(x: BigDecimal, precision: Int) raises -> BigDecimal:
 # ===----------------------------------------------------------------------=== #
 
 
+comptime ARCTAN_SLACK = 4
+"""Units in the last place `arctan()` may be off at the width it was asked
+for.
+
+It reaches the series through at most one halving and one reciprocal, each
+rounding once, and the series itself is summed with its own buffer.
+"""
+
+
+def cot_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `cot(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The angle in radians.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `cot()`.
+    """
+    return _round_by_deciding[cot, TRIG_SLACK](x, precision, rounding_mode)
+
+
+def csc_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `csc(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The angle in radians.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `csc()`.
+    """
+    return _round_by_deciding[csc, TRIG_SLACK](x, precision, rounding_mode)
+
+
+def sec_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `sec(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The angle in radians.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `sec()`.
+    """
+    if x.is_zero():
+        # `sec(0)` is exactly one, which the loop could not settle on.
+        return sec(x, precision)
+    return _round_by_deciding[sec, TRIG_SLACK](x, precision, rounding_mode)
+
+
+def arctan_rounded(
+    x: BigDecimal, precision: Int, rounding_mode: RoundingMode
+) raises -> BigDecimal:
+    """Returns `arctan(x)` rounded to `precision` digits, decided not assumed.
+
+    Args:
+        x: The value to take the arctangent of.
+        precision: The number of significant digits wanted.
+        rounding_mode: How to round the result.
+
+    Returns:
+        The correctly rounded value.
+
+    Raises:
+        Error: Propagated from `arctan()`.
+
+    Notes:
+
+    `arctan()` on its own adds nine guard digits and rounds once, which is
+    wrong when the discarded tail sits on a boundary. It does, for instance,
+    at `x = 0.719140535117048373117282825889546395318364929183100430962012`,
+    where the true value continues `...67850000000000000000000000000021929`
+    and nine digits of guard see only the zeros: the kernel rounds the
+    apparent tie to even and answers one unit low.
+    """
+    if x.is_zero():
+        # `arctan(0)` is exactly zero.
+        return arctan(x, precision)
+    return _round_by_deciding[arctan, ARCTAN_SLACK](x, precision, rounding_mode)
+
+
 def arctan(x: BigDecimal, precision: Int) raises -> BigDecimal:
     """Calculates arctangent (arctan) of the number.
 

--- a/tests/bigdecimal/test_bigdecimal_boundary_arguments.mojo
+++ b/tests/bigdecimal/test_bigdecimal_boundary_arguments.mojo
@@ -1,0 +1,51 @@
+"""
+Arguments whose result lands on a rounding boundary.
+
+These were built backwards: pick a value whose 29th significant digit is a 5,
+apply the inverse function to it at sixty digits, and the result is an
+argument whose true answer continues `...5000000000000000000000000021929`.
+Nine guard digits see only the zeros, read the tail as an exact tie, and round
+to even -- which is the wrong way when the digits past the ninth are not zero.
+
+`arctan` and `log10` were both one unit low or high here before their rounding
+was decided rather than assumed. The values are from CPython's `decimal` at
+eighty digits.
+"""
+
+from std import testing
+from std.testing import assert_equal
+
+from decimo.bigdecimal.bigdecimal import BDec
+from decimo.rounding_mode import RoundingMode
+
+
+def test_arctan_on_a_constructed_boundary() raises:
+    # The true value continues ...678 5000000000000000000000000000000219
+    var x = BDec(
+        "0.719140535117048373117282825889546395318364929183100430962012"
+    )
+    assert_equal(String(x.arctan(28)), "0.6234567890123456789012345679")
+    assert_equal(
+        String(x.arctan(28, RoundingMode.ROUND_DOWN)),
+        "0.6234567890123456789012345678",
+    )
+    assert_equal(
+        String(x.arctan(28, RoundingMode.ROUND_UP)),
+        "0.6234567890123456789012345679",
+    )
+
+
+def test_log10_on_a_constructed_boundary() raises:
+    # The true value continues ...678 4999999999999999999999999999999
+    var x = BDec(
+        "2.65128728481795205648160305012060516526399375372733407716933"
+    )
+    assert_equal(String(x.log10(28)), "0.4234567890123456789012345678")
+    assert_equal(
+        String(x.log10(28, RoundingMode.ROUND_UP)),
+        "0.4234567890123456789012345679",
+    )
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
`arctan`, `cot`, `csc` and `sec` were the last functions still adding nine guard digits and rounding once. That is wrong whenever the discarded tail sits on a boundary.

Random arguments do not find it. Forty values across every branch of `arctan`, at five precisions, all agreed with an independent computation. So I built the arguments instead: take a value whose 29th significant digit is a 5, apply the inverse function to it at sixty digits, and you get an argument whose true answer continues `...5000000000000000000000000021929`. Nine digits of guard see only the zeros, read it as an exact tie, and round to even.

| input | returned | correct |
| --- | --- | --- |
| `arctan(0.71914053511704837311728282588954639531836492918310043096)` | 0.6234567890123456789012345678 | 0.6234567890123456789012345679 |
| `log10(2.65128728481795205648160305012060516526399375372733407717)` | 0.4234567890123456789012345679 | 0.4234567890123456789012345678 |

Both are decided now, and both arguments are pinned as tests. The `log10` one was already fixed by the earlier branch — this shows the machinery working, and the construction is what proves it.

`sec_rounded` answers zero before entering the loop, `sec(0)` being exactly one.