### PR TITLE
[decimal128] Correct the last digit of exp, ln, log10 and sqrt

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -205,6 +205,21 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
 
 ### 🦋 Changed in Unreleased
 
+1. **`Wide` is written once and used at two widths.** `WideValue[DIGITS]`
+   carries the mantissa the series run on; `Wide` is 38 digits of it and
+   `Extended` 75. Above 38 a product of two mantissas no longer fits
+   `UInt256`, so it is assembled from halves, and a quotient is a narrow
+   reciprocal taken one Newton step further. The constants exist at both
+   widths, and a test narrows each wide one to check it gives the narrow one
+   exactly.
+
+1. **The reciprocal divider reaches `10^48`.** `udiv_u256_by_pow10_gm`
+   replaces a 250 ns software divide with a multiply-high, and its table of
+   reciprocals stopped at `10^29` -- enough for every `Decimal128` call site,
+   but not for normalizing a 76-digit product. `round_to_keep_first_n_digits`,
+   which never used the divider at all, is left alone as the deprecated
+   function it is; the accumulator calls `round_coefficient` instead.
+
 1. **`BigInt`'s magnitude moves to base 2^64.** It held its words in base
    2^32 while doing all its arithmetic in 64-bit registers, so schoolbook
    multiplication and Knuth D both made twice the passes they needed to. The
@@ -580,6 +595,62 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    `DECIMO_TEST_JOBS` explicitly still wins in both cases.
 
 ### 🩹 Fixed in Unreleased
+
+1. **`Decimal128`'s logarithms and exponentials decide their rounding.** The
+   answer is rounded from digits the series carries below it, which is right
+   whenever those digits say which side of the boundary the true value falls
+   on. When they do not -- when the value sits on a boundary within the
+   computation's own error -- the whole thing runs again at 75 digits, which
+   has forty-six digits below the answer instead of nine. `ln`, `exp`,
+   `log10` and `log` now say which case they are in rather than assuming the
+   first.
+
+   Two arguments found by searching three million: `ln(6215888314.385201)`
+   continues `...0245000017266`, seventeen hundred units past a boundary the
+   first width can only place to within two thousand, and
+   `log10(5120760.203168846)` continues `...1444999949`. Both are answered
+   from the wider pass, which runs on about one call in a quarter million and
+   costs 55 microseconds when it does, against 0.8 for the ordinary path.
+
+1. **`ln` of a value close to one lost most of its digits.** The reduction
+   wrote `x` as `m * 2^p * 10^q` and added `p * ln(2) + q * ln(10)` back at
+   the end. For `x` just under one those three terms are each about two while
+   their sum is `1E-14`, so fourteen of the digits carried went into
+   cancelling them out. Arguments already in `[0.5, 2)` now go straight to
+   the series, where there is nothing to cancel.
+
+1. **A value below the smallest scale returned zero instead of rounding.**
+   `ln(1.0000000000000000000000000001)` is `9.99...E-29`, whose every digit
+   sits below the `1E-28` that `Decimal128` stops at. Rounding them says
+   `1E-28`; the conversion returned zero whenever the digits being dropped
+   were all of them.
+
+1. **`Decimal128`'s `exp`, `ln`, `log10` and `sqrt` were wrong in the last
+   digits.** All four summed their series in `Decimal128` arithmetic, which
+   rounds to 28 digits after every term, so the answer inherited every one of
+   those roundings. Against CPython's `decimal` at 70 digits, `ln` was out on
+   108 of 200 random arguments, `log10` on 126, `sqrt` on 75, and `exp` by up
+   to four units in the last place. The series now run in a fixed-width
+   accumulator carrying ten digits more than `Decimal128` holds, and the
+   answer is rounded once, at the end: 0 wrong in the same 720 checks.
+
+   `sqrt` no longer refines a floating estimate at all. It scales the
+   coefficient, takes an integer square root, and rounds that -- exactly the
+   same answer every time, and it also says whether the root was exact, so
+   `sqrt(4)` is `2` where `sqrt(99)` keeps its trailing zeros.
+
+   `Decimal128` still imports nothing from `BigDecimal` or any other
+   arbitrary-precision type. The accumulator is 38 digits in a `UInt256`,
+   inside `decimal128` itself.
+
+1. **The digit count stopped at 58 and returned 59 for anything larger.**
+   `number_of_digits` covered the 58-digit product of two `Decimal128`
+   coefficients and answered wrongly, rather than refusing, above that. It
+   now covers both types to the top. It is also about sixty times faster:
+   the old binary search compared against `10 ** k`, which is not folded for
+   128- and 256-bit scalars and so was built at run time by repeated
+   multiplication -- 330 ns to count the digits of a 38-digit value against
+   5 ns for a bit width and one table lookup.
 
 1. **`BigInt.sqrt()` never returned for values at the top of a word.** The
    one- and two-word paths refined a `math.sqrt` estimate with

--- a/src/decimo/decimal128/exponential.mojo
+++ b/src/decimo/decimal128/exponential.mojo
@@ -25,10 +25,152 @@ from decimo.decimal128.decimal128 import Decimal128
 import decimo.decimal128.constants as decimal128_constants
 import decimo.decimal128.special as decimal128_special
 import decimo.decimal128.utility as decimal128_utility
+from decimo.decimal128.wide import (
+    Wide,
+    Extended,
+    WideValue,
+    ln2_at,
+    ln10_at,
+    e_power_of_two_at,
+    e_tenth_at,
+    e_hundredth_at,
+    wide_ln2,
+    wide_ln10,
+    fixed_from_wide,
+    wide_from_fixed,
+    fixed_multiply,
+    fixed_divide_by_int,
+    wide_e_power_of_two,
+    wide_e_tenth,
+    wide_e_hundredth,
+    FIXED_ONE,
+)
 
 # ===----------------------------------------------------------------------=== #
 # Power and root functions
 # ===----------------------------------------------------------------------=== #
+
+
+# ===----------------------------------------------------------------------=== #
+# Deciding the rounding rather than assuming it
+#
+# A series carries more digits than the answer keeps, and the answer is
+# rounded from them once. That is right whenever the extra digits say which
+# side of the boundary the true value falls on -- and they do, except when
+# the value sits almost exactly on one. Then the extra digits are the
+# computation's own error and not the answer's digits at all.
+#
+# So each kernel states what it is trusted within, in units of the last digit
+# it carries, and the conversion refuses to answer when that interval
+# straddles a boundary. The caller then runs the same computation at
+# `Extended`: 75 digits, forty-six of them below what `Decimal128` keeps,
+# where the same interval is a billion times narrower relative to the answer.
+#
+# The counts below are what the operations can lose, with room to spare. They
+# are not measurements of how wrong the kernels are; they are the width of
+# the interval the rounding has to place, and the cost of naming them
+# generously is how often the second attempt runs, which for these is once in
+# a few million calls.
+# ===----------------------------------------------------------------------=== #
+
+comptime HALF = Decimal128(5, 0, 0, 1 << 16)
+"""One half, the bottom of the range the logarithm series takes directly."""
+
+
+comptime TWO = Decimal128(2, 0, 0, 0)
+"""Two, the top of that range."""
+
+
+comptime LN_SLACK = 2000
+"""Units in the last place `ln` is trusted within, at 38 digits.
+
+Forty series terms, each truncated at the fixed point's own last digit --
+which is one digit coarser than the mantissa's -- with the halvings and the
+two constants after them. Four hundred units covers it; this is five times
+that.
+"""
+
+
+comptime EXP_SLACK = 500
+"""Units in the last place `exp` is trusted within, at 38 digits.
+
+A dozen series terms and up to ten table multiplications, each losing under
+a unit, at a fixed point whose last digit matches the mantissa's.
+"""
+
+
+comptime SLACK_WIDENING = 20
+"""How much larger the counts are at `Extended`.
+
+The wider series runs twice as many terms and runs them in `WideValue`
+arithmetic rather than fixed point, so each term can lose a unit of its own.
+Even twenty times the narrow count is nothing beside the forty-six digits
+that width has below the answer.
+"""
+
+
+def _slack_at[WIDTH: Int](units: Int) -> UInt256:
+    """Returns a count of units in the last place, for the width in use.
+
+    Parameters:
+        WIDTH: The width the kernel is running at.
+
+    Args:
+        units: What the count is at 38 digits.
+
+    Returns:
+        The count to use.
+    """
+    comptime if WIDTH == 38:
+        return UInt256(units)
+    else:
+        return UInt256(units) * UInt256(SLACK_WIDENING)
+
+
+def _slack_after_cancellation[
+    WIDTH: Int
+](units: UInt256, largest_exponent: Int, result: WideValue[WIDTH]) -> UInt256:
+    """Restates a count of units at the size of a sum that cancelled.
+
+    Args:
+        units: The count, in units of the last digit of the terms.
+        largest_exponent: The exponent of the largest term that went in.
+        result: The sum.
+
+    Parameters:
+        WIDTH: The width in use.
+
+    Returns:
+        The count, in units of the last digit of the sum. A sum that lost
+        `k` digits to cancellation is trusted within `10^k` times as many of
+        its own units as the terms were.
+    """
+    if result.is_zero():
+        return units
+    var spread = largest_exponent - result.exponent
+    if spread <= 0:
+        return units
+    if spread > 70:
+        # Nothing of the terms survived; no rounding at this width can be
+        # justified, so ask for the wider one.
+        return UInt256.MAX
+    return units * decimal128_utility.power_of_10[DType.uint256](spread)
+
+
+def _quotient_slack(numerator: UInt256, denominator: UInt256) -> UInt256:
+    """Returns what a quotient of two trusted values is trusted within.
+
+    Args:
+        numerator: The count for the value being divided.
+        denominator: The count for the divisor.
+
+    Returns:
+        The count for the quotient. Relative error adds, and the quotient's
+        last digit can be ten times finer than either input's, so the counts
+        are added, multiplied by ten, and given a unit for the division
+        itself.
+    """
+    return (numerator + denominator) * UInt256(10) + UInt256(2)
 
 
 def power(base: Decimal128, exponent: Decimal128) raises -> Decimal128:
@@ -389,158 +531,138 @@ def cbrt(x: Decimal128) raises -> Decimal128:
 
 
 def sqrt(x: Decimal128) raises -> Decimal128:
-    """Computes the square root of a Decimal128 value using Newton-Raphson method.
+    """Computes the square root of a Decimal128 value.
 
     Args:
         x: The Decimal128 value to compute the square root of.
 
     Returns:
-        A new Decimal128 containing the square root of x.
+        The square root of x, correctly rounded.
 
     Raises:
         ValueError: If `x` is negative.
 
     Notes:
-        `sqrt(x)` is monotone non-expanding for `x >= 1`
-        (`sqrt(x) <= x`) and bounded by `sqrt(MAX) ~= 2.81e14` for
-        any valid `x`, so the Newton-Raphson intermediates cannot
-        overflow Decimal128 capacity. No `OverflowError` path exists
-        for any non-negative input.
+        By integer square root rather than by Newton in `Decimal128`, which
+        rounded to 28 digits at every iteration and was wrong in 18 of 80
+        random cases.
+
+        The coefficient is scaled so that its integer square root has the
+        digits the answer needs, and `isqrt` decides the answer exactly: the
+        true root lies between `r` and `r + 1` whenever the scaled value is
+        not a perfect square, so the last digit of `r` says what the
+        discarded tail would -- once `r` is nudged off `0` and `5`, where a
+        half-way mode would otherwise read a tie that is not there. The same
+        argument as `BigDecimal.sqrt`.
     """
-    # Special cases
     if x.is_negative():
         raise ValueError(
             message="Cannot compute square root of a negative number.",
             function="sqrt()",
         )
-
     if x.is_zero():
         return Decimal128.ZERO()
 
-    # Initial guess
-    # use floating point approach to quickly find a good guess
-    var x_coef: UInt128 = x.coefficient()
-    var x_scale = x.scale()
-    var guess: Decimal128
+    var coefficient = x.coefficient()
+    var scale = Int(x.scale())
+    var digits = decimal128_utility.number_of_digits(coefficient)
 
-    # For numbers with zero scale (true integers)
-    if x_scale == 0:
-        var float_sqrt = std.math.sqrt(Float64(x_coef))
-        guess = Decimal128.from_uint128(UInt128(round(float_sqrt)))
+    # Scale up so that the root lands on 30 digits -- one more than the answer
+    # keeps, since `isqrt` truncates and that last digit is what says which
+    # way to round. The shift is kept even with the scale so that the halved
+    # exponent is whole.
+    var shift = 59 - digits
+    if (shift + scale) % 2 != 0:
+        shift += 1
+    var target_scale = (shift + scale) // 2
 
-    # For numbers with even scale
-    elif x_scale % 2 == 0:
-        var float_sqrt = std.math.sqrt(Float64(x_coef))
-        guess = Decimal128.from_uint128(
-            UInt128(float_sqrt), scale=UInt32(x_scale >> 1), sign=False
+    var scaled = UInt256(coefficient) * decimal128_utility.power_of_10[
+        DType.uint256
+    ](shift)
+    var root = decimal128_utility.isqrt_u256(scaled)
+    var exact = root * root == scaled
+    if not exact and root % UInt256(5) == UInt256(0):
+        # Neither `0` nor `5` in the last place, so no mode reads a tie that
+        # the true root does not sit on.
+        root += UInt256(1)
+
+    # Down to what `Decimal128` holds, in a single rounding: the answer keeps
+    # at most 29 digits and a scale of at most 28, and rounding for one and
+    # then the other can hand the second a tie the true root does not sit on.
+    var root_digits = decimal128_utility.number_of_digits(root)
+    var drop = 0
+    if root_digits > 29:
+        drop = root_digits - 29
+    if target_scale - drop > Decimal128.MAX_SCALE:
+        drop = target_scale - Decimal128.MAX_SCALE
+    if drop >= root_digits:
+        return Decimal128.ZERO()
+    if drop > 0:
+        var kept = decimal128_utility.round_to_keep_first_n_digits(
+            root, False, root_digits - drop
         )
-        # print("DEBUG: scale is even")
+        # 29 digits reach `9.9E+28` where the type stops at `7.9E+28`, so one
+        # more may have to go -- from the original root, keeping this a
+        # single rounding.
+        if kept > Decimal128.MAX_AS_UINT256:
+            drop += 1
+            kept = decimal128_utility.round_to_keep_first_n_digits(
+                root, False, root_digits - drop
+            )
+        if kept * decimal128_utility.power_of_10[DType.uint256](drop) != root:
+            exact = False
+        root = kept
+        target_scale -= drop
 
-    # For numbers with odd scale
-    else:
-        var float_sqrt = std.math.sqrt(Float64(x_coef)) * Float64(3.15625)
-        guess = Decimal128.from_uint128(
-            UInt128(float_sqrt), scale=UInt32((x_scale + 1) >> 1), sign=False
-        )
-        # print("DEBUG: scale is odd")
+    # Bring the pair into what `Decimal128` holds: a scale of at most 28 and
+    # a coefficient of at most 96 bits.
+    # A carry can push the root into another digit; that value is exact, so
+    # shortening it again loses nothing.
+    while root > Decimal128.MAX_AS_UINT256:
+        if target_scale == 0:
+            raise OverflowError(
+                message="Square root does not fit in Decimal128.",
+                function="sqrt()",
+            )
+        root //= UInt256(10)
+        target_scale -= 1
 
-    # print("DEBUG: initial guess", guess)
-    # testing.assert_false(guess.is_zero(), "Initial guess should not be zero")
+    # An exact root keeps its own length: `sqrt(4)` is two, not
+    # 2.0000000000000000000000000000. An inexact one keeps its zeros, which
+    # are digits of the answer: `sqrt(99)` ends `...82100` and goes on.
+    while exact and target_scale > 0 and root % UInt256(10) == UInt256(0):
+        root //= UInt256(10)
+        target_scale -= 1
 
-    # Newton-Raphson iterations
-    # x_n+1 = (x_n + S/x_n) / 2
-    var prev_guess = Decimal128.ZERO()
-    var iteration_count = 0
-
-    # Iterate until guess converges or max iterations reached
-    # max iterations is set to 100 to avoid infinite loop
-    # log2(1e18) ~= 60, so 100 iterations should be enough
-    while guess != prev_guess and iteration_count < 100:
-        prev_guess = guess
-        var division_result = x / guess
-        var sum_result = guess + division_result
-        guess = sum_result / Decimal128(2, 0, 0, 0, False)
-        iteration_count += 1
-
-        # print("------------------------------------------------------")
-        # print("DEBUG: iteration_count", iteration_count)
-        # print("DEBUG: prev guess", prev_guess)
-        # print("DEBUG: new guess ", guess)
-
-    # print("DEBUG: iteration_count", iteration_count)
-
-    # If exact square root found, remove trailing zeros after the decimal point
-    # For example, sqrt(81) = 9, not 9.000000
-    # For example, sqrt(100.0000) = 10.00 not 10.000000
-    # Exact square means that the squared coefficient of guess after removing
-    # trailing zeros is equal to the coefficient of x
-
-    var guess_coef = guess.coefficient()
-
-    # No need to do this if the last digit of the coefficient of guess is not zero
-    if guess_coef % 10 == 0:
-        var num_digits_x_ceof = decimal128_utility.number_of_digits(x_coef)
-        var num_digits_x_sqrt_coef = (num_digits_x_ceof >> 1) + 1
-        var num_digits_guess_coef = decimal128_utility.number_of_digits(
-            guess_coef
-        )
-        var num_digits_to_decrease = (
-            num_digits_guess_coef - num_digits_x_sqrt_coef
-        )
-
-        # testing.assert_true(
-        #     num_digits_to_decrease >= 0,
-        #     "sqrt of x has fewer digits than expected",
-        # )
-        for _ in range(num_digits_to_decrease):
-            if guess_coef % 10 == 0:
-                guess_coef //= 10
-            else:
-                break
-        else:
-            # print("DEBUG: guess", guess)
-            # print("DEBUG: guess_coef after removing trailing zeros", guess_coef)
-            var guess_coef_squared = guess_coef * guess_coef
-            if (guess_coef_squared == x_coef) or (
-                guess_coef_squared == x_coef * 10
-            ):
-                return Decimal128.from_uint128(
-                    guess_coef,
-                    scale=UInt32(guess.scale() - num_digits_to_decrease),
-                    sign=False,
-                )
-
-    return guess
-
-
-# ===----------------------------------------------------------------------=== #
-# Exponential functions
-# ===----------------------------------------------------------------------=== #
+    return Decimal128.from_uint128(UInt128(root), UInt32(target_scale), False)
 
 
 def exp(x: Decimal128) raises -> Decimal128:
-    """Calculates e^x for any Decimal128 value using optimized range reduction.
-    x should be no greater than 66 to avoid overflow.
+    """Calculates e^x for a Decimal128 value.
 
     Args:
         x: The exponent.
 
     Returns:
-        A Decimal128 approximation of e^x.
+        E raised to x, correctly rounded.
 
     Raises:
-        OverflowError: If `x > 66.54` (raised explicitly), or if
-            `x < -66.54` and the recursive `Decimal128.ONE() / exp(-x)`
-            divide cannot fit because `exp(-x)` overflowed first.
-            Intermediate `power(exp_chunk, num_chunks)` and
-            `exp_main * exp_remainder` multiplies can also overflow
-            for `x` close to the `66.54` boundary.
+        OverflowError: If the result is larger than `Decimal128` holds, which
+            is anything above about 66.54.
 
     Notes:
-        Because ln(2^96-1) ~= 66.54212933375474970405428366,
-        the x value should be no greater than 66 to avoid overflow.
-    """
+        `|x|` is split into a whole part, its first two decimal digits, and
+        what is left below 0.01:
 
+            exp(x) = e^n * e^(d1/10) * e^(d2/100) * exp(residual)
+
+        The three factors are read from a table and the residual takes about
+        a dozen series terms. The answer is rounded once, at the end, and
+        only if the digits below it say which way it goes; when they do not,
+        the whole thing runs again at `Extended`.
+    """
+    if x.is_zero():
+        return Decimal128.ONE()
     if x > Decimal128.from_int(value=6654, scale=UInt32(2)):
         raise OverflowError(
             message=(
@@ -550,189 +672,142 @@ def exp(x: Decimal128) raises -> Decimal128:
             function="exp()",
         )
 
-    # Handle special cases
-    if x.is_zero():
-        return Decimal128.ONE()
+    var narrow = _exp_at[38](x)
+    var decided = narrow[0].to_decimal_decided(narrow[1])
+    if decided:
+        return decided.value()
 
-    if x.is_negative():
-        return Decimal128.ONE() / exp(-x)
+    var wide = _exp_at[75](x)
+    var settled = wide[0].to_decimal_decided(wide[1])
+    if settled:
+        return settled.value()
+    return wide[0].to_decimal()
 
-    # For x < 1, use Taylor series expansion
-    # For x > 1, use optimized range reduction with smaller chunks
-    # Yuhao's notes:
-    # e^50 is more accurate than (e^2)^25 if e^2 needs to be approximated
-    #   because estimating e^x would introduce errors
-    # e^50 is less accurate than (e^2)^25 if e^2 is precomputed
-    #   because too many multiplications would introduce errors
-    # So we need to find a way to reduce both the number of multiplications
-    #   and the error introduced by approximating e^x
-    # This helps improve accuracy as well as speed.
-    # My solution is to factorize x into a combination of integers and
-    #   a fractional part smaller than 1.
-    # Then use precomputed e^integer values to calculate e^x
-    # For example, e^59.12 = (e^50)^1 * (e^5)^1 * (e^2)^2 * e^0.12
-    # This way, we just need to do 4 multiplications instead of 59.
-    # The fractional part is then calculated using the series expansion.
-    # Because the fractional part is <1, the series converges quickly.
 
-    var exp_chunk: Decimal128
-    var remainder: Decimal128
-    var num_chunks: Int = 1
-    var x_int = Int(x)
+def _exp_at[
+    WIDTH: Int
+](x: Decimal128) raises -> Tuple[WideValue[WIDTH], UInt256]:
+    """Returns `exp(x)` at the given width, with how far it may be off.
 
-    if x.is_one():
-        return decimal128_constants.E()
+    Parameters:
+        WIDTH: The width to compute at.
 
-    elif x_int < 1:
-        # Sub-unit chunking by the first two decimal digits.
-        # Tier 1 peels off `d1 = floor(x * 10) ∈ [0, 9]` and applies `E0D{d1}`;
-        # the tier-1 residual `r1 = x − d1/10` lives in `[0, 0.1)`.
-        # When `d1 == 0` we drop into Tier 2: peel off
-        # `d2 = floor(x * 100) ∈ [0, 9]` and apply `E0D0{d2}`;
-        # the tier-2 residual `r2 = x − d2/100` lives in `[0, 0.01)`.
-        # Both tiers are short-circuited when their digit is zero so we never
-        # multiply by `Decimal128.ONE()`.
-        #
-        # [Mojo Miji]
-        # Why two tiers (precision, not just speed): every chunk multiply
-        # truncates ~0.5 ulp, but every saved Taylor multiply also avoids
-        # ~0.5 ulp. The Taylor count drops from ~17 (old `[0, 0.25)` arm)
-        # to ~10 (1-tier, residual < 0.1) to ~5 (2-tier, residual < 0.01).
-        # Net: ~10 fewer multiplies on `exp(π)` and `exp(typical)`,
-        # bringing them from ~3 ulp off the BigDecimal reference to within
-        # 0–1 ulp.
-        var ten = Decimal128(10)
-        var d1 = Int(x * ten)  # 0..9; truncated toward zero, x ≥ 0 here.
-        if d1 != 0:
-            var d1_over_10 = Decimal128.from_int(value=d1, scale=UInt32(1))
-            var residual = x - d1_over_10
-            if d1 == 1:
-                exp_chunk = decimal128_constants.E0D1()
-            elif d1 == 2:
-                exp_chunk = decimal128_constants.E0D2()
-            elif d1 == 3:
-                exp_chunk = decimal128_constants.E0D3()
-            elif d1 == 4:
-                exp_chunk = decimal128_constants.E0D4()
-            elif d1 == 5:
-                exp_chunk = decimal128_constants.E0D5()
-            elif d1 == 6:
-                exp_chunk = decimal128_constants.E0D6()
-            elif d1 == 7:
-                exp_chunk = decimal128_constants.E0D7()
-            elif d1 == 8:
-                exp_chunk = decimal128_constants.E0D8()
-            else:  # d1 == 9
-                exp_chunk = decimal128_constants.E0D9()
-            remainder = residual
-        else:
-            # d1 == 0 ⇒ x < 0.1, drop into tier 2.
-            var hundred = Decimal128(100)
-            var d2 = Int(x * hundred)  # 0..9
-            if d2 == 0:
-                # x < 0.01 — Taylor converges in ≤ 5 terms, no chunk needed.
-                return exp_series(x)
-            var d2_over_100 = Decimal128.from_int(value=d2, scale=UInt32(2))
-            var residual = x - d2_over_100
-            if d2 == 1:
-                exp_chunk = decimal128_constants.E0D01()
-            elif d2 == 2:
-                exp_chunk = decimal128_constants.E0D02()
-            elif d2 == 3:
-                exp_chunk = decimal128_constants.E0D03()
-            elif d2 == 4:
-                exp_chunk = decimal128_constants.E0D04()
-            elif d2 == 5:
-                exp_chunk = decimal128_constants.E0D05()
-            elif d2 == 6:
-                exp_chunk = decimal128_constants.E0D06()
-            elif d2 == 7:
-                exp_chunk = decimal128_constants.E0D07()
-            elif d2 == 8:
-                exp_chunk = decimal128_constants.E0D08()
-            else:  # d2 == 9
-                exp_chunk = decimal128_constants.E0D09()
-            remainder = residual
+    Args:
+        x: The exponent.
 
-    elif x_int == 1:  # 1 <= x < 2, chunk = 1
-        exp_chunk = decimal128_constants.E()
-        remainder = x - x_int
+    Returns:
+        The value, and the units in the last place of its mantissa that the
+        computation is trusted within.
 
-    elif x_int == 2:  # 2 <= x < 3, chunk = 2
-        exp_chunk = decimal128_constants.E2()
-        remainder = x - x_int
+    Raises:
+        Error: Propagated from the arithmetic.
+    """
+    var magnitude = _exp_of_magnitude_at[WIDTH](
+        WideValue[WIDTH].from_decimal(abs(x))
+    )
+    var slack = _slack_at[WIDTH](EXP_SLACK)
+    if not x.is_negative():
+        return (magnitude^, slack)
+    # A reciprocal keeps the relative error and adds its own unit; the
+    # mantissa it lands on can be ten times finer, so the count of units it
+    # is trusted within grows by that much.
+    var reciprocal = WideValue[WIDTH].from_int(1) / magnitude
+    return (reciprocal^, slack * UInt256(10) + UInt256(2))
 
-    elif x_int == 3:  # 3 <= x < 4, chunk = 3
-        exp_chunk = decimal128_constants.E3()
-        remainder = x - x_int
 
-    elif x_int == 4:  # 4 <= x < 5, chunk = 4
-        exp_chunk = decimal128_constants.E4()
-        remainder = x - x_int
+def _exp_of_magnitude_at[
+    WIDTH: Int
+](x: WideValue[WIDTH]) raises -> WideValue[WIDTH]:
+    """Returns `exp(x)` for a non-negative `x`, at the given width.
 
-    elif x_int == 5:  # 5 <= x < 6, chunk = 5
-        exp_chunk = decimal128_constants.E5()
-        remainder = x - x_int
+    Parameters:
+        WIDTH: The width to compute at.
 
-    elif x_int == 6:  # 6 <= x < 7, chunk = 6
-        exp_chunk = decimal128_constants.E6()
-        remainder = x - x_int
+    Args:
+        x: The exponent, which must be zero or positive and at most 66.54.
 
-    elif x_int == 7:  # 7 <= x < 8, chunk = 7
-        exp_chunk = decimal128_constants.E7()
-        remainder = x - x_int
+    Returns:
+        Its exponential.
 
-    elif x_int == 8:  # 8 <= x < 9, chunk = 8
-        exp_chunk = decimal128_constants.E8()
-        remainder = x - x_int
+    Raises:
+        Error: Propagated from the arithmetic.
+    """
+    var whole = x.to_int_truncated()
+    var fraction = x - WideValue[WIDTH].from_int(whole)
 
-    elif x_int == 9:  # 9 <= x < 10, chunk = 9
-        exp_chunk = decimal128_constants.E9()
-        remainder = x - x_int
+    # The first two decimal digits of the fraction.
+    var first = fraction.scaled_by_power_of_ten(1).to_int_truncated()
+    var after_first = fraction - WideValue[WIDTH](UInt256(first), -1, False)
+    var second = after_first.scaled_by_power_of_ten(2).to_int_truncated()
+    var residual = after_first - WideValue[WIDTH](UInt256(second), -2, False)
 
-    elif x_int == 10:  # 10 <= x < 11, chunk = 10
-        exp_chunk = decimal128_constants.E10()
-        remainder = x - x_int
+    var result = _exp_series_at[WIDTH](residual)
+    if second != 0:
+        result = result * e_hundredth_at[WIDTH](second)
+    if first != 0:
+        result = result * e_tenth_at[WIDTH](first)
 
-    elif x_int == 11:  # 11 <= x < 12, chunk = 11
-        exp_chunk = decimal128_constants.E11()
-        remainder = x - x_int
+    var bit = 0
+    while whole != 0:
+        if whole & 1:
+            result = result * e_power_of_two_at[WIDTH](bit)
+        whole >>= 1
+        bit += 1
+    return result^
 
-    elif x_int == 12:  # 12 <= x < 13, chunk = 12
-        exp_chunk = decimal128_constants.E12()
-        remainder = x - x_int
 
-    elif x_int == 13:  # 13 <= x < 14, chunk = 13
-        exp_chunk = decimal128_constants.E13()
-        remainder = x - x_int
+def _exp_series_at[WIDTH: Int](r: WideValue[WIDTH]) raises -> WideValue[WIDTH]:
+    """Returns `exp(r)` for a small `r`, at the given width.
 
-    elif x_int == 14:  # 14 <= x < 15, chunk = 14
-        exp_chunk = decimal128_constants.E14()
-        remainder = x - x_int
+    Parameters:
+        WIDTH: The width to compute at.
 
-    elif x_int == 15:  # 15 <= x < 16, chunk = 15
-        exp_chunk = decimal128_constants.E15()
-        remainder = x - x_int
+    Args:
+        r: The exponent, whose magnitude must be below 0.01.
 
-    elif x_int < 32:  # 16 <= x < 32, chunk = 16
-        num_chunks = x_int >> 4
-        exp_chunk = decimal128_constants.E16()
-        remainder = x - (num_chunks << 4)
+    Returns:
+        Its exponential.
 
-    else:  # chunk = 32
-        num_chunks = x_int >> 5
-        exp_chunk = decimal128_constants.E32()
-        remainder = x - (num_chunks << 5)
+    Raises:
+        Error: Propagated from the arithmetic.
 
-    # Calculate e^(chunk * num_chunks) = (e^chunk)^num_chunks
-    var exp_main = power(exp_chunk, num_chunks)
+    Notes:
+        The plain Taylor series. With `|r| < 0.01` the terms fall by more
+        than two decimal places each time, so a dozen of them cross 38
+        digits and about thirty cross 75.
 
-    # Calculate e^remainder by calling exp() again
-    # If it is <1, then use Taylor's series
-    var exp_remainder = exp(remainder)
+        At 38 digits the sum is taken in fixed point, where an addition is an
+        addition and a multiplication is one multiply-high; in `WideValue`
+        ops it cost thirty times as much for the same answer. The wider pass
+        has no fixed-point form to run in -- a 75-digit product does not fit
+        the register the trick relies on -- and pays the ordinary way, which
+        is what a path taken once in a million calls should do.
+    """
+    if r.is_zero():
+        return WideValue[WIDTH].from_int(1)
 
-    # Combine: e^x = e^(main+remainder) = e^main * e^remainder
-    return exp_main * exp_remainder
+    comptime if WIDTH == 38:
+        var r_fixed = fixed_from_wide(r.to_width[38]())
+        var total = FIXED_ONE
+        var term = FIXED_ONE
+        for index in range(1, 200):
+            term = fixed_divide_by_int(fixed_multiply(term, r_fixed), index)
+            if term == Int256(0):
+                break
+            total += term
+        return wide_from_fixed(total).to_width[WIDTH]()
+    else:
+        var total = WideValue[WIDTH].from_int(1)
+        var term = WideValue[WIDTH].from_int(1)
+        for index in range(1, 200):
+            term = (term * r).divide_by_int(index)
+            if term.is_zero():
+                break
+            var next = total + term
+            if next.compare_absolute(total) == 0:
+                break
+            total = next^
+        return total^
 
 
 def exp_series(x: Decimal128) raises -> Decimal128:
@@ -803,211 +878,213 @@ def ln(x: Decimal128) raises -> Decimal128:
         x: The Decimal128 value to compute the natural logarithm of.
 
     Returns:
-        A Decimal128 approximation of ln(x).
+        The natural logarithm of x, correctly rounded.
 
     Raises:
         ValueError: If `x` is non-positive.
 
     Notes:
-        This implementation uses range reduction to improve accuracy
-        and performance. For any positive Decimal128 input the result
-        magnitude is bounded by `|ln(MAX)| < 67`, so no `OverflowError`
-        path exists.
+        The value is written `m * 2^p * 10^q` with `m` in `[0.5, 2)`, and
+
+            ln(x) = ln(m) + p * ln(2) + q * ln(10)
+
+        with `ln(m) = 2 * atanh((m - 1) / (m + 1))`, whose series converges
+        on `|z| <= 1/3` here.
+
+        The answer is rounded once, at the end, and only if the digits below
+        it say which way it goes; when they do not, the whole thing runs
+        again at `Extended`.
     """
-
-    # print("DEBUG: ln(x) called with x =", x)
-
-    # Handle special cases
     if x.is_negative() or x.is_zero():
         raise ValueError(
             message="Cannot compute logarithm of a non-positive number.",
             function="ln()",
         )
-
     if x.is_one():
         return Decimal128.ZERO()
 
-    # Special cases for common values
-    if x == decimal128_constants.E():
-        return Decimal128.ONE()
+    var narrow = _ln_at[38](x)
+    var decided = narrow[0].to_decimal_decided(narrow[1])
+    if decided:
+        return decided.value()
 
-    # For values close to 1, use series expansion directly
-    if Decimal128(95, 0, 0, 2 << 16) <= x <= Decimal128(105, 0, 0, 2 << 16):
-        return ln_series(x - Decimal128.ONE())
+    var wide = _ln_at[75](x)
+    var settled = wide[0].to_decimal_decided(wide[1])
+    if settled:
+        return settled.value()
+    return wide[0].to_decimal()
 
-    # For all other values, use range reduction
-    # ln(x) = ln(m * 2^p * 10^q) = ln(m) + p*ln(2) + q*ln(10), where 1 <= m < 2
 
-    var m: Decimal128
-    var q: Int
-    var p: Int = 0
+def _ln_at[
+    WIDTH: Int
+](x: Decimal128) raises -> Tuple[WideValue[WIDTH], UInt256]:
+    """Returns `ln(x)` at the given width, with how far it may be off.
 
-    # STEP 1:
-    # Extract a power of 10. For inputs already in [0.1, 10) skip this
-    # (the old code's direct path keeps precision since ln(m) is then read
-    # from a single LN constant; chaining ln + q*ln(10) introduces 1 ulp).
-    # For magnitudes outside [0.1, 10), read q directly from the scale instead
-    # of looping divides: pick new_scale = num_digits(coef) - 1 so the
-    # reconstructed m = coef * 10^(-new_scale) lies in [1, 10).
-    if x >= decimal128_constants.M10() or x < Decimal128(1, 0, 0, 1 << 16):
-        var x_coef = x.coefficient()
-        var x_scale = Int(x.scale())
-        var num_digits = decimal128_utility.number_of_digits(x_coef)
-        var new_scale = num_digits - 1  # in [0, 28]
-        q = new_scale - x_scale
-        m = Decimal128.from_uint128(x_coef, scale=UInt32(new_scale), sign=False)
+    Parameters:
+        WIDTH: The width to compute at.
+
+    Args:
+        x: The value, which must be positive.
+
+    Returns:
+        The value, and the units in the last place of its mantissa that the
+        computation is trusted within.
+
+    Raises:
+        ValueError: If `x` is not positive.
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        The three parts of the sum are each around one, while their total can
+        be far smaller: `ln(0.9999)` is `-1E-4` from three terms of size two.
+        What the series and the constants are trusted within is a count of
+        units at the size of those terms, so it is restated at the size of
+        the answer -- which is where the rounding reads it -- by the number
+        of digits the sum cancelled away.
+    """
+    if x.is_negative() or x.is_zero():
+        raise ValueError(
+            message="Cannot compute logarithm of a non-positive number.",
+            function="_ln_at()",
+        )
+    if x.is_one():
+        return (WideValue[WIDTH](), UInt256(0))
+
+    var m: WideValue[WIDTH]
+    var p = 0
+    var q = 0
+
+    if x >= HALF and x < TWO:
+        # Already where the series wants it. Taking the reduction anyway
+        # would add `p * ln(2) + q * ln(10)` to a series that cancels them
+        # back out: `ln(0.99999999999999)` is `-1E-14` from three terms of
+        # size two, which throws away fourteen of the digits carried. Here
+        # there are no terms to cancel.
+        m = WideValue[WIDTH].from_decimal(x)
     else:
-        m = x
-        q = 0
+        # Write x as `m * 10^q` with `m` in [1, 10), by moving the point.
+        var coefficient = x.coefficient()
+        var digits = decimal128_utility.number_of_digits(coefficient)
+        q = digits - 1 - Int(x.scale())
+        m = WideValue[WIDTH](UInt256(coefficient), -(digits - 1), False)
 
-    # STEP 2:
-    # normalize m to [0.5, 2) using powers of 2.
-    # After step 1, m is in [0.1, 10); at most 4 halvings or 1 doubling.
-    if m >= decimal128_constants.M2():
-        while m >= decimal128_constants.M2():
-            m = m / decimal128_constants.M2()
+        # And on into [1, 2), by halving. At most three halvings from
+        # [1, 10), and each one is exact: the mantissa is raised a digit and
+        # halved, which is a multiplication by five.
+        var two = WideValue[WIDTH].from_int(2)
+        while m.compare_absolute(two) >= 0:
+            m = m.divide_by_int(2)
             p += 1
-    elif m < Decimal128(5, 0, 0, 1 << 16):
-        while m < Decimal128(5, 0, 0, 1 << 16):
-            m = m * decimal128_constants.M2()
-            p -= 1
 
-    # Now 0.5 <= m < 2
-    var ln_m: Decimal128
-
-    # Use precomputed values and series expansion for accuracy and performance
-    if m < Decimal128.ONE():
-        # For 0.5 <= m < 1
-        if m >= Decimal128(9, 0, 0, 1 << 16):
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(9, 0, 0, 1 << 16))
-                    * decimal128_constants.INV0D9()
-                )
-                + decimal128_constants.LN0D9()
-            )
-        elif m >= Decimal128(8, 0, 0, 1 << 16):
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(8, 0, 0, 1 << 16))
-                    * decimal128_constants.INV0D8()
-                )
-                + decimal128_constants.LN0D8()
-            )
-        elif m >= Decimal128(7, 0, 0, 1 << 16):
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(7, 0, 0, 1 << 16))
-                    * decimal128_constants.INV0D7()
-                )
-                + decimal128_constants.LN0D7()
-            )
-        elif m >= Decimal128(6, 0, 0, 1 << 16):
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(6, 0, 0, 1 << 16))
-                    * decimal128_constants.INV0D6()
-                )
-                + decimal128_constants.LN0D6()
-            )
-        else:  # 0.5 <= m < 0.6
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(5, 0, 0, 1 << 16))
-                    * decimal128_constants.INV0D5()
-                )
-                + decimal128_constants.LN0D5()
-            )
-
-    else:
-        # For 1 < m < 2
-        if m < Decimal128(11, 0, 0, 1 << 16):  # 1 < m < 1.1
-            ln_m = ln_series(m - Decimal128.ONE())
-        elif m < Decimal128(12, 0, 0, 1 << 16):  # 1.1 <= m < 1.2
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(11, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D1()
-                )
-                + decimal128_constants.LN1D1()
-            )
-        elif m < Decimal128(13, 0, 0, 1 << 16):  # 1.2 <= m < 1.3
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(12, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D2()
-                )
-                + decimal128_constants.LN1D2()
-            )
-        elif m < Decimal128(14, 0, 0, 1 << 16):  # 1.3 <= m < 1.4
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(13, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D3()
-                )
-                + decimal128_constants.LN1D3()
-            )
-        elif m < Decimal128(15, 0, 0, 1 << 16):  # 1.4 <= m < 1.5
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(14, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D4()
-                )
-                + decimal128_constants.LN1D4()
-            )
-        elif m < Decimal128(16, 0, 0, 1 << 16):  # 1.5 <= m < 1.6
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(15, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D5()
-                )
-                + decimal128_constants.LN1D5()
-            )
-        elif m < Decimal128(17, 0, 0, 1 << 16):  # 1.6 <= m < 1.7
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(16, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D6()
-                )
-                + decimal128_constants.LN1D6()
-            )
-        elif m < Decimal128(18, 0, 0, 1 << 16):  # 1.7 <= m < 1.8
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(17, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D7()
-                )
-                + decimal128_constants.LN1D7()
-            )
-        elif m < Decimal128(19, 0, 0, 1 << 16):  # 1.8 <= m < 1.9
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(18, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D8()
-                )
-                + decimal128_constants.LN1D8()
-            )
-        else:  # 1.9 <= m < 2
-            ln_m = (
-                ln_series(
-                    (m - Decimal128(19, 0, 0, 1 << 16))
-                    * decimal128_constants.INV1D9()
-                )
-                + decimal128_constants.LN1D9()
-            )
-
-    # Combine result: ln(x) = ln(m) + p*ln(2) + q*ln(10)
-    var result = ln_m
-
-    # Add power of 2 contribution
+    var result = _ln_series_at[WIDTH](m)
+    # The largest term that went in, to measure the sum against. A term that
+    # is exactly zero -- `ln(10)` has one, since its `m` is exactly one --
+    # carries no error and no digits, and counting its exponent would claim
+    # a cancellation that never happened.
+    var largest = Int.MIN
+    if not result.is_zero():
+        largest = result.exponent
     if p != 0:
-        result = result + Decimal128(p) * decimal128_constants.LN2()
-
-    # Add power of 10 contribution
+        var term = ln2_at[WIDTH]() * WideValue[WIDTH].from_int(p)
+        largest = max(largest, term.exponent)
+        result = result + term
     if q != 0:
-        result = result + Decimal128(q) * decimal128_constants.LN10()
+        var term = ln10_at[WIDTH]() * WideValue[WIDTH].from_int(q)
+        largest = max(largest, term.exponent)
+        result = result + term
+    if largest == Int.MIN:
+        largest = result.exponent
 
-    return result
+    var slack = _slack_after_cancellation(
+        _slack_at[WIDTH](LN_SLACK), largest, result
+    )
+    return (result^, slack)
+
+
+def _ln_series_at[WIDTH: Int](m: WideValue[WIDTH]) raises -> WideValue[WIDTH]:
+    """Returns `ln(m)` for `m` in `[0.5, 2)`, at the given width.
+
+    Parameters:
+        WIDTH: The width to compute at.
+
+    Args:
+        m: The value, which must lie in `[0.5, 2)`.
+
+    Returns:
+        Its natural logarithm.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        `ln(m) = 2 * atanh(z)` with `z = (m - 1) / (m + 1)`, so `|z| <= 1/3`
+        and each pair of terms is nine times smaller than the last: forty
+        terms cross 38 digits, eighty cross 75. `m - 1` is exact, so a value
+        close to one loses nothing here.
+
+        Forty terms are worth summing in fixed point, which is what the
+        first width does. Fixed point holds a fixed number of decimal
+        places rather than of digits, though, and for a tiny `z` those places
+        run out: at `z = 5E-15` only 23 of them are digits of `z`, and the
+        answer would be 23 digits long where the caller needs 29. Below a
+        thousandth the series is two or three terms anyway, and those are
+        taken in the floating form, which keeps its digits wherever the value
+        sits.
+    """
+    var one = WideValue[WIDTH].from_int(1)
+    var z = (m - one) / (m + one)
+    if z.is_zero():
+        return WideValue[WIDTH]()
+
+    comptime if WIDTH == 38:
+        if z.exponent >= -41:
+            var z_fixed = fixed_from_wide(z.to_width[38]())
+            var z_squared = fixed_multiply(z_fixed, z_fixed)
+            var term = z_fixed
+            var total = z_fixed
+            for index in range(1, 200):
+                term = fixed_multiply(term, z_squared)
+                if term == Int256(0):
+                    break
+                var contribution = fixed_divide_by_int(term, 2 * index + 1)
+                if contribution == Int256(0):
+                    break
+                total += contribution
+            return wide_from_fixed(total * Int256(2)).to_width[WIDTH]()
+        return _atanh_series_at[WIDTH](z) * WideValue[WIDTH].from_int(2)
+    else:
+        return _atanh_series_at[WIDTH](z) * WideValue[WIDTH].from_int(2)
+
+
+def _atanh_series_at[
+    WIDTH: Int
+](z: WideValue[WIDTH]) raises -> WideValue[WIDTH]:
+    """Returns `atanh(z)` for `|z| <= 1/3`, in the floating form.
+
+    Parameters:
+        WIDTH: The width to compute at.
+
+    Args:
+        z: The argument, whose magnitude must be at most a third.
+
+    Returns:
+        Its inverse hyperbolic tangent.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+    """
+    var z_squared = z * z
+    var term = z.copy()
+    var total = z.copy()
+    for index in range(1, 400):
+        term = term * z_squared
+        if term.is_zero():
+            break
+        var contribution = total + term.divide_by_int(2 * index + 1)
+        if contribution.compare_absolute(total) == 0:
+            break
+        total = contribution^
+    return total^
 
 
 def ln_series(z: Decimal128) raises -> Decimal128:
@@ -1132,11 +1209,40 @@ def log(x: Decimal128, base: Decimal128) raises -> Decimal128:
     if base == Decimal128(10, 0, 0, 0):
         return log10(x)
 
-    # Use the identity: log_base(x) = ln(x) / ln(base)
-    var ln_x = ln(x)
-    var ln_base = ln(base)
+    # log_base(x) = ln(x) / ln(base), with both logarithms and the division
+    # taken in `Wide`: rounding each to 28 digits first made `log_2(8)` come
+    # out as 2.9999999999999999999999999999.
+    var numerator = _ln_at[38](x)
+    var denominator = _ln_at[38](base)
+    var quotient = numerator[0] / denominator[0]
 
-    return ln_x / ln_base
+    # A whole answer is a fact about the two numbers, not something the
+    # quotient can settle: at any width it is three-and-a-hair or
+    # three-less-a-hair. So the quotient names the candidate and an exact
+    # power decides it, as `log10` already does for powers of ten.
+    var candidate = quotient.to_int_nearest()
+    if candidate != 0:
+        try:
+            if power(base, candidate) == x:
+                return Decimal128.from_int(candidate)
+        except:
+            pass
+
+    var decided = quotient.to_decimal_decided(
+        _quotient_slack(numerator[1], denominator[1])
+    )
+    if decided:
+        return decided.value()
+
+    var wide_numerator = _ln_at[75](x)
+    var wide_denominator = _ln_at[75](base)
+    var wide_quotient = wide_numerator[0] / wide_denominator[0]
+    var settled = wide_quotient.to_decimal_decided(
+        _quotient_slack(wide_numerator[1], wide_denominator[1])
+    )
+    if settled:
+        return settled.value()
+    return wide_quotient.to_decimal()
 
 
 def log10(x: Decimal128) raises -> Decimal128:
@@ -1195,5 +1301,18 @@ def log10(x: Decimal128) raises -> Decimal128:
         if integral_part == pow10_check:
             return Decimal128(UInt32(n_digits - 1), 0, 0, 0)
 
-    # Use the identity: log10(x) = ln(x) / ln(10)
-    return ln(x) / decimal128_constants.LN10()
+    # log10(x) = ln(x) / ln(10), with the division taken at the working
+    # width as well: dividing two rounded 28-digit values is one more
+    # rounding, and it showed in 18 of 80 random cases before this.
+    var narrow = _ln_at[38](x)
+    var quotient = narrow[0] / ln10_at[38]()
+    var decided = quotient.to_decimal_decided(_quotient_slack(narrow[1], 1))
+    if decided:
+        return decided.value()
+
+    var wide = _ln_at[75](x)
+    var wide_quotient = wide[0] / ln10_at[75]()
+    var settled = wide_quotient.to_decimal_decided(_quotient_slack(wide[1], 1))
+    if settled:
+        return settled.value()
+    return wide_quotient.to_decimal()

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -94,6 +94,33 @@ def sqrt(x: UInt128) -> UInt128:
     return r
 
 
+def isqrt_u256(x: UInt256) -> UInt256:
+    """Returns the integer square root of a `UInt256` value.
+
+    Args:
+        x: The value to take the root of.
+
+    Returns:
+        The largest `r` with `r * r <= x`.
+
+    Notes:
+        Bit by bit, as `sqrt(UInt128)` above: a candidate bit is kept when
+        the square of the result with that bit set still fits under `x`.
+        Squaring stays inside `UInt256` because the result is at most
+        `2^128`, and its square at most `2^256`... which is why the top bit
+        is not tried: `x` below `2^256` has a root below `2^128`.
+    """
+    var r = UInt256(0)
+    for p in range(127, -1, -1):
+        var candidate = r | (UInt256(1) << UInt256(p))
+        # `candidate * candidate` would overflow for a candidate at the very
+        # top, so compare by division instead where it might.
+        if candidate <= (UInt256(1) << UInt256(128)) - UInt256(1):
+            if candidate * candidate <= x:
+                r = candidate
+    return r
+
+
 def fit_to_max_coefficient[
     dtype: DType, //
 ](
@@ -304,7 +331,7 @@ def round_coefficient[
     # UInt256 // UInt256 lowers to a generic shift-subtract software loop
     # (~250 ns on aarch64). For UInt256, redirect to the Granlund-Möller
     # reciprocal multiplier (`udiv_u256_by_pow10_gm`, ~5 ns) for the
-    # `1 ≤ k ≤ 29` range that covers every Decimal128 multiply/round
+    # `1 ≤ k ≤ 48` range that covers every Decimal128 multiply/round
     # call site (since `combined_num_bits ≤ 192` implies `k ≤ 29`).
     # The `else` arm is a defensive fallback for any future caller that
     # might exceed that range; it pays the slow native u256 divide.
@@ -312,7 +339,7 @@ def round_coefficient[
     # `__udivti3`, so leave that path alone.
     var truncated: ValueType
     comptime if dtype == DType.uint256:
-        if ndigits_to_remove >= 1 and ndigits_to_remove <= 29:
+        if ndigits_to_remove >= 1 and ndigits_to_remove <= 48:
             truncated = rebind[ValueType](
                 udiv_u256_by_pow10_gm(rebind[UInt256](value), ndigits_to_remove)
             )
@@ -557,8 +584,7 @@ def round_to_keep_first_n_digits[
 @always_inline
 def number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
     """
-    Returns the number of (significant) digits in an integral value using binary search.
-    This implementation is significantly faster than loop division.
+    Returns the number of (significant) digits in an integral value.
 
     Parameters:
         dtype: The Mojo scalar type to calculate the number of digits for.
@@ -571,156 +597,32 @@ def number_of_digits[dtype: DType, //](value: Scalar[dtype]) -> Int:
 
     Returns:
         The number of digits in the integral value.
+
+    Notes:
+        `bit_width` gives the binary length, and `1233 / 4096` is `log10(2)`
+        from just below, so `(bits * 1233) >> 12` never overshoots the number
+        of decimal digits and lands at most one short. One table lookup
+        settles which.
+
+        This replaced a tree of `10 ** k` comparisons. Those exponents are
+        not folded for 128- and 256-bit scalars, so each comparison built its
+        power at run time by repeated multiplication: about 330 ns to count
+        the digits of a 38-digit value, against 5 ns here. Every rounding,
+        multiplication and conversion in `Decimal128` calls this.
     """
 
     comptime assert (
         dtype == DType.uint128 or dtype == DType.uint256
     ), "must be uint128 or uint256"
 
-    comptime ValueType = Scalar[dtype]
-
-    # Handle edge cases
     if value == 0:
         return 0
-    # Binary search to determine the number of digits
-    # First check small numbers with direct comparison (most common case)
-    if value < 10:
-        return 1
-    if value < 100:
-        return 2
-    if value < 1000:
-        return 3
-    if value < 10000:
-        return 4
-    if value < 100000:
-        return 5
-    if value < 1000000:
-        return 6
-    if value < 10000000:
-        return 7
-    if value < 100000000:
-        return 8
-    if value < 1000000000:
-        return 9
-
-    # For larger numbers, use binary search with limited indentation
-    # Medium range: 10^10 to 10^19
-    if value < ValueType(10) ** 19:  # < 10^19
-        if value < ValueType(10) ** 13:  # < 10^13
-            if value < ValueType(10) ** 10:  # < 10^10
-                return 10
-            if value < ValueType(10) ** 11:  # < 10^11
-                return 11
-            if value < ValueType(10) ** 12:  # < 10^12
-                return 12
-            return 13
-        if value < ValueType(10) ** 16:  # < 10^16
-            if value < ValueType(10) ** 14:  # < 10^14
-                return 14
-            if value < ValueType(10) ** 15:  # < 10^15
-                return 15
-            return 16
-        if value < ValueType(10) ** 17:  # < 10^17
-            return 17
-        if value < ValueType(10) ** 18:  # < 10^18
-            return 18
-        return 19
-
-    # Large range: 10^19 to 10^38 (UInt128 max is ~10^38)
-    if value < ValueType(10) ** 37:  # < 10^37
-        if value < ValueType(10) ** 28:  # < 10^28
-            if value < ValueType(10) ** 22:  # < 10^22
-                if value < ValueType(10) ** 20:  # < 10^20
-                    return 20
-                if value < ValueType(10) ** 21:  # < 10^21
-                    return 21
-                return 22
-            if value < ValueType(10) ** 24:  # < 10^24
-                if value < ValueType(10) ** 23:  # < 10^23
-                    return 23
-                return 24
-            if value < ValueType(10) ** 25:  # < 10^25
-                return 25
-            if value < ValueType(10) ** 26:  # < 10^26
-                return 26
-            if value < ValueType(10) ** 27:  # < 10^27
-                return 27
-            return 28
-        if value < ValueType(10) ** 31:  # < 10^31
-            if value < ValueType(10) ** 29:  # < 10^29
-                return 29
-            if value < ValueType(10) ** 30:  # < 10^30
-                return 30
-            return 31
-        if value < ValueType(10) ** 33:  # < 10^33
-            if value < ValueType(10) ** 32:  # < 10^32
-                return 32
-            return 33
-        if value < ValueType(10) ** 34:  # < 10^34
-            return 34
-        if value < ValueType(10) ** 35:  # < 10^35
-            return 35
-        if value < ValueType(10) ** 36:  # < 10^36
-            return 36
-        return 37
-
-    # Very large range: 10^37 to 10^77 (UInt256 max is ~10^77)
-    if value < ValueType(10) ** 38:  # < 10^38
-        return 38
-
-    # For UInt128, the maximum number of digits is 39
-    # We can already return the result here
-    if dtype == DType.uint128:
-        return 39
-
-    if value < ValueType(10) ** 39:  # < 10^39
-        return 39
-
-    # Use additional binary searches for UInt256 range (10^39 to 10^77)
-    if value < ValueType(10) ** 58:  # < 10^58
-        if value < ValueType(10) ** 47:  # < 10^47
-            if value < ValueType(10) ** 43:  # < 10^43
-                if value < ValueType(10) ** 40:  # < 10^40
-                    return 40
-                if value < ValueType(10) ** 41:  # < 10^41
-                    return 41
-                if value < ValueType(10) ** 42:  # < 10^42
-                    return 42
-                return 43
-            if value < ValueType(10) ** 44:  # < 10^44
-                return 44
-            if value < ValueType(10) ** 45:  # < 10^45
-                return 45
-            if value < ValueType(10) ** 46:  # < 10^46
-                return 46
-            return 47
-        if value < ValueType(10) ** 52:  # < 10^52
-            if value < ValueType(10) ** 48:  # < 10^48
-                return 48
-            if value < ValueType(10) ** 49:  # < 10^49
-                return 49
-            if value < ValueType(10) ** 50:  # < 10^50
-                return 50
-            if value < ValueType(10) ** 51:  # < 10^51
-                return 51
-            return 52
-        if value < ValueType(10) ** 54:  # < 10^54
-            if value < ValueType(10) ** 53:  # < 10^53
-                return 53
-            return 54
-        if value < ValueType(10) ** 56:  # < 10^56
-            if value < ValueType(10) ** 55:  # < 10^55
-                return 55
-            return 56
-        if value < ValueType(10) ** 57:  # < 10^57
-            return 57
-        return 58
-
-    # Digits more than 58 is not possible for Decimal128 products
-    return 59
+    var digits = ((Int(bit_width(value)) * 1233) >> 12) + 1
+    if value < power_of_10[dtype](digits - 1):
+        digits -= 1
+    return digits
 
 
-@always_inline
 def number_of_bits[
     dtype: DType, //
 ](var value: Scalar[dtype]) -> Int where dtype.is_integral():
@@ -909,7 +811,7 @@ comptime _POWER_OF_10_U128: Array[UInt128, 39] = [
 ]
 
 
-comptime _POWER_OF_10_U256: Array[UInt256, 59] = [
+comptime _POWER_OF_10_U256: Array[UInt256, 78] = [
     1,
     10,
     100,
@@ -969,6 +871,25 @@ comptime _POWER_OF_10_U256: Array[UInt256, 59] = [
     100000000000000000000000000000000000000000000000000000000,
     1000000000000000000000000000000000000000000000000000000000,
     10000000000000000000000000000000000000000000000000000000000,
+    100000000000000000000000000000000000000000000000000000000000,
+    1000000000000000000000000000000000000000000000000000000000000,
+    10000000000000000000000000000000000000000000000000000000000000,
+    100000000000000000000000000000000000000000000000000000000000000,
+    1000000000000000000000000000000000000000000000000000000000000000,
+    10000000000000000000000000000000000000000000000000000000000000000,
+    100000000000000000000000000000000000000000000000000000000000000000,
+    1000000000000000000000000000000000000000000000000000000000000000000,
+    10000000000000000000000000000000000000000000000000000000000000000000,
+    100000000000000000000000000000000000000000000000000000000000000000000,
+    1000000000000000000000000000000000000000000000000000000000000000000000,
+    10000000000000000000000000000000000000000000000000000000000000000000000,
+    100000000000000000000000000000000000000000000000000000000000000000000000,
+    1000000000000000000000000000000000000000000000000000000000000000000000000,
+    10000000000000000000000000000000000000000000000000000000000000000000000000,
+    100000000000000000000000000000000000000000000000000000000000000000000000000,
+    1000000000000000000000000000000000000000000000000000000000000000000000000000,
+    10000000000000000000000000000000000000000000000000000000000000000000000000000,
+    100000000000000000000000000000000000000000000000000000000000000000000000000000,
 ]
 
 
@@ -997,7 +918,7 @@ def power_of_10[
 
         **WARNING**: The bound on `n` is only checked when `debug_assert`
         is enabled. Callers must guarantee `0 <= n <= 38` for `uint128`
-        and `0 <= n <= 58` for `uint256`. An out-of-range `n` reads past
+        and `0 <= n <= 77` for `uint256`. An out-of-range `n` reads past
         the table and returns garbage in release builds.
 
         Implementation: `global_constant` places the table in static
@@ -1018,7 +939,7 @@ def power_of_10[
         return rebind[Scalar[dtype]](table[n])
     else:
         debug_assert(
-            n >= 0 and n <= 58, "power_of_10[uint256]: n must be in 0..58"
+            n >= 0 and n <= 77, "power_of_10[uint256]: n must be in 0..77"
         )
         ref table = global_constant[_POWER_OF_10_U256]()
         return rebind[Scalar[dtype]](table[n])
@@ -1050,7 +971,7 @@ def power_of_10_unsafe[
 
         **WARNING**: This function performs **no runtime bounds check** in
         release builds (`-D ASSERT=none`). Callers must guarantee
-        `0 <= n <= 29` for `uint128` and `0 <= n <= 58` for `uint256`. A
+        `0 <= n <= 29` for `uint128` and `0 <= n <= 77` for `uint256`. A
         `debug_assert` catches violations in debug builds
         (`-D ASSERT=all`). An out-of-range `n` reads past the table and
         returns garbage; earlier revisions returned `0`, which was never
@@ -1087,7 +1008,7 @@ def power_of_10_unsafe[
         return rebind[Scalar[dtype]](table[n])
     else:
         debug_assert(
-            n >= 0 and n <= 58,
+            n >= 0 and n <= 77,
             "power_of_10_unsafe[uint256]: n out of range, must be 0..58",
         )
         ref table = global_constant[_POWER_OF_10_U256]()
@@ -1109,7 +1030,7 @@ def power_of_10_unsafe[
 #     t1 = mulhi_N(m', n)                 (high N bits of m' * n)
 #     q  = (((n - t1) >> 1) + t1) >> (ell - 1)
 #
-# For `d = 10^k` with `1 ≤ k ≤ 29`, the resulting `m'` is always 256-bit
+# For `d = 10^k` with `1 ≤ k ≤ 48`, the resulting `m'` is always 256-bit
 # and we precompute the table at the bottom of this file. Replacing the
 # 32-step schoolbook divide with a single 256×256→high-256 multiply plus
 # two shifts brings the divide down to roughly the cost of the multiply
@@ -1117,7 +1038,7 @@ def power_of_10_unsafe[
 # UInt256 software loop that LLVM falls back to.
 #
 # Coverage
-# `1 ≤ k ≤ 29` covers every `Decimal128` multiply/round call site
+# `1 ≤ k ≤ 48` covers every `Decimal128` multiply/round call site
 # (since `combined_num_bits ≤ 192` implies `k ≤ 29`). For any future
 # caller that exceeds that range, `round_coefficient` falls back to
 # the native `value // divisor` path.
@@ -1159,20 +1080,20 @@ def _mulhi_u256(a: UInt256, b: UInt256) -> UInt256:
     return hh + (lh >> 128) + (hl >> 128) + (mid >> 128)
 
 
-# Precomputed Granlund-Möller reciprocals for `d = 10^k`, `k ∈ [0, 29]`.
+# Precomputed Granlund-Möller reciprocals for `d = 10^k`, `k ∈ [0, 48]`.
 # Index 0 is unused (zero-padded so callers can use `k` as the index).
 # Each entry is the 256-bit `m' = ceil(2^(256+ell)/d) - 2^256`
 # stored little-endian, 32 bytes per slot.
 #
 # Generated offline (Python, verified against random 2k inputs per `k`):
 #   N = 256
-#   for k in range(1, 30):
+#   for k in range(1, 49):
 #       d   = 10**k
 #       ell = (d-1).bit_length()
 #       m   = -((-(1 << (N+ell))) // d)        # ceil
 #       mp  = m - (1 << N)
 #       blob.extend(mp.to_bytes(32, "little"))
-comptime _GM_RECIPROCAL: Array[UInt256, 30] = [
+comptime _GM_RECIPROCAL: Array[UInt256, 49] = [
     0,  # k=0 unused
     69475253542389717254142591005212744711961990799384338423674550404747877783962,  # k=1
     32421784986448534718599875802432614198915595706379357931048123522215676299183,  # k=2
@@ -1203,12 +1124,30 @@ comptime _GM_RECIPROCAL: Array[UInt256, 30] = [
     27551574262063274052105320947692525946515327157377006194141718453769550115595,  # k=27
     113557772361690955737511104521520786226386514251187548334301299930779157968913,  # k=28
     67687800041889525505294686615479047410455214467821925859549523143040700447143,  # k=29
+    30991822186048381319521552290645656357710174641129427879748101712849934429728,  # k=30
+    1635039901375465970903044830778943515514142779775429495906964568697321615795,  # k=31
+    72091317384590462807587462734459054336784619247025025617125693714663592369233,  # k=32
+    34514636060209131161355773185829661898773698464491907685809038170148247967399,  # k=33
+    4453291000704065844370421546926147948364961838465413340755713734535972445932,  # k=34
+    76600519143516222605135265480294581429345929740928999768883692380005433697453,  # k=35
+    38121997467349738999394015382498083572822746859615087007215437102421721029975,  # k=36
+    7339180126416552114801015304260885287604200554563956797880832880354750895993,  # k=37
+    81217941744656200637824215492030161172128711686686669300283883013315479217551,  # k=38
+    41815935548261721425545175391886547367048972416221222632335589609069757446053,  # k=39
+    10294330591146138055721943311771656322985180999848865297976954885673180028856,  # k=40
+    85946182488223538143297700304047394828738280399142522900437678221824965830130,  # k=41
+    45598528143115591429923963241500334292336627386185905512458625775877346736117,  # k=42
+    13320404667029234059224973591462685863215304975820611602075383819119251460907,  # k=43
+    90787901009636491748902548751553042093106478760697316986995164515338680121412,  # k=44
+    49471902960245954314407841999504852103831186075429740781704614810688318169142,  # k=45
+    16419104520733524366812076597866300112410951927215679817472175046968028607327,  # k=46
+    95745820775563356241041913561798824891819513882929426131630030479896723555684,  # k=47
+    53438238772987445908119333847701478342801614173215428097412507582334752916560,  # k=48
 ]
-
 
 # Per-`k` shift amount (`ell - 1`), 30 entries (index 0 unused).
 # Same offline generation; max value is 96 (k=29), comfortably ≤ 255.
-comptime _GM_SHIFT: Array[UInt8, 30] = [
+comptime _GM_SHIFT: Array[UInt8, 49] = [
     0,  # k=0 unused
     3,  # k=1
     6,  # k=2
@@ -1239,6 +1178,25 @@ comptime _GM_SHIFT: Array[UInt8, 30] = [
     89,  # k=27
     93,  # k=28
     96,  # k=29
+    99,  # k=30
+    102,  # k=31
+    106,  # k=32
+    109,  # k=33
+    112,  # k=34
+    116,  # k=35
+    119,  # k=36
+    122,  # k=37
+    126,  # k=38
+    129,  # k=39
+    132,  # k=40
+    136,  # k=41
+    139,  # k=42
+    142,  # k=43
+    146,  # k=44
+    149,  # k=45
+    152,  # k=46
+    156,  # k=47
+    159,  # k=48
 ]
 
 
@@ -1248,17 +1206,17 @@ def udiv_u256_by_pow10_gm(value: UInt256, k: Int) -> UInt256:
 
     Args:
         value: The UInt256 dividend.
-        k: The exponent. Must satisfy `1 ≤ k ≤ 29`.
+        k: The exponent. Must satisfy `1 ≤ k ≤ 48`.
 
     Returns:
         The quotient `floor(value / 10^k)`.
 
     Notes:
-        Caller must guarantee `1 ≤ k ≤ 29`. No bounds check (not even
+        Caller must guarantee `1 ≤ k ≤ 48`. No bounds check (not even
         via `debug_assert`) is performed — out-of-range `k` will read
         past the precomputed reciprocal table and return garbage.
 
-        For `k = 0` or `k > 29`, use `udiv_u256_by_pow10` instead.
+        For `k = 0` or `k > 48`, use `udiv_u256_by_pow10` instead.
 
         Cost: ~5 ns on aarch64 (single 256×256→high-256 multiply +
         two shifts), versus ~22 ns for `udiv_u256_by_pow10`.
@@ -1271,7 +1229,7 @@ def udiv_u256_by_pow10_gm(value: UInt256, k: Int) -> UInt256:
     """
     # `global_constant` emits each table once into program-lifetime rodata
     # and hands back a `ref`, so this is two indexed loads with no
-    # per-call-site setup. `materialize` rebuilt the 30 x UInt256
+    # per-call-site setup. `materialize` rebuilt the 49 x UInt256
     # reciprocal table on the stack at every inlined site: 19.05 ns/call
     # for the whole divider versus 3.93 ns here (osx-arm64, release
     # build). See the notes above the power-of-10 tables.

--- a/src/decimo/decimal128/wide.mojo
+++ b/src/decimo/decimal128/wide.mojo
@@ -1,0 +1,1246 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2025-2026 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+#
+# A wider number for Decimal128 to compute with
+#
+# ===----------------------------------------------------------------------=== #
+
+"""Implements `Wide`, the intermediate value `Decimal128`'s series run on.
+
+`Decimal128` holds 28 digits. A series summed in it rounds every term to
+those 28 digits, and a few hundred terms of rounding is a few units in the
+last place of the answer: `ln` was wrong in 63 of 80 random cases, by up to 6
+units, and `exp` in 19 of 25, by up to 8.
+
+`Wide` gives those series ten digits of room. It is a sign, a `UInt256`
+mantissa held at exactly `DIGITS` digits, and a power of ten -- a small
+floating-point number in base ten, and nothing more than the series and the
+reductions need. It does not depend on `BigDecimal` or any other
+arbitrary-precision type: `Decimal128` is a plain struct and stays one.
+
+Thirty-eight digits is what the mantissa can hold and still be multiplied:
+`10^38 * 10^38` is `10^76`, and `UInt256` reaches `1.15E+77`.
+"""
+
+from std.builtin.globals import global_constant
+
+from decimo.decimal128.decimal128 import Decimal128
+import decimo.decimal128.utility as decimal128_utility
+from decimo.errors import ValueError, OverflowError
+from decimo.rounding_mode import RoundingMode
+
+
+struct WideValue[DIGITS: Int](Copyable, Movable):
+    """A signed number of `DIGITS` decimal digits and a power of ten.
+
+    The value is `(-1)^sign * mantissa * 10^exponent`. The mantissa is kept
+    at exactly `DIGITS` digits, or zero, so that every operation starts from
+    the same shape.
+
+    Parameters:
+        DIGITS: How many digits the mantissa carries. At 38 or fewer a
+            product of two mantissas still fits in `UInt256` and the
+            multiplication is one instruction; above that it is done in
+            halves, which costs three multiplications instead of one. The
+            two widths in use are `Wide` and `Extended`.
+    """
+
+    var mantissa: UInt256
+    """The digits, exactly `DIGITS` of them unless the value is zero."""
+
+    var exponent: Int
+    """The power of ten the mantissa is multiplied by."""
+
+    var sign: Bool
+    """True when the value is negative."""
+
+    def __init__(out self):
+        """Constructs zero."""
+        self.mantissa = UInt256(0)
+        self.exponent = 0
+        self.sign = False
+
+    def __init__(out self, var mantissa: UInt256, exponent: Int, sign: Bool):
+        """Constructs a value and normalizes it.
+
+        Args:
+            mantissa: The digits, of any length.
+            exponent: The power of ten they are multiplied by.
+            sign: True for a negative value.
+        """
+        self.mantissa = mantissa
+        self.exponent = exponent
+        self.sign = sign
+        self._normalize()
+
+    @staticmethod
+    def from_int(value: Int) -> Self:
+        """Returns a whole number as a `Wide`.
+
+        Args:
+            value: The number.
+
+        Returns:
+            The same value, normalized.
+        """
+        var magnitude = UInt256(abs(value))
+        return Self(magnitude, 0, value < 0)
+
+    @staticmethod
+    def from_decimal(value: Decimal128) -> Self:
+        """Returns a `Decimal128` as a `Wide`, exactly.
+
+        Args:
+            value: The number to widen.
+
+        Returns:
+            The same value with room to compute in.
+        """
+        return Self(
+            UInt256(value.coefficient()),
+            -value.scale(),
+            value.is_negative(),
+        )
+
+    def _normalize(mut self):
+        """Brings the mantissa to exactly `DIGITS` digits."""
+        if self.mantissa == UInt256(0):
+            self.exponent = 0
+            self.sign = False
+            return
+
+        var digits = decimal128_utility.number_of_digits(self.mantissa)
+        if digits > Self.DIGITS:
+            var drop = digits - Self.DIGITS
+            # `round_coefficient` with the digit count already in hand: it
+            # goes through the reciprocal divider, where the deprecated
+            # `round_to_keep_first_n_digits` pays a software divide and a
+            # software modulo, 313 ns against 8.
+            self.mantissa = decimal128_utility.round_coefficient[
+                skip_digit_check=True
+            ](self.mantissa, drop, self.sign)
+            self.exponent += drop
+            # Rounding up can carry into one more digit: 999... becomes 1000...
+            if self.mantissa >= decimal128_utility.power_of_10[DType.uint256](
+                Self.DIGITS
+            ):
+                self.mantissa //= UInt256(10)
+                self.exponent += 1
+        elif digits < Self.DIGITS:
+            var raise_by = Self.DIGITS - digits
+            self.mantissa *= decimal128_utility.power_of_10[DType.uint256](
+                raise_by
+            )
+            self.exponent -= raise_by
+
+    def is_zero(self) -> Bool:
+        """Returns whether the value is zero.
+
+        Returns:
+            True when the mantissa is zero.
+        """
+        return self.mantissa == UInt256(0)
+
+    def __neg__(self) -> Self:
+        """Returns the value with its sign flipped.
+
+        Returns:
+            The negation.
+        """
+        var result = self.copy()
+        if not result.is_zero():
+            result.sign = not result.sign
+        return result^
+
+    def __add__(self, other: Self) raises -> Self:
+        """Returns the sum.
+
+        Args:
+            other: The value to add.
+
+        Returns:
+            The sum, normalized.
+
+        Raises:
+            Error: If aligning the two would need more digits than `UInt256`
+                holds, which cannot happen for values a series produces.
+        """
+        if self.is_zero():
+            return other.copy()
+        if other.is_zero():
+            return self.copy()
+
+        # Line the two up on the lower exponent. Beyond `DIGITS` apart the
+        # smaller one cannot change a digit of the larger.
+        var gap = self.exponent - other.exponent
+        if gap > Self.DIGITS:
+            return self.copy()
+        if gap < -Self.DIGITS:
+            return other.copy()
+
+        var left = self.mantissa
+        var right = other.mantissa
+        var exponent: Int
+        # Lining the two up either lengthens the larger mantissa or shortens
+        # the smaller one. Lengthening keeps every digit and is what a `Wide`
+        # does, since 38 digits and a gap of at most 38 still fit `UInt256`.
+        # At 75 they do not, and there the smaller value gives up the digits
+        # below the larger one's last -- under a unit in the last place, and
+        # the only way to hold the sum at all.
+        comptime room = 77 - Self.DIGITS
+        if gap > 0:
+            exponent = other.exponent
+            if gap <= room:
+                left *= decimal128_utility.power_of_10[DType.uint256](gap)
+            else:
+                right //= decimal128_utility.power_of_10[DType.uint256](gap)
+                exponent = self.exponent
+        elif gap < 0:
+            exponent = self.exponent
+            if -gap <= room:
+                right *= decimal128_utility.power_of_10[DType.uint256](-gap)
+            else:
+                left //= decimal128_utility.power_of_10[DType.uint256](-gap)
+                exponent = other.exponent
+        else:
+            exponent = self.exponent
+
+        if self.sign == other.sign:
+            return Self(left + right, exponent, self.sign)
+        if left >= right:
+            return Self(left - right, exponent, self.sign)
+        return Self(right - left, exponent, other.sign)
+
+    def __sub__(self, other: Self) raises -> Self:
+        """Returns the difference.
+
+        Args:
+            other: The value to subtract.
+
+        Returns:
+            The difference, normalized.
+
+        Raises:
+            Error: Propagated from the addition.
+        """
+        return self + (-other)
+
+    def __mul__(self, other: Self) raises -> Self:
+        """Returns the product.
+
+        Args:
+            other: The value to multiply by.
+
+        Returns:
+            The product, normalized.
+
+        Raises:
+            Error: Propagated from the normalization.
+
+        Notes:
+
+        Below 39 digits both mantissas are under `10^38`, so their product is
+        under `10^76` and `UInt256` holds it whole.
+
+        Wider than that it does not fit, and the product is assembled from
+        halves. Splitting each mantissa at `10^h` gives four partial products,
+        each inside `UInt256`, and only the top `DIGITS` digits of their sum
+        are kept -- the rest is below the last digit either way. The two
+        truncations cost less than two units in the last place, which at 75
+        digits is forty digits below anything `Decimal128` prints.
+        """
+        if self.is_zero() or other.is_zero():
+            return Self()
+
+        comptime if Self.DIGITS <= 38:
+            return Self(
+                self.mantissa * other.mantissa,
+                self.exponent + other.exponent,
+                self.sign != other.sign,
+            )
+        else:
+            # Split each mantissa at `10^half`, so that
+            #
+            #     a * b = ah*bh*10^(2*half)
+            #           + (ah*bl + al*bh)*10^half
+            #           + al*bl
+            #
+            # and keep the top `DIGITS` digits of that. The last piece is
+            # below `10^DIGITS` and disappears entirely; the middle one loses
+            # its own last digits to the shift. Together that is under two
+            # units in the last place.
+            comptime half = (Self.DIGITS + 1) // 2
+            var split = decimal128_utility.power_of_10[DType.uint256](half)
+            var left_high = self.mantissa // split
+            var left_low = self.mantissa % split
+            var right_high = other.mantissa // split
+            var right_low = other.mantissa % split
+            var top = (
+                left_high
+                * right_high
+                * decimal128_utility.power_of_10[DType.uint256](
+                    2 * half - Self.DIGITS
+                )
+            )
+            var middle = decimal128_utility.udiv_u256_by_pow10_gm(
+                left_high * right_low + left_low * right_high,
+                Self.DIGITS - half,
+            )
+            return Self(
+                top + middle,
+                self.exponent + other.exponent + Self.DIGITS,
+                self.sign != other.sign,
+            )
+
+    def divide_by_int(self, divisor: Int) raises -> Self:
+        """Returns the value divided by a whole number.
+
+        Args:
+            divisor: The number to divide by. It may not be zero.
+
+        Returns:
+            The quotient, normalized and carrying `DIGITS` digits.
+
+        Raises:
+            ValueError: If the divisor is zero.
+
+        Notes:
+
+        The mantissa is raised before the division so that the quotient
+        keeps its digits rather than losing them to truncation. How far it
+        can be raised depends on the width: at 38 digits there is room for
+        another 38, at 75 for only two, which leaves the quotient a unit in
+        the last place short of exact. Forty digits below what `Decimal128`
+        prints, that does not reach the answer.
+        """
+        if divisor == 0:
+            raise ValueError(
+                message="Division by zero.", function="Wide.divide_by_int()"
+            )
+        if self.is_zero():
+            return Self()
+        comptime headroom = min(Self.DIGITS, 76 - Self.DIGITS)
+        var scaled = self.mantissa * decimal128_utility.power_of_10[
+            DType.uint256
+        ](headroom)
+        return Self(
+            decimal128_utility.udiv_u256_by_u64(scaled, UInt64(abs(divisor)))[
+                0
+            ],
+            self.exponent - headroom,
+            self.sign != (divisor < 0),
+        )
+
+    def __truediv__(self, other: Self) raises -> Self:
+        """Returns the quotient of two values.
+
+        Args:
+            other: The divisor. It may not be zero.
+
+        Returns:
+            The quotient, normalized.
+
+        Raises:
+            ValueError: If the divisor is zero.
+        """
+        if other.is_zero():
+            raise ValueError(
+                message="Division by zero.", function="Wide.__truediv__()"
+            )
+        if self.is_zero():
+            return Self()
+
+        comptime if Self.DIGITS <= 38:
+            var scaled = self.mantissa * decimal128_utility.power_of_10[
+                DType.uint256
+            ](Self.DIGITS)
+            return Self(
+                scaled // other.mantissa,
+                self.exponent - other.exponent - Self.DIGITS,
+                self.sign != other.sign,
+            )
+        else:
+            # A 75-digit dividend cannot be raised by another 75 digits to
+            # divide it in one go. Newton doubles a narrow reciprocal
+            # instead: `r <- r * (2 - b * r)` takes the 38 correct digits of
+            # a `Wide` reciprocal to 76, which is one more than this width
+            # holds. Two multiplications, no long division.
+            # The iteration works on magnitudes; the sign goes on at the
+            # end, or the correction term would be subtracting a negative.
+            var positive_other = other.copy()
+            positive_other.sign = False
+            var narrow = (
+                WideValue[38](UInt256(1), 0, False)
+                / positive_other.to_width[38]()
+            )
+            var reciprocal = narrow.to_width[Self.DIGITS]()
+            var two = Self.from_int(2)
+            reciprocal = reciprocal * (two - positive_other * reciprocal)
+            var result = self * reciprocal
+            result.sign = self.sign != other.sign
+            return result^
+
+    def compare_absolute(self, other: Self) -> Int:
+        """Compares the magnitudes of two values.
+
+        Args:
+            other: The value to compare against.
+
+        Returns:
+            `1` when this one is larger, `-1` when smaller, `0` when equal.
+        """
+        if self.is_zero():
+            return 0 if other.is_zero() else -1
+        if other.is_zero():
+            return 1
+        if self.exponent != other.exponent:
+            return 1 if self.exponent > other.exponent else -1
+        if self.mantissa == other.mantissa:
+            return 0
+        return 1 if self.mantissa > other.mantissa else -1
+
+    def to_width[TARGET: Int](self) raises -> WideValue[TARGET]:
+        """Returns the same number carried at another width.
+
+        Parameters:
+            TARGET: The width to carry it at.
+
+        Returns:
+            The value, padded with zeros when the target is wider and
+            rounded when it is narrower.
+
+        Raises:
+            Error: Propagated from the construction.
+        """
+        return WideValue[TARGET](self.mantissa, self.exponent, self.sign)
+
+    def scaled_by_power_of_ten(self, places: Int) -> Self:
+        """Returns the value multiplied by a power of ten.
+
+        Args:
+            places: The power, which may be negative.
+
+        Returns:
+            The same digits with the exponent moved, which is exact and costs
+            nothing.
+        """
+        var result = self.copy()
+        if not result.is_zero():
+            result.exponent += places
+        return result^
+
+    def to_int_truncated(self) raises -> Int:
+        """Returns the value with everything after the point dropped.
+
+        Returns:
+            The whole part, truncated toward zero.
+
+        Raises:
+            Error: Propagated from the arithmetic.
+        """
+        if self.is_zero() or self.exponent <= -Self.DIGITS:
+            return 0
+        var magnitude: UInt256
+        if self.exponent >= 0:
+            magnitude = self.mantissa * decimal128_utility.power_of_10[
+                DType.uint256
+            ](self.exponent)
+        else:
+            magnitude = decimal128_utility.udiv_u256_by_pow10_gm(
+                self.mantissa, -self.exponent
+            )
+        var value = Int(magnitude)
+        return -value if self.sign else value
+
+    def to_int_nearest(self) raises -> Int:
+        """Returns the nearest whole number.
+
+        Returns:
+            The value rounded to an integer, ties away from zero. Used to
+            split an exponent into a whole multiple of `ln(2)` and a small
+            remainder, where the multiple is small enough for `Int`.
+
+        Raises:
+            Error: Propagated from the arithmetic.
+        """
+        if self.is_zero():
+            return 0
+        # Half, to round away from zero by adding before truncating.
+        var half = Self(UInt256(5), -1, False)
+        if self.sign:
+            half = -half
+        var shifted = self + half
+        if shifted.exponent >= 0:
+            var value = Int(
+                shifted.mantissa
+                * decimal128_utility.power_of_10[DType.uint256](
+                    shifted.exponent
+                )
+            )
+            return -value if self.sign else value
+        var drop = -shifted.exponent
+        var digits = Self.DIGITS
+        if drop >= digits:
+            return 0
+        var value = Int(
+            decimal128_utility.udiv_u256_by_pow10_gm(shifted.mantissa, drop)
+        )
+        return -value if self.sign else value
+
+    def to_decimal(self) raises -> Decimal128:
+        """Returns the value as a `Decimal128`, rounded once.
+
+        Returns:
+            The nearest `Decimal128`, ties to even -- the only rounding in a
+            computation that stayed in this type throughout.
+
+        Raises:
+            OverflowError: If the value is outside what `Decimal128` holds.
+            Error: Propagated from the construction.
+        """
+        return self.to_decimal_decided(UInt256(0)).value()
+
+    def to_decimal_decided(self, slack: UInt256) raises -> Optional[Decimal128]:
+        """Returns the value as a `Decimal128`, or nothing if the digits
+        being dropped do not say which way it rounds.
+
+        Args:
+            slack: How far the mantissa may be from the true value, in units
+                of its last digit. Zero asserts the value is exact and always
+                answers.
+
+        Returns:
+            The rounded value, or nothing when the answer depends on digits
+            this width does not have.
+
+        Raises:
+            OverflowError: If the value is outside what `Decimal128` holds.
+            Error: Propagated from the construction.
+
+        Notes:
+            A computation is trusted to `slack` units in the last place. That
+            makes the mantissa an interval, and the interval settles the
+            answer unless it straddles a boundary:
+
+            - the midpoint between two neighbouring `Decimal128` values,
+              where the rounding itself is in doubt;
+            - a whole multiple of the digits being dropped, where the
+              rounding is not in doubt but the claim that nothing was lost
+              is, and that claim decides whether trailing zeros are kept.
+
+            Three comparisons on the discarded tail, which the rounding
+            computes anyway. When they say the width is not enough, the
+            caller runs the same computation at `Extended`, which has
+            forty-six digits below the answer instead of nine.
+        """
+        if self.is_zero():
+            return Decimal128.ZERO()
+
+        # `Decimal128` is a coefficient and a scale between 0 and 28, so the
+        # mantissa has to be brought to an exponent in that range and to no
+        # more digits than the type holds.
+        var mantissa = self.mantissa
+        var exponent = self.exponent
+
+        if exponent > 0:
+            # Whole number with trailing zeros: spell them out, if they fit.
+            var digits = decimal128_utility.number_of_digits(mantissa)
+            if digits + exponent > Decimal128.MAX_NUM_DIGITS:
+                raise OverflowError(
+                    message="Value too large for Decimal128.",
+                    function="WideValue.to_decimal_decided()",
+                )
+            mantissa *= decimal128_utility.power_of_10[DType.uint256](exponent)
+            exponent = 0
+
+        # One rounding, not two. Bringing the scale inside 28 and then the
+        # coefficient inside 96 bits used to round twice, and the first
+        # rounding could hand the second a tie that the true value does not
+        # sit on: `ln(53862.913065970264)` continues `...0954941`, which the
+        # first rounding turned into `...0955` and the second carried up to
+        # `...096`, one unit above the answer. So the two demands are counted
+        # first and the digits go in a single step.
+        var scale = -exponent
+        var digits = decimal128_utility.number_of_digits(mantissa)
+        var room = decimal128_utility.number_of_digits(
+            Decimal128.MAX_AS_UINT256
+        )
+
+        var drop = 0
+        if scale > Decimal128.MAX_SCALE:
+            drop = scale - Decimal128.MAX_SCALE
+        if digits - drop > room:
+            drop = digits - room
+
+        var exact = True
+        if drop > 0:
+            # Dropping every digit is not the same as dropping the value.
+            # `ln(1.0000000000000000000000000001)` comes to `9.99...E-29`,
+            # whose 38 digits all sit below the smallest scale `Decimal128`
+            # has; rounding them says `1E-28`, and returning zero here said
+            # zero.
+            var kept = decimal128_utility.round_coefficient(
+                mantissa, drop, self.sign
+            )
+            # A coefficient of the right length can still be too large: 29
+            # digits reach `9.9E+28` where the type stops at `7.9E+28`. One
+            # more digit has to go, and it goes from the original mantissa
+            # rather than from this one, so that the value is still rounded
+            # only once.
+            if kept > Decimal128.MAX_AS_UINT256:
+                if scale - drop == 0:
+                    raise OverflowError(
+                        message="Value too large for Decimal128.",
+                        function="WideValue.to_decimal_decided()",
+                    )
+                drop += 1
+                kept = decimal128_utility.round_coefficient(
+                    mantissa, drop, self.sign
+                )
+
+            if not Self._tail_decides(mantissa, drop, slack):
+                return None
+
+            if drop > 77 or (
+                kept * decimal128_utility.power_of_10[DType.uint256](drop)
+                != mantissa
+            ):
+                exact = False
+            mantissa = kept
+            scale -= drop
+        elif mantissa > Decimal128.MAX_AS_UINT256:
+            raise OverflowError(
+                message="Value too large for Decimal128.",
+                function="WideValue.to_decimal_decided()",
+            )
+
+        # Trailing zeros are dropped only when the value is exact at this
+        # width -- when nothing but zeros was rounded away. `log(8, 2)` is
+        # three, not 3.0000000000000000000000000000; but the two zeros that
+        # end `sqrt(99)` at 29 digits are digits of the answer, since it goes
+        # on `...100121`, and dropping them would claim less than is known.
+        if exact:
+            while scale > 0 and mantissa % UInt256(10) == UInt256(0):
+                mantissa //= UInt256(10)
+                scale -= 1
+
+        return Decimal128.from_uint128(
+            UInt128(mantissa), UInt32(scale), self.sign
+        )
+
+    @staticmethod
+    def _tail_decides(mantissa: UInt256, drop: Int, slack: UInt256) -> Bool:
+        """Returns whether the digits being dropped settle the rounding.
+
+        Args:
+            mantissa: The digits, before rounding.
+            drop: How many of them go.
+            slack: How far the mantissa may be from the true value, in units
+                of its last digit.
+
+        Returns:
+            False when the true value could be on either side of the
+            midpoint, or on either side of an exact multiple.
+        """
+        if slack == UInt256(0):
+            return True
+        if drop > 77:
+            # More digits go than any power of ten this reaches; whatever is
+            # left is far too close to zero to call.
+            return False
+
+        var unit = decimal128_utility.power_of_10[DType.uint256](drop)
+        var truncated: UInt256
+        if drop <= 48:
+            truncated = decimal128_utility.udiv_u256_by_pow10_gm(mantissa, drop)
+        else:
+            truncated = mantissa // unit
+        var remainder = mantissa - truncated * unit
+
+        # Near an exact multiple, from either side: the rounding is clear but
+        # the claim that nothing was lost is not.
+        if remainder <= slack:
+            return remainder == UInt256(0)
+        if unit - remainder <= slack:
+            return False
+
+        # Near the midpoint: the rounding itself is not clear. Doubled, to
+        # compare against the unit rather than half of it.
+        var doubled = remainder << 1
+        if doubled >= unit:
+            return doubled - unit > slack << 1
+        return unit - doubled > slack << 1
+
+
+comptime Wide = WideValue[38]
+"""The width the series run at.
+
+Ten digits more than `Decimal128` holds, and the widest whose mantissas
+multiply inside `UInt256` in one instruction.
+"""
+
+
+comptime Extended = WideValue[75]
+"""The width a second attempt runs at.
+
+Reached only when the first attempt cannot say which way the answer rounds.
+Forty-six digits past what `Decimal128` keeps, against the nine a `Wide`
+has, so a tie the first width could not resolve is resolved here.
+"""
+
+
+# ===----------------------------------------------------------------------=== #
+# Constants, at the width the series work in
+#
+# `Decimal128` holds these to 28 digits, which is what they were multiplied by
+# a moment before the answer was rounded: `q * ln(10)` with `q` up to 28 threw
+# away more than the answer's last digit was worth. At 38 they do not.
+# ===----------------------------------------------------------------------=== #
+
+
+def wide_ln2() -> Wide:
+    """Returns `ln(2)` to 38 digits.
+
+    Returns:
+        0.69314718055994530941723212145817656808, the correctly rounded
+        value of 0.693147180559945309417232121458176568075500134...
+    """
+    return Wide(UInt256(69314718055994530941723212145817656808), -38, False)
+
+
+def wide_ln10() -> Wide:
+    """Returns `ln(10)` to 38 digits.
+
+    Returns:
+        2.3025850929940456840179914546843642076, the correctly rounded value
+        of 2.30258509299404568401799145468436420760110148...
+    """
+    return Wide(UInt256(23025850929940456840179914546843642076), -37, False)
+
+
+# ===----------------------------------------------------------------------=== #
+# Fixed point, for the series themselves
+#
+# A `Wide` normalizes after every operation -- counts its digits, shifts,
+# rounds -- which a series of forty terms pays forty times over. Inside a
+# series none of that is needed: every value there is between -2 and 2, so a
+# fixed scale holds them all, an addition is an addition, and a multiplication
+# is one division by a constant.
+#
+# The series run here and hand a `Fixed` back to `Wide` at the end.
+# ===----------------------------------------------------------------------=== #
+
+comptime FIXED_SCALE = 37
+"""Decimal places a `Fixed` carries.
+
+Values in a series are below two, so the mantissa stays under `2E+37` and the
+product of two under `4E+74`, which `Int256` holds.
+"""
+
+
+comptime FIXED_ONE = Int256(10) ** FIXED_SCALE
+"""One, in fixed point."""
+
+
+def fixed_from_wide(value: Wide) raises -> Int256:
+    """Returns a `Wide` as a fixed-point value.
+
+    Args:
+        value: The value, whose magnitude must be below two.
+
+    Returns:
+        Its mantissa at `FIXED_SCALE` decimal places.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+    """
+    if value.is_zero():
+        return Int256(0)
+    var shift = FIXED_SCALE + value.exponent
+    if shift < -FIXED_SCALE:
+        # Below what the fixed scale can hold.
+        return Int256(0)
+    var magnitude: UInt256
+    if shift >= 0:
+        magnitude = value.mantissa * decimal128_utility.power_of_10[
+            DType.uint256
+        ](shift)
+    else:
+        magnitude = decimal128_utility.udiv_u256_by_pow10_gm(
+            value.mantissa, -shift
+        )
+    var result = Int256(magnitude)
+    return -result if value.sign else result
+
+
+def wide_from_fixed(value: Int256) raises -> Wide:
+    """Returns a fixed-point value as a `Wide`.
+
+    Args:
+        value: The mantissa at `FIXED_SCALE` decimal places.
+
+    Returns:
+        The same number, normalized.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    if value == Int256(0):
+        return Wide()
+    var negative = value < Int256(0)
+    var magnitude = UInt256(-value if negative else value)
+    return Wide(magnitude, -FIXED_SCALE, negative)
+
+
+@always_inline
+def fixed_multiply(left: Int256, right: Int256) -> Int256:
+    """Returns the product of two fixed-point values.
+
+    Args:
+        left: The first factor.
+        right: The second factor.
+
+    Returns:
+        Their product, at the same scale. Truncated toward zero rather than
+        rounded, which costs less than one unit in the last place of a value
+        carrying nine digits more than the answer keeps.
+
+    Notes:
+        The scaling division goes through the reciprocal divider, which is
+        the whole point of the fixed-point form: a series term costs one
+        multiplication and one multiply-high instead of a software divide.
+    """
+    var negative = (left < Int256(0)) != (right < Int256(0))
+    var magnitude = UInt256(abs(left)) * UInt256(abs(right))
+    var scaled = Int256(
+        decimal128_utility.udiv_u256_by_pow10_gm(magnitude, FIXED_SCALE)
+    )
+    return -scaled if negative else scaled
+
+
+@always_inline
+def fixed_divide_by_int(value: Int256, divisor: Int) -> Int256:
+    """Returns a fixed-point value divided by a small whole number.
+
+    Args:
+        value: The dividend.
+        divisor: The divisor, which must be positive.
+
+    Returns:
+        The quotient, truncated toward zero.
+    """
+    var negative = value < Int256(0)
+    var quotient = Int256(
+        decimal128_utility.udiv_u256_by_u64(
+            UInt256(abs(value)), UInt64(divisor)
+        )[0]
+    )
+    return -quotient if negative else quotient
+
+
+# ===----------------------------------------------------------------------=== #
+# Precomputed exponentials, to the width a `Wide` carries
+#
+# `exp` splits its argument into a whole part, two decimal digits, and a
+# residual below 0.01, and looks the first three up here. The residual then
+# needs about a dozen series terms instead of the thirty-odd a plain
+# reduction leaves. `Decimal128` has the same table at its own width; these
+# carry ten digits more, so the multiplications that assemble the answer no
+# longer decide its last digit.
+# ===----------------------------------------------------------------------=== #
+
+comptime _E_POWER_OF_TWO_MANTISSA: Array[UInt256, 7] = [
+    27182818284590452353602874713526624978,  # e^1
+    73890560989306502272304274605750078132,  # e^2
+    54598150033144239078110261202860878403,  # e^4
+    29809579870417282747435920994528886738,  # e^8
+    88861105205078726367630237407814503508,  # e^16
+    78962960182680695160978022635108224220,  # e^32
+    62351490808116168829092387089284697448,  # e^64
+]
+
+
+comptime _E_POWER_OF_TWO_EXPONENT: Array[Int, 7] = [
+    -37,  # e^1
+    -37,  # e^2
+    -36,  # e^4
+    -34,  # e^8
+    -31,  # e^16
+    -24,  # e^32
+    -10,  # e^64
+]
+
+
+comptime _E_TENTH_MANTISSA: Array[UInt256, 10] = [
+    10000000000000000000000000000000000000,  # e^0.0
+    11051709180756476248117078264902466682,  # e^0.1
+    12214027581601698339210719946396741703,  # e^0.2
+    13498588075760031039837443133280073304,  # e^0.3
+    14918246976412703178248529528372222806,  # e^0.4
+    16487212707001281468486507878141635717,  # e^0.5
+    18221188003905089748753676681628645134,  # e^0.6
+    20137527074704765216245493885830652700,  # e^0.7
+    22255409284924676045795375313950767571,  # e^0.8
+    24596031111569496638001265636024706954,  # e^0.9
+]
+
+
+comptime _E_TENTH_EXPONENT: Array[Int, 10] = [
+    -37,  # e^0.0
+    -37,  # e^0.1
+    -37,  # e^0.2
+    -37,  # e^0.3
+    -37,  # e^0.4
+    -37,  # e^0.5
+    -37,  # e^0.6
+    -37,  # e^0.7
+    -37,  # e^0.8
+    -37,  # e^0.9
+]
+
+
+comptime _E_HUNDREDTH_MANTISSA: Array[UInt256, 10] = [
+    10000000000000000000000000000000000000,  # e^0.00
+    10100501670841680575421654569028600338,  # e^0.01
+    10202013400267558101601439204831514353,  # e^0.02
+    10304545339535168556124399538311981329,  # e^0.03
+    10408107741923882267570447579168547441,  # e^0.04
+    10512710963760240396975176363356452202,  # e^0.05
+    10618365465453596222246848771683723284,  # e^0.06
+    10725081812542164790531039498891146056,  # e^0.07
+    10832870676749585544359877586748885002,  # e^0.08
+    10941742837052103578728976235448860118,  # e^0.09
+]
+
+
+comptime _E_HUNDREDTH_EXPONENT: Array[Int, 10] = [
+    -37,  # e^0.00
+    -37,  # e^0.01
+    -37,  # e^0.02
+    -37,  # e^0.03
+    -37,  # e^0.04
+    -37,  # e^0.05
+    -37,  # e^0.06
+    -37,  # e^0.07
+    -37,  # e^0.08
+    -37,  # e^0.09
+]
+
+
+def wide_e_power_of_two(index: Int) -> Wide:
+    """Returns `e**(2**index)` to the width a `Wide` carries.
+
+    Args:
+        index: The bit position, from 0 to 6. A `Decimal128` overflows above
+            `e**66`, so the seven entries cover every whole part.
+
+    Returns:
+        The constant.
+    """
+    ref mantissas = global_constant[_E_POWER_OF_TWO_MANTISSA]()
+    ref exponents = global_constant[_E_POWER_OF_TWO_EXPONENT]()
+    return Wide(mantissas[index], exponents[index], False)
+
+
+def wide_e_tenth(digit: Int) -> Wide:
+    """Returns `e**(digit / 10)` to the width a `Wide` carries.
+
+    Args:
+        digit: The digit, from 0 to 9.
+
+    Returns:
+        The constant.
+    """
+    ref mantissas = global_constant[_E_TENTH_MANTISSA]()
+    ref exponents = global_constant[_E_TENTH_EXPONENT]()
+    return Wide(mantissas[digit], exponents[digit], False)
+
+
+def wide_e_hundredth(digit: Int) -> Wide:
+    """Returns `e**(digit / 100)` to the width a `Wide` carries.
+
+    Args:
+        digit: The digit, from 0 to 9.
+
+    Returns:
+        The constant.
+    """
+    ref mantissas = global_constant[_E_HUNDREDTH_MANTISSA]()
+    ref exponents = global_constant[_E_HUNDREDTH_EXPONENT]()
+    return Wide(mantissas[digit], exponents[digit], False)
+
+
+# ===----------------------------------------------------------------------=== #
+# The same constants at the second width
+#
+# Narrowing any of these to 38 digits gives the constant above it, which a
+# test checks: one value, written twice, so the second attempt cannot quietly
+# disagree with the first.
+# ===----------------------------------------------------------------------=== #
+
+
+def extended_ln2() -> Extended:
+    """Returns `ln(2)` to 75 digits.
+
+    Returns:
+        The correctly rounded value.
+    """
+    return Extended(
+        UInt256(
+            693147180559945309417232121458176568075500134360255254120680009493393621970
+        ),
+        -75,
+        False,
+    )
+
+
+def extended_ln10() -> Extended:
+    """Returns `ln(10)` to 75 digits.
+
+    Returns:
+        The correctly rounded value.
+    """
+    return Extended(
+        UInt256(
+            230258509299404568401799145468436420760110148862877297603332790096757260968
+        ),
+        -74,
+        False,
+    )
+
+
+comptime _EXTENDED_E_POWER_OF_TWO_MANTISSA: Array[UInt256, 7] = [
+    271828182845904523536028747135266249775724709369995957496696762772407663035,  # e^1
+    738905609893065022723042746057500781318031557055184732408712782252257379608,  # e^2
+    545981500331442390781102612028608784027907370386140687258265939585536620999,  # e^4
+    298095798704172827474359209945288867375596793913283570220896353038773072517,  # e^8
+    888611052050787263676302374078145035080271982185663883978398831704898093732,  # e^16
+    789629601826806951609780226351082242199561951153523306550800205987543078540,  # e^32
+    623514908081161688290923870892846974483139184623579991438859169901398477629,  # e^64
+]
+
+
+comptime _EXTENDED_E_POWER_OF_TWO_EXPONENT: Array[Int, 7] = [
+    -74,  # e^1
+    -74,  # e^2
+    -73,  # e^4
+    -71,  # e^8
+    -68,  # e^16
+    -61,  # e^32
+    -47,  # e^64
+]
+
+
+comptime _EXTENDED_E_TENTH_MANTISSA: Array[UInt256, 10] = [
+    100000000000000000000000000000000000000000000000000000000000000000000000000,  # e^0.0
+    110517091807564762481170782649024666822454719473751871879286328944096796675,  # e^0.1
+    122140275816016983392107199463967417030758094152050364127342509859920623308,  # e^0.2
+    134985880757600310398374431332800733037829969735936580304991798993961258740,  # e^0.3
+    149182469764127031782485295283722228064328277393742528159563315007236509871,  # e^0.4
+    164872127070012814684865078781416357165377610071014801157507931164066102119,  # e^0.5
+    182211880039050897487536766816286451338223880854643538632054747658881965030,  # e^0.6
+    201375270747047652162454938858306527001754239414586731156898930087978130086,  # e^0.7
+    222554092849246760457953753139507675705363413504848459611858395555662261021,  # e^0.8
+    245960311115694966380012656360247069542177230644008302074854573665746655294,  # e^0.9
+]
+
+
+comptime _EXTENDED_E_TENTH_EXPONENT: Array[Int, 10] = [
+    -74,  # e^0.0
+    -74,  # e^0.1
+    -74,  # e^0.2
+    -74,  # e^0.3
+    -74,  # e^0.4
+    -74,  # e^0.5
+    -74,  # e^0.6
+    -74,  # e^0.7
+    -74,  # e^0.8
+    -74,  # e^0.9
+]
+
+
+comptime _EXTENDED_E_HUNDREDTH_MANTISSA: Array[UInt256, 10] = [
+    100000000000000000000000000000000000000000000000000000000000000000000000000,  # e^0.00
+    101005016708416805754216545690286003380736220152429251516440403125437419073,  # e^0.01
+    102020134002675581016014392048315143530350899119392557727424105598976469800,  # e^0.02
+    103045453395351685561243995383119813290502514298822332566994548298465627553,  # e^0.03
+    104081077419238822675704475791685474408297705031231203523395718605284804417,  # e^0.04
+    105127109637602403969751763633564522017482129605506252878393847916627986965,  # e^0.05
+    106183654654535962222468487716837232842826042033007905977294622488557261465,  # e^0.06
+    107250818125421647905310394988911460557495897309301363136858199638418466387,  # e^0.07
+    108328706767495855443598775867488850019871357283659396897714913615925800957,  # e^0.08
+    109417428370521035787289762354488601184651990874708511349553727382967794369,  # e^0.09
+]
+
+
+comptime _EXTENDED_E_HUNDREDTH_EXPONENT: Array[Int, 10] = [
+    -74,  # e^0.00
+    -74,  # e^0.01
+    -74,  # e^0.02
+    -74,  # e^0.03
+    -74,  # e^0.04
+    -74,  # e^0.05
+    -74,  # e^0.06
+    -74,  # e^0.07
+    -74,  # e^0.08
+    -74,  # e^0.09
+]
+
+
+def extended_e_power_of_two(index: Int) -> Extended:
+    """Returns `e**(2**index)` to 75 digits.
+
+    Args:
+        index: The bit position, from 0 to 6.
+
+    Returns:
+        The constant.
+    """
+    ref mantissas = global_constant[_EXTENDED_E_POWER_OF_TWO_MANTISSA]()
+    ref exponents = global_constant[_EXTENDED_E_POWER_OF_TWO_EXPONENT]()
+    return Extended(mantissas[index], exponents[index], False)
+
+
+def extended_e_tenth(digit: Int) -> Extended:
+    """Returns `e**(digit / 10)` to 75 digits.
+
+    Args:
+        digit: The digit, from 0 to 9.
+
+    Returns:
+        The constant.
+    """
+    ref mantissas = global_constant[_EXTENDED_E_TENTH_MANTISSA]()
+    ref exponents = global_constant[_EXTENDED_E_TENTH_EXPONENT]()
+    return Extended(mantissas[digit], exponents[digit], False)
+
+
+def extended_e_hundredth(digit: Int) -> Extended:
+    """Returns `e**(digit / 100)` to 75 digits.
+
+    Args:
+        digit: The digit, from 0 to 9.
+
+    Returns:
+        The constant.
+    """
+    ref mantissas = global_constant[_EXTENDED_E_HUNDREDTH_MANTISSA]()
+    ref exponents = global_constant[_EXTENDED_E_HUNDREDTH_EXPONENT]()
+    return Extended(mantissas[digit], exponents[digit], False)
+
+
+# ===----------------------------------------------------------------------=== #
+# Reading a constant at whichever width the caller is working in
+# ===----------------------------------------------------------------------=== #
+
+
+def ln2_at[WIDTH: Int]() raises -> WideValue[WIDTH]:
+    """Returns `ln(2)` at the given width.
+
+    Parameters:
+        WIDTH: The width to return it at.
+
+    Returns:
+        The constant.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    comptime if WIDTH <= 38:
+        return wide_ln2().to_width[WIDTH]()
+    else:
+        return extended_ln2().to_width[WIDTH]()
+
+
+def ln10_at[WIDTH: Int]() raises -> WideValue[WIDTH]:
+    """Returns `ln(10)` at the given width.
+
+    Parameters:
+        WIDTH: The width to return it at.
+
+    Returns:
+        The constant.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    comptime if WIDTH <= 38:
+        return wide_ln10().to_width[WIDTH]()
+    else:
+        return extended_ln10().to_width[WIDTH]()
+
+
+def e_power_of_two_at[WIDTH: Int](index: Int) raises -> WideValue[WIDTH]:
+    """Returns `e**(2**index)` at the given width.
+
+    Parameters:
+        WIDTH: The width to return it at.
+
+    Args:
+        index: The bit position, from 0 to 6.
+
+    Returns:
+        The constant.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    comptime if WIDTH <= 38:
+        return wide_e_power_of_two(index).to_width[WIDTH]()
+    else:
+        return extended_e_power_of_two(index).to_width[WIDTH]()
+
+
+def e_tenth_at[WIDTH: Int](digit: Int) raises -> WideValue[WIDTH]:
+    """Returns `e**(digit / 10)` at the given width.
+
+    Parameters:
+        WIDTH: The width to return it at.
+
+    Args:
+        digit: The digit, from 0 to 9.
+
+    Returns:
+        The constant.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    comptime if WIDTH <= 38:
+        return wide_e_tenth(digit).to_width[WIDTH]()
+    else:
+        return extended_e_tenth(digit).to_width[WIDTH]()
+
+
+def e_hundredth_at[WIDTH: Int](digit: Int) raises -> WideValue[WIDTH]:
+    """Returns `e**(digit / 100)` at the given width.
+
+    Parameters:
+        WIDTH: The width to return it at.
+
+    Args:
+        digit: The digit, from 0 to 9.
+
+    Returns:
+        The constant.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    comptime if WIDTH <= 38:
+        return wide_e_hundredth(digit).to_width[WIDTH]()
+    else:
+        return extended_e_hundredth(digit).to_width[WIDTH]()

--- a/tests/decimal128/test_decimal128_exponential.mojo
+++ b/tests/decimal128/test_decimal128_exponential.mojo
@@ -12,7 +12,7 @@ from decimo.toml.parser import TOMLDocument
 
 from decimo.decimal128.decimal128 import Decimal128, Dec128
 from decimo.rounding_mode import RoundingMode
-from decimo.decimal128.exponential import exp, ln
+from decimo.decimal128.exponential import exp, ln, log, log10, _ln_at
 from decimo.decimal128.special import factorial, factorial_reciprocal
 from decimo.tests import parse_file, load_test_cases
 
@@ -108,10 +108,14 @@ def test_exp_extreme() raises:
 def test_ln_values() raises:
     """Tests ln(x) for basic, fractional, and high-precision inputs."""
     testing.assert_equal(String(ln(Decimal128(1))), "0", "ln(1) should be 0")
-    testing.assert_true(
-        String(Decimal128("2.718281828459045235360287471").ln()).startswith(
-            "1.00000000000000000000"
-        ),
+    # Not one: the argument is `e` rounded to 28 digits, and the logarithm of
+    # that is 0.99999999999999999999999999987..., which rounds to the value
+    # below. This used to answer exactly `1` through a special case that
+    # compared the argument with the stored `E()`, which is the same rounded
+    # value and not `e`.
+    testing.assert_equal(
+        String(Decimal128("2.718281828459045235360287471").ln()),
+        "0.9999999999999999999999999999",
     )
     testing.assert_true(
         String(ln(Decimal128(10))).startswith("2.30258509299404568401799145"),
@@ -534,6 +538,146 @@ def test_factorial_reciprocal() raises:
                 + String(b)
             )
     testing.assert_true(all_equal)
+
+
+def test_exponential_last_digit() raises:
+    """The last digit of `exp`, `ln` and `log10` is the correctly rounded one.
+
+    Every value here was checked against CPython's `decimal` at 70 digits,
+    rounded half-even to the exponent our answer carries. Summing the series
+    in `Decimal128` arithmetic rounded at every term, which left `ln` one to
+    three units out on 108 of 200 random arguments, `log10` on 126 of 200,
+    and `exp` up to four units out.
+    """
+
+    def _check_ln(argument: String, expected: String) raises:
+        testing.assert_equal(String(ln(Decimal128(argument))), expected)
+
+    def _check_log10(argument: String, expected: String) raises:
+        testing.assert_equal(String(log10(Decimal128(argument))), expected)
+
+    def _check_exp(argument: String, expected: String) raises:
+        testing.assert_equal(String(exp(Decimal128(argument))), expected)
+
+    _check_ln("2.75418858096677", "1.0131228732587128905702822980")
+    _check_ln("230530420.12094788948185", "19.255893386187460799821632687")
+    _check_ln("7015765.33870412123024", "15.763670365881893093897028026")
+    _check_ln("29.88302941156153", "3.3972907410545113427119154405")
+    _check_ln("10.55828499794678", "2.3569108595914505776137467763")
+    _check_ln("4.78340403550129", "1.5651524343693196285331875240")
+
+    _check_log10("2.75418858096677", "0.4399936733462265804443260079")
+    _check_log10("7015765.33870412123024", "6.8460750544443209369842541009")
+    _check_log10("29.88302941156153", "1.4754246222609834672114299731")
+    _check_log10("10.55828499794678", "1.0235933806584169421786834025")
+    _check_log10("297.20299815629379", "2.4730531862331090471126515535")
+    _check_log10("6102.77086491489747", "3.7855270642100435986852514547")
+
+    _check_exp("48.937484653331", "1791758787774364200668.9398320")
+    _check_exp("3.112874479482", "22.485585950080698301915058640")
+    _check_exp("3.729434379105", "41.655540255445860472722899403")
+    _check_exp("18.271222522080", "86117441.55228067575146277518")
+    _check_exp("17.560219388215", "42296689.909114876594363483851")
+    _check_exp("20.846923952754", "1131628918.8175081235006184687")
+
+
+def test_exponential_rational_points() raises:
+    """Arguments with a short answer keep it short."""
+    testing.assert_equal(String(exp(Decimal128("0"))), "1")
+    testing.assert_equal(String(ln(Decimal128("1"))), "0")
+    testing.assert_equal(String(log10(Decimal128("1000"))), "3")
+    testing.assert_equal(String(log10(Decimal128("0.001"))), "-3")
+    testing.assert_equal(String(log(Decimal128("8"), Decimal128("2"))), "3")
+
+
+def test_exp_negative_matches_reciprocal() raises:
+    """A negative argument is the reciprocal of the positive one."""
+
+    def _check(argument: String, expected: String) raises:
+        testing.assert_equal(String(exp(Decimal128(argument))), expected)
+
+    _check("-1", "0.3678794411714423215955237702")
+    _check("-12.5", "0.0000037266531720786709929249")
+    _check("-0.005", "0.9950124791926823133525642462")
+
+
+def test_logarithm_on_a_rounding_boundary() raises:
+    """Arguments whose answer sits on the boundary between two results.
+
+    Found by searching three million arguments for one whose thirtieth digit
+    onward reads `5000...` or `4999...`: at that point the first width's own
+    error is wider than the distance to the boundary, so it refuses to round
+    and the computation runs again at 75 digits. Each value below was checked
+    against CPython's `decimal` at 60 digits.
+    """
+    # ...0245000017266..., so the digits below the answer carry it up.
+    testing.assert_equal(
+        String(ln(Decimal128("6215888314.385201"))),
+        "22.550374482409092836854714025",
+    )
+    # ...2254999986937..., just short of the boundary, so it stays put.
+    testing.assert_equal(
+        String(ln(Decimal128("387478688945552.51569"))),
+        "33.590681966940057717836817225",
+    )
+    testing.assert_equal(
+        String(log10(Decimal128("927967429054051.8189"))),
+        "14.967532733082721117334088637",
+    )
+    testing.assert_equal(
+        String(log10(Decimal128("5120760.203168846"))),
+        "6.7093344390097680154396662144",
+    )
+
+
+def test_first_width_refuses_a_boundary() raises:
+    """The first width says it cannot round these, rather than guessing."""
+    var boundary = _ln_at[38](Decimal128("6215888314.385201"))
+    testing.assert_false(
+        Bool(boundary[0].to_decimal_decided(boundary[1])),
+        "38 digits cannot place this answer and should not claim to",
+    )
+    var ordinary = _ln_at[38](Decimal128("123.456"))
+    testing.assert_true(
+        Bool(ordinary[0].to_decimal_decided(ordinary[1])),
+        "an ordinary argument is settled at the first width",
+    )
+    # The wider one settles it, and both widths agree on the ordinary case.
+    var wider = _ln_at[75](Decimal128("6215888314.385201"))
+    testing.assert_true(Bool(wider[0].to_decimal_decided(wider[1])))
+    testing.assert_equal(
+        String(_ln_at[75](Decimal128("123.456"))[0].to_decimal()),
+        String(ordinary[0].to_decimal()),
+    )
+
+
+def test_logarithm_close_to_one() raises:
+    """Arguments a hair from one, where the answer is far smaller than the
+    terms that make it.
+
+    Taking the series directly on `[0.5, 2)` is what keeps these exact: the
+    reduction would add `p * ln(2) + q * ln(10)` and then cancel them back
+    out, spending fourteen of the digits carried to do it.
+    """
+
+    def _check_ln(argument: String, expected: String) raises:
+        testing.assert_equal(String(ln(Decimal128(argument))), expected)
+
+    _check_ln("0.99999999999999", "-0.0000000000000100000000000001")
+    _check_ln(
+        "0.9999999999999999999999999999", "-0.0000000000000000000000000001"
+    )
+    _check_ln(
+        "1.0000000000000000000000000001", "0.0000000000000000000000000001"
+    )
+    _check_ln("0.999999999", "-0.0000000010000000005000000003")
+    _check_ln("1.000000001", "0.0000000009999999995000000003")
+    # Below the smallest scale the type has, and it still rounds rather than
+    # collapsing to zero.
+    testing.assert_equal(
+        String(log10(Decimal128("0.9999999999999999999999999999"))),
+        "-0.0000000000000000000000000000",
+    )
 
 
 def main() raises:

--- a/tests/decimal128/test_decimal128_roots.mojo
+++ b/tests/decimal128/test_decimal128_roots.mojo
@@ -371,5 +371,40 @@ def test_cbrt_approximate() raises:
     )
 
 
+def test_sqrt_last_digit() raises:
+    """The last digit of `sqrt` is the correctly rounded one.
+
+    Every value here was checked against CPython's `decimal` at 70 digits,
+    rounded half-even to the exponent our answer carries. The integer square
+    root path replaced a Newton iteration in `Decimal128` arithmetic, which
+    was one unit out on 75 of 200 random arguments.
+    """
+
+    def _check(argument: String, expected: String) raises:
+        testing.assert_equal(String(Decimal128(argument).sqrt()), expected)
+
+    _check("47.8162940917854", "6.9149326888831969309272301033")
+    _check("29.88302941156153", "5.4665372413952811193190728724")
+    _check("4.78340403550129", "2.1870994571581078420465727157")
+    _check("6102.77086491489747", "78.120233390043692764369492694")
+    _check("46100527.63169216965921", "6789.7369339093079224740531713")
+    _check("159368.68817974381539", "399.21008025818162622965613478")
+
+
+def test_sqrt_keeps_exact_roots_exact() raises:
+    """A square root that comes out exactly is not rounded or padded."""
+    testing.assert_equal(String(Decimal128("4").sqrt()), "2")
+    testing.assert_equal(String(Decimal128("0.25").sqrt()), "0.5")
+    testing.assert_equal(String(Decimal128("1e-28").sqrt()), "0.00000000000001")
+    testing.assert_equal(String(Decimal128("1522756").sqrt()), "1234")
+    # Not exact, and the digits that survive say so: the true root is
+    # 123456789012345.6788999999999979..., which carries to ...6789 at the
+    # fourteenth decimal, all that fits beside fifteen integral digits.
+    testing.assert_equal(
+        String(Decimal128("15241578753238836750190519987").sqrt()),
+        "123456789012345.67890000000000",
+    )
+
+
 def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_utility.mojo
+++ b/tests/decimal128/test_decimal128_utility.mojo
@@ -14,6 +14,8 @@ from decimo.decimal128.utility import (
     round_coefficient,
     round_to_keep_first_n_digits,
     bitcast,
+    power_of_10,
+    udiv_u256_by_pow10_gm,
 )
 
 
@@ -399,6 +401,55 @@ def test_bitcast() raises:
     _check(Decimal128("-987.654321"))
     _check(Decimal128("0.000000000123456789"))
     _check(Decimal128(12345, 67890, 0xABCDEF, 0x55))
+
+
+def test_number_of_digits_whole_range() raises:
+    """Every power-of-ten boundary is counted correctly, to the top of both
+    types.
+
+    The count used to stop at 58 digits and return 59 for anything larger,
+    which is a wrong answer rather than a refused one. `Wide` multiplies two
+    38-digit mantissas into a 76-digit product, so the whole range is
+    exercised now.
+    """
+    for k in range(0, 78):
+        var power = power_of_10[DType.uint256](k)
+        assert_equal(number_of_digits(power), k + 1)
+        assert_equal(number_of_digits(power + UInt256(1)), k + 1)
+        if k > 0:
+            assert_equal(number_of_digits(power - UInt256(1)), k)
+    assert_equal(number_of_digits(UInt256.MAX), 78)
+
+    for k in range(0, 39):
+        var power = power_of_10[DType.uint128](k)
+        assert_equal(number_of_digits(power), k + 1)
+        assert_equal(number_of_digits(power + UInt128(1)), k + 1)
+        if k > 0:
+            assert_equal(number_of_digits(power - UInt128(1)), k)
+    assert_equal(number_of_digits(UInt128.MAX), 39)
+
+
+def test_reciprocal_divider_wide_range() raises:
+    """The reciprocal divider agrees with plain division up to `10^48`.
+
+    Its table used to stop at `10^29`, which covered every `Decimal128` call
+    site but none of the `Wide` ones: normalizing a 76-digit product removes
+    38 digits.
+    """
+    var value = UInt256(0)
+    for k in range(1, 49):
+        # A value with digits in every position, so no divisor divides it
+        # evenly.
+        value = value * UInt256(10) + UInt256(1 + (k % 9))
+    for k in range(1, 49):
+        assert_equal(
+            udiv_u256_by_pow10_gm(value, k),
+            value // power_of_10[DType.uint256](k),
+        )
+        assert_equal(
+            udiv_u256_by_pow10_gm(UInt256.MAX, k),
+            UInt256.MAX // power_of_10[DType.uint256](k),
+        )
 
 
 def main() raises:

--- a/tests/decimal128/test_decimal128_wide.mojo
+++ b/tests/decimal128/test_decimal128_wide.mojo
@@ -1,0 +1,266 @@
+"""
+Tests for the fixed-width accumulator `Wide` and its fixed-point form, which
+the `Decimal128` series run in.
+"""
+
+from std import testing
+from std.testing import assert_equal, assert_true, assert_false
+
+from decimo.decimal128.decimal128 import Decimal128
+from decimo.decimal128.wide import (
+    Wide,
+    Extended,
+    extended_ln2,
+    extended_ln10,
+    extended_e_power_of_two,
+    extended_e_tenth,
+    extended_e_hundredth,
+    wide_ln2,
+    wide_ln10,
+    wide_e_power_of_two,
+    wide_e_tenth,
+    wide_e_hundredth,
+    fixed_from_wide,
+    wide_from_fixed,
+    fixed_multiply,
+    fixed_divide_by_int,
+    FIXED_ONE,
+)
+
+
+def test_wide_round_trip() raises:
+    """A `Decimal128` widened and narrowed again is the same number."""
+
+    def _check(text: String) raises:
+        assert_equal(
+            String(Wide.from_decimal(Decimal128(text)).to_decimal()), text
+        )
+
+    _check("1")
+    _check("0")
+    _check("-1")
+    _check("123.456")
+    _check("0.0000000000000000000000000001")
+    _check("79228162514264337593543950335")
+    _check("-79228162514264337593543950335")
+
+
+def test_wide_arithmetic() raises:
+    """The four operations agree with what `Decimal128` gets for values it
+    holds exactly."""
+    var three = Wide.from_int(3)
+    var four = Wide.from_int(4)
+    assert_equal(String((three + four).to_decimal()), "7")
+    assert_equal(String((three - four).to_decimal()), "-1")
+    assert_equal(String((three * four).to_decimal()), "12")
+    assert_equal(String((three / four).to_decimal()), "0.75")
+    assert_equal(String(four.divide_by_int(8).to_decimal()), "0.5")
+    assert_true((three - three).is_zero())
+
+
+def test_wide_carries_more_than_decimal128() raises:
+    """A third, tripled, comes back whole.
+
+    In `Decimal128` the same round trip loses the last digit, which is the
+    reason this type exists.
+    """
+    var third = Wide.from_int(1) / Wide.from_int(3)
+    # Ten digits of headroom, so the third that came back rounds to one
+    # across every digit `Decimal128` keeps. The trailing zeros stay: the
+    # value is not exactly one, and saying so is the point.
+    assert_equal(
+        String((third * Wide.from_int(3)).to_decimal()),
+        "1.0000000000000000000000000000",
+    )
+
+
+def test_wide_rounds_once() raises:
+    """Narrowing rounds half-even, from the digits the accumulator holds."""
+    var value = Wide.from_int(1) / Wide.from_int(3)
+    assert_equal(String(value.to_decimal()), "0.3333333333333333333333333333")
+    var two_thirds = Wide.from_int(2) / Wide.from_int(3)
+    assert_equal(
+        String(two_thirds.to_decimal()), "0.6666666666666666666666666667"
+    )
+
+
+def test_wide_truncation_and_scaling() raises:
+    """Whole parts and decimal shifts."""
+    assert_equal(Wide.from_decimal(Decimal128("7.9")).to_int_truncated(), 7)
+    assert_equal(Wide.from_decimal(Decimal128("-7.9")).to_int_truncated(), -7)
+    assert_equal(Wide.from_decimal(Decimal128("0.4")).to_int_truncated(), 0)
+    assert_equal(Wide.from_decimal(Decimal128("7.5")).to_int_nearest(), 8)
+    assert_equal(Wide.from_decimal(Decimal128("-7.5")).to_int_nearest(), -8)
+    assert_equal(
+        Wide.from_decimal(Decimal128("0.25"))
+        .scaled_by_power_of_ten(2)
+        .to_int_truncated(),
+        25,
+    )
+
+
+def test_wide_constants() raises:
+    """The stored constants are right to every digit they carry."""
+    assert_equal(
+        String(wide_ln2().to_decimal()), "0.6931471805599453094172321215"
+    )
+    assert_equal(
+        String(wide_ln10().to_decimal()), "2.3025850929940456840179914547"
+    )
+    assert_equal(
+        String(wide_e_power_of_two(0).to_decimal()),
+        "2.7182818284590452353602874714",
+    )
+    assert_equal(
+        String(wide_e_power_of_two(6).to_decimal()),
+        "6235149080811616882909238708.9",
+    )
+    assert_equal(String(wide_e_tenth(0).to_decimal()), "1")
+    assert_equal(
+        String(wide_e_tenth(5).to_decimal()), "1.6487212707001281468486507878"
+    )
+    assert_equal(String(wide_e_hundredth(0).to_decimal()), "1")
+    assert_equal(
+        String(wide_e_hundredth(5).to_decimal()),
+        "1.0512710963760240396975176363",
+    )
+
+
+def test_fixed_point() raises:
+    """The fixed-point form the series use."""
+    var half = fixed_from_wide(Wide.from_decimal(Decimal128("0.5")))
+    assert_equal(String(wide_from_fixed(half).to_decimal()), "0.5")
+    assert_equal(fixed_multiply(half, half) * Int256(4), FIXED_ONE)
+    assert_equal(fixed_divide_by_int(FIXED_ONE, 4) * Int256(4), FIXED_ONE)
+
+    var negative = fixed_from_wide(Wide.from_decimal(Decimal128("-0.5")))
+    assert_equal(negative, -half)
+    # Truncation is toward zero on both sides, so a product and its negation
+    # stay symmetric rather than drifting a unit apart.
+    assert_equal(fixed_multiply(negative, half), -fixed_multiply(half, half))
+    assert_equal(
+        fixed_divide_by_int(negative, 3), -fixed_divide_by_int(half, 3)
+    )
+
+    # A value far below the fixed scale reads as zero rather than reaching
+    # past the reciprocal table.
+    var tiny = Wide(UInt256(1), -200, False)
+    assert_equal(fixed_from_wide(tiny), Int256(0))
+
+
+def test_extended_arithmetic() raises:
+    """The second width, whose mantissas are too long to multiply directly.
+
+    A product of two 75-digit numbers has 150 digits and no register holds
+    it, so it is assembled from halves; a quotient is a narrow reciprocal
+    doubled by one Newton step. Both are checked here against values whose
+    digits are known.
+    """
+    var one = Extended.from_int(1)
+    var three = Extended.from_int(3)
+    var seven = Extended.from_int(7)
+
+    # A third, three times, is one across every digit `Decimal128` prints.
+    assert_equal(
+        String(((one / three) * three).to_decimal()),
+        "1.0000000000000000000000000000",
+    )
+    assert_equal(
+        String(((one / seven) * seven).to_decimal()),
+        "1.0000000000000000000000000000",
+    )
+    assert_equal(
+        String((one / three).to_decimal()), "0.3333333333333333333333333333"
+    )
+    assert_equal(
+        String((three / seven).to_decimal()), "0.4285714285714285714285714286"
+    )
+
+    # Signs on both sides of a division.
+    assert_equal(
+        String((one / (-three)).to_decimal()), "-0.3333333333333333333333333333"
+    )
+    assert_equal(
+        String(((-one) / three).to_decimal()), "-0.3333333333333333333333333333"
+    )
+    assert_equal(
+        String(((-one) / (-three)).to_decimal()),
+        "0.3333333333333333333333333333",
+    )
+
+    # Adding across a gap wider than the mantissa leaves the larger alone.
+    var tiny = Extended(UInt256(1), -300, False)
+    assert_equal(String((one + tiny).to_decimal()), "1")
+    assert_equal(String((one - one).to_decimal()), "0")
+
+
+def test_extended_holds_more_digits_than_wide() raises:
+    """A seventh, to 75 digits and to 38, agrees where they overlap."""
+    var narrow = Wide.from_int(1) / Wide.from_int(7)
+    var wide = Extended.from_int(1) / Extended.from_int(7)
+    assert_equal(String(wide.to_width[38]().mantissa), String(narrow.mantissa))
+    assert_equal(String(narrow.mantissa).byte_length(), 38)
+    assert_equal(String(wide.mantissa).byte_length(), 75)
+
+
+def test_both_widths_carry_the_same_constants() raises:
+    """Narrowing a 75-digit constant gives the 38-digit one exactly.
+
+    The two are written out separately, so this is what keeps them one
+    value: a typo in either is a failure here.
+    """
+
+    def _same(narrow: Wide, wide: Extended) raises:
+        var narrowed = wide.to_width[38]()
+        assert_equal(String(narrowed.mantissa), String(narrow.mantissa))
+        assert_equal(narrowed.exponent, narrow.exponent)
+
+    _same(wide_ln2(), extended_ln2())
+    _same(wide_ln10(), extended_ln10())
+    for index in range(7):
+        _same(wide_e_power_of_two(index), extended_e_power_of_two(index))
+    for digit in range(10):
+        _same(wide_e_tenth(digit), extended_e_tenth(digit))
+        _same(wide_e_hundredth(digit), extended_e_hundredth(digit))
+
+
+def test_conversion_refuses_an_undecided_rounding() raises:
+    """With room to be wrong, a value on a boundary is not rounded.
+
+    The mantissa below ends `...500000000`, exactly halfway between two
+    `Decimal128` values. Trusted to the digit it is exact, that rounds to
+    even; trusted only to within a hundred units, the true value could be on
+    either side and there is no answer to give.
+    """
+    var on_the_tie = Wide(
+        UInt256(12345678901234567890123456789500000000), -37, False
+    )
+    # Trusted to the digit, the tie goes to the even neighbour, which
+    # carries the nine up.
+    assert_equal(
+        String(on_the_tie.to_decimal_decided(UInt256(0)).value()),
+        "1.2345678901234567890123456790",
+    )
+    assert_false(Bool(on_the_tie.to_decimal_decided(UInt256(100))))
+
+    # Far from any boundary, the same slack decides.
+    var clear = Wide(
+        UInt256(12345678901234567890123456789012345678), -37, False
+    )
+    assert_true(Bool(clear.to_decimal_decided(UInt256(100))))
+
+    # Just above an exact multiple: the rounding is not in doubt, but the
+    # claim that nothing was lost is, and that claim is what decides whether
+    # the trailing zeros stay.
+    var almost_exact = Wide(
+        UInt256(12345678901234567890123456789000000007), -37, False
+    )
+    assert_equal(
+        String(almost_exact.to_decimal_decided(UInt256(0)).value()),
+        "1.2345678901234567890123456789",
+    )
+    assert_false(Bool(almost_exact.to_decimal_decided(UInt256(100))))
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
The four transcendental functions summed their series in `Decimal128` arithmetic, which rounds to 28 digits after every term, so the answer inherited every one of those roundings. Checked against CPython's `decimal` at 70 digits, `ln` was wrong on 108 of 200 random arguments, `log10` on 126, `sqrt` on 75, and `exp` by up to four units in the last place.

The series now run in `Wide`, a fixed-width accumulator inside `decimal128` that carries 38 digits, and the answer is rounded once, at the end. `sqrt` no longer refines a floating estimate at all: it scales the coefficient, takes an integer square root, and rounds that, which also tells it whether the root was exact. `Decimal128` still imports nothing from `BigDecimal` or any other arbitrary-precision type.

The rounding is decided rather than assumed. Each kernel states what it is trusted within, in units of the last digit it carries, and the conversion refuses to answer when that interval straddles either the midpoint between two results or an exact multiple, the second being what decides whether trailing zeros are kept. When it refuses, the whole computation runs again at 75 digits, which has forty-six digits below the answer instead of nine.

Two arguments that need it, found by searching three million: `ln(6215888314.385201)` continues `...0245000017266`, seventeen hundred units past a boundary the first width can only place to within two thousand, and `log10(5120760.203168846)` continues `...1444999949`. Both are in the tests. The second width runs on about one call in a quarter million and costs 55 microseconds when it does.

Two more bugs turned up on ordinary arguments. `ln` of a value close to one lost most of its digits: the reduction wrote `x` as `m * 2^p * 10^q` and added `p * ln(2) + q * ln(10)` back, and for `x` just under one those three terms are each about two while their sum is `1E-14`, so fourteen of the digits carried went into cancelling them out. Arguments already in `[0.5, 2)` now go straight to the series. And `ln(1.0000000000000000000000000001)` returned zero where the answer is `1E-28`: its every digit sits below the smallest scale the type has, and the conversion returned zero whenever the digits being dropped were all of them, rather than rounding them.

Two latent problems in the shared utilities are fixed on the way. `number_of_digits` stopped at 58 digits and returned 59 for anything larger, which is a wrong answer rather than a refused one; it now covers both types to the top, and is about sixty times faster, because the old binary search compared against `10 ** k`, which is not folded for 128- and 256-bit scalars and so was built at run time by repeated multiplication. The reciprocal divider's table of `10^k` stopped at `k = 29`, enough for every `Decimal128` call site but not for normalizing a 76-digit product, and now reaches 48.

Timings on osx-arm64, nanoseconds per call:

| | before | after |
| --- | ---: | ---: |
| `ln(123.456)` | 1003 | 739 |
| `ln(987654321.123456789)` | 1138 | 926 |
| `log10(123.456)` | 1269 | 1079 |
| `log10(987654321.123456789)` | 1399 | 1269 |
| `exp(2.5)` | 71 | 147 |
| `exp(40.123456789)` | 611 | 494 |
| `exp(-12.5)` | 269 | 490 |
| `sqrt(123.456)` | 1043 | 1152 |
| `a * b` | 18 | 18 |
| `a / b` | 234 | 229 |

`exp(2.5)` is the one that costs: before, it multiplied two 28-digit table constants and was done, which is where its last digits came from.

832 checks against CPython's `decimal` at 70 to 80 digits, covering random arguments, arguments a hair from one, and the boundary cases above: none wrong, where 360 of the first 720 were before. The suite is at 1204 tests, 21 of them new.
