### PR TITLE
[decimal128] Give Decimal128 trigonometry that holds across its range

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,25 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
 
 ### ⭐️ New in Unreleased
 
+1. **`Decimal128` has trigonometry.** `sin`, `cos`, `tan`, `cot`, `sec` and
+   `csc`, as functions and as methods, correctly rounded across the whole
+   range the type holds.
+
+   The work is the argument reduction. `Decimal128` reaches `7.9E+28`, so an
+   angle can be twenty billion billion billion quarter turns from zero, and
+   subtracting `k * (pi/2)` with the 28-digit quarter turn the type itself
+   holds answers a different question than the caller asked: at `1E+20` only
+   8 digits of the remainder are right, and at `1.2E+27` only one. The
+   quarter turn is kept here in four exact pieces of 38 digits. `k` has at
+   most 29 digits, so each `k * piece` is 67 and exact at `Extended`, and
+   what the subtractions leave is measured rather than assumed -- the same
+   two widths and the same decided rounding as `exp` and `ln`.
+
+   881 checks against a reference built on CPython's `decimal` at 140
+   digits, covering the quadrants, arguments from `1E+8` to `1E+28`, and
+   angles sitting on a quarter turn where the reduction cancels 28 digits:
+   none wrong.
+
 1. **The Python package rounds in every mode.** `getcontext().rounding`
    accepts `ROUND_HALF_EVEN`, `ROUND_HALF_UP`, `ROUND_HALF_DOWN`,
    `ROUND_DOWN`, `ROUND_UP`, `ROUND_CEILING` and `ROUND_FLOOR`, and every
@@ -204,6 +223,15 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    `BigInt10.from_bigint()` and `BigInt10.to_bigint()` (PR #269).
 
 ### 🦋 Changed in Unreleased
+
+1. **The second width stopped paying for software division.** Multiplying
+   two 75-digit mantissas splits each in half, and the splitting used `//`
+   and `%`; lining up an addition whose gap was wider than `UInt256` had room
+   for did the same. Four software divides made one multiplication cost 370
+   nanoseconds. Through the reciprocal divider it is 20, which takes the
+   argument reduction from 3298 nanoseconds to 226 and the wider series from
+   20.9 microseconds to 2.4 -- so every second attempt in `exp`, `ln` and
+   `power` got about ten times cheaper as well.
 
 1. **`Wide` is written once and used at two widths.** `WideValue[DIGITS]`
    carries the mantissa the series run on; `Wide` is 38 digits of it and
@@ -595,6 +623,12 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    `DECIMO_TEST_JOBS` explicitly still wins in both cases.
 
 ### 🩹 Fixed in Unreleased
+
+1. **A value too large for `Decimal128` came back with a scale of four
+   billion.** When more digits had to be dropped than there were places after
+   the point, the scale went negative and wrapped. Nothing reached it before:
+   `exp` refuses its argument above 66.54 and a logarithm is small. `tan` of
+   an angle a hair past a pole reaches it, and now raises `OverflowError`.
 
 1. **`Decimal128`'s powers and roots were wrong in the last digits.**
    `x^y` went through `exp(y * ln(x))` with the logarithm and the product

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -33,6 +33,7 @@ import decimo.decimal128.comparison as decimal128_comparison
 import decimo.decimal128.constants as decimal128_constants
 import decimo.decimal128.exponential as decimal128_exponential
 import decimo.decimal128.rounding as decimal128_rounding
+import decimo.decimal128.trigonometric as decimal128_trigonometric
 from decimo.rounding_mode import RoundingMode
 from decimo.errors import (
     ValueError,
@@ -2452,6 +2453,90 @@ struct Decimal128(
             ValueError: If `n` is non-positive, or `n` is even and the value is negative.
         """
         return decimal128_exponential.root(self, n)
+
+    @always_inline
+    def sin(self) raises -> Self:
+        """Calculates the sine of this angle in radians.
+        See `sin()` for more information.
+
+        Returns:
+            The sine of this value.
+
+        Raises:
+            Error: Propagated from the arithmetic.
+        """
+        return decimal128_trigonometric.sin(self)
+
+    @always_inline
+    def cos(self) raises -> Self:
+        """Calculates the cosine of this angle in radians.
+        See `cos()` for more information.
+
+        Returns:
+            The cosine of this value.
+
+        Raises:
+            Error: Propagated from the arithmetic.
+        """
+        return decimal128_trigonometric.cos(self)
+
+    @always_inline
+    def tan(self) raises -> Self:
+        """Calculates the tangent of this angle in radians.
+        See `tan()` for more information.
+
+        Returns:
+            The tangent of this value.
+
+        Raises:
+            OverflowError: If the angle is too close to a pole.
+            Error: Propagated from the arithmetic.
+        """
+        return decimal128_trigonometric.tan(self)
+
+    @always_inline
+    def cot(self) raises -> Self:
+        """Calculates the cotangent of this angle in radians.
+        See `cot()` for more information.
+
+        Returns:
+            The cotangent of this value.
+
+        Raises:
+            ZeroDivisionError: If the angle is a whole number of half turns.
+            OverflowError: If the angle is too close to one.
+            Error: Propagated from the arithmetic.
+        """
+        return decimal128_trigonometric.cot(self)
+
+    @always_inline
+    def sec(self) raises -> Self:
+        """Calculates the secant of this angle in radians.
+        See `sec()` for more information.
+
+        Returns:
+            The secant of this value.
+
+        Raises:
+            OverflowError: If the angle is too close to a quarter turn.
+            Error: Propagated from the arithmetic.
+        """
+        return decimal128_trigonometric.sec(self)
+
+    @always_inline
+    def csc(self) raises -> Self:
+        """Calculates the cosecant of this angle in radians.
+        See `csc()` for more information.
+
+        Returns:
+            The cosecant of this value.
+
+        Raises:
+            ZeroDivisionError: If the angle is zero.
+            OverflowError: If the angle is too close to a half turn.
+            Error: Propagated from the arithmetic.
+        """
+        return decimal128_trigonometric.csc(self)
 
     @always_inline
     def sqrt(self) raises -> Self:

--- a/src/decimo/decimal128/trigonometric.mojo
+++ b/src/decimo/decimal128/trigonometric.mojo
@@ -1,0 +1,807 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2025-2026 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+#
+# Trigonometric functions for Decimal128
+#
+# ===----------------------------------------------------------------------=== #
+
+"""Implements sine, cosine and tangent for `Decimal128`.
+
+The work is in the argument reduction, not the series. `Decimal128` reaches
+`7.9E+28`, so `x` can be twenty billion billion billion quarter-turns from
+zero, and what the series needs is where `x` sits inside its own quarter
+turn. Subtracting `k * (pi/2)` with a 28-digit quarter turn answers a
+different question than the caller asked: by `x = 1E+20` there is nothing
+left of the answer.
+
+So the quarter turn is kept in four exact pieces of 38 digits, 152 digits in
+all. `k` has at most 29 digits, so each `k * piece` is 67 digits and exact at
+`Extended`, and the subtractions give back the digits the reduction is meant
+to expose rather than the ones it cancelled. What survives is measured rather
+than assumed, and the rounding is decided the same way `exp` and `ln` decide
+theirs.
+"""
+
+from std.builtin.globals import global_constant
+
+from decimo.decimal128.decimal128 import Decimal128
+import decimo.decimal128.utility as decimal128_utility
+from decimo.decimal128.wide import Wide, Extended, WideValue
+from decimo.decimal128.wide import (
+    fixed_from_wide,
+    wide_from_fixed,
+    fixed_multiply,
+    fixed_divide_by_int,
+    FIXED_ONE,
+)
+from decimo.errors import ValueError, OverflowError, ZeroDivisionError
+
+
+# ===----------------------------------------------------------------------=== #
+# The quarter turn, in pieces
+#
+# `pi/2 = PART_0 + PART_1 + PART_2 + PART_3` to within `4E-152`, each part 38
+# digits and so exact at either width. Multiplied by a `k` of 29 digits the
+# neglected tail is `2E-123`, which is far below the last digit of any answer
+# this type can hold, even one whose reduction cancelled thirty digits.
+# ===----------------------------------------------------------------------=== #
+
+comptime _HALF_PI_PART_MANTISSA: Array[UInt256, 4] = [
+    15707963267948966192313216916397514420,  # pi/2 part 0
+    98584699687552910487472296153908203143,  # pi/2 part 1
+    10449931401741267105853399107404325664,  # pi/2 part 2
+    11533235469223047752911158626797040642,  # pi/2 part 3
+]
+
+
+comptime _HALF_PI_PART_EXPONENT: Array[Int, 4] = [
+    -37,  # pi/2 part 0
+    -75,  # pi/2 part 1
+    -113,  # pi/2 part 2
+    -151,  # pi/2 part 3
+]
+
+
+def half_pi_part_at[WIDTH: Int](index: Int) raises -> WideValue[WIDTH]:
+    """Returns one piece of the quarter turn.
+
+    Parameters:
+        WIDTH: The width to return it at.
+
+    Args:
+        index: Which piece, from 0 to 3, each 38 digits below the last.
+
+    Returns:
+        The piece, exactly.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    ref mantissas = global_constant[_HALF_PI_PART_MANTISSA]()
+    ref exponents = global_constant[_HALF_PI_PART_EXPONENT]()
+    return WideValue[WIDTH](mantissas[index], exponents[index], False)
+
+
+def two_over_pi_at[WIDTH: Int]() raises -> WideValue[WIDTH]:
+    """Returns `2/pi`, the number of quarter turns in one radian.
+
+    Parameters:
+        WIDTH: The width to return it at.
+
+    Returns:
+        The constant.
+
+    Raises:
+        Error: Propagated from the construction.
+    """
+    comptime if WIDTH <= 38:
+        return WideValue[WIDTH](
+            UInt256(63661977236758134307553505349005744814), -38, False
+        )
+    else:
+        return WideValue[WIDTH](
+            UInt256(
+                636619772367581343075535053490057448137838582961825794990669376235587190537
+            ),
+            -75,
+            False,
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# What the series and the reduction are trusted within
+# ===----------------------------------------------------------------------=== #
+
+comptime SERIES_SLACK = 500
+"""Units in the last place a sine or cosine series is trusted within.
+
+Twenty-five terms at 38 digits, each truncated at the fixed point's own last
+digit, with the divisions between them.
+"""
+
+
+comptime REDUCTION_SLACK = 100
+"""Units in the last place the reduction is trusted within, before
+cancellation.
+
+The first subtraction is exact -- `k * PART_0` has 67 digits and `Extended`
+holds 75 -- so what is left is what the later pieces lose against a remainder
+that has already shrunk, plus the tail beyond the fourth piece.
+"""
+
+
+comptime QUOTIENT_SLACK = 20
+"""Units added for the division that turns a sine and a cosine into a
+tangent."""
+
+
+# ===----------------------------------------------------------------------=== #
+# The reduction
+# ===----------------------------------------------------------------------=== #
+
+
+def reduce(x: Decimal128) raises -> Tuple[Extended, Int, UInt256]:
+    """Writes `x` as `k * (pi/2) + r` and returns what is left.
+
+    Args:
+        x: The angle in radians.
+
+    Returns:
+        The remainder `r`, with `|r| <= pi/4`; the quadrant `k mod 4`, always
+        from 0 to 3; and the units in the last place of `r`'s mantissa that
+        the reduction is trusted within.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        `k` is the nearest whole number of quarter turns, and it need not be
+        the exactly nearest one: any `k` gives a true identity, since the
+        quadrant that selects the series is the same `k` that was subtracted.
+        What matters is that `r` comes back with digits in it.
+
+        The reduction runs at `Extended` whatever the caller wants, because
+        at 38 digits an argument of `1E+20` has nothing left after the
+        subtraction. How much is left here is measured: the widest remainder
+        along the way, against the one that came out.
+    """
+    var wide_x = Extended.from_decimal(x)
+    if x.is_zero():
+        return (Extended(), 0, UInt256(REDUCTION_SLACK))
+
+    var turns = wide_x * two_over_pi_at[75]()
+    var k = turns.rounded_to_integer()
+    if k.is_zero():
+        # Already inside the first quarter turn, exactly as given.
+        return (wide_x^, 0, UInt256(REDUCTION_SLACK))
+
+    var quadrant = k.integer_remainder(4)
+    if k.sign:
+        quadrant = (4 - quadrant) % 4
+
+    var remainder = wide_x.copy()
+    var largest = remainder.exponent
+    for index in range(4):
+        remainder = remainder - k * half_pi_part_at[75](index)
+        if remainder.is_zero():
+            break
+        if remainder.exponent > largest:
+            largest = remainder.exponent
+
+    var slack = UInt256(REDUCTION_SLACK)
+    if not remainder.is_zero():
+        var spread = largest - remainder.exponent
+        if spread > 0:
+            if spread > 70:
+                slack = UInt256.MAX
+            else:
+                slack *= decimal128_utility.power_of_10[DType.uint256](spread)
+    return (remainder^, quadrant, slack)
+
+
+# ===----------------------------------------------------------------------=== #
+# The series
+# ===----------------------------------------------------------------------=== #
+
+
+def sine_series_at[WIDTH: Int](r: WideValue[WIDTH]) raises -> WideValue[WIDTH]:
+    """Returns `sin(r)` for `|r| <= pi/4`, at the given width.
+
+    Parameters:
+        WIDTH: The width to compute at.
+
+    Args:
+        r: The angle, whose magnitude must be at most a quarter turn.
+
+    Returns:
+        Its sine.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        `r - r^3/3! + r^5/5! - ...`, which at `|r| <= 0.79` crosses 38 digits
+        in about twenty terms. Fixed point sums them for the price of an
+        addition, but holds a fixed number of decimal places rather than of
+        digits, so a tiny `r` -- which is what a reduction that cancelled
+        thirty digits leaves -- would come back with a tenth of the digits it
+        needs. There the series is two terms and is taken in the floating
+        form.
+    """
+    if r.is_zero():
+        return WideValue[WIDTH]()
+
+    comptime if WIDTH == 38:
+        if r.exponent >= -41:
+            var r_fixed = fixed_from_wide(r.to_width[38]())
+            var minus_r_squared = -fixed_multiply(r_fixed, r_fixed)
+            var term = r_fixed
+            var total = r_fixed
+            for index in range(1, 200):
+                term = fixed_multiply(term, minus_r_squared)
+                term = fixed_divide_by_int(term, 2 * index * (2 * index + 1))
+                if term == Int256(0):
+                    break
+                total += term
+            return wide_from_fixed(total).to_width[WIDTH]()
+        return _sine_series_floating[WIDTH](r)
+    else:
+        return _sine_series_floating[WIDTH](r)
+
+
+def _sine_series_floating[
+    WIDTH: Int
+](r: WideValue[WIDTH]) raises -> WideValue[WIDTH]:
+    """Returns `sin(r)` in the floating form, which keeps its digits wherever
+    the value sits.
+
+    Parameters:
+        WIDTH: The width to compute at.
+
+    Args:
+        r: The angle, whose magnitude must be at most a quarter turn.
+
+    Returns:
+        Its sine.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+    """
+    var minus_r_squared = -(r * r)
+    var term = r.copy()
+    var total = r.copy()
+    for index in range(1, 400):
+        term = (term * minus_r_squared).divide_by_int(
+            2 * index * (2 * index + 1)
+        )
+        if term.is_zero():
+            break
+        var next_total = total + term
+        if next_total.compare_absolute(total) == 0:
+            break
+        total = next_total^
+    return total^
+
+
+def cosine_series_at[
+    WIDTH: Int
+](r: WideValue[WIDTH]) raises -> WideValue[WIDTH]:
+    """Returns `cos(r)` for `|r| <= pi/4`, at the given width.
+
+    Parameters:
+        WIDTH: The width to compute at.
+
+    Args:
+        r: The angle, whose magnitude must be at most a quarter turn.
+
+    Returns:
+        Its cosine.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        `1 - r^2/2! + r^4/4! - ...`. The answer is about one whatever `r` is,
+        so the fixed point's last decimal place is the answer's last digit
+        and a tiny `r` costs nothing here.
+    """
+    if r.is_zero():
+        return WideValue[WIDTH].from_int(1)
+
+    comptime if WIDTH == 38:
+        var r_fixed = fixed_from_wide(r.to_width[38]())
+        var minus_r_squared = -fixed_multiply(r_fixed, r_fixed)
+        var term = FIXED_ONE
+        var total = FIXED_ONE
+        for index in range(1, 200):
+            term = fixed_multiply(term, minus_r_squared)
+            term = fixed_divide_by_int(term, (2 * index - 1) * (2 * index))
+            if term == Int256(0):
+                break
+            total += term
+        return wide_from_fixed(total).to_width[WIDTH]()
+    else:
+        var minus_r_squared = -(r * r)
+        var term = WideValue[WIDTH].from_int(1)
+        var total = WideValue[WIDTH].from_int(1)
+        for index in range(1, 400):
+            term = (term * minus_r_squared).divide_by_int(
+                (2 * index - 1) * (2 * index)
+            )
+            if term.is_zero():
+                break
+            var next_total = total + term
+            if next_total.compare_absolute(total) == 0:
+                break
+            total = next_total^
+        return total^
+
+
+# ===----------------------------------------------------------------------=== #
+# The functions
+# ===----------------------------------------------------------------------=== #
+
+
+def sin(x: Decimal128) raises -> Decimal128:
+    """Calculates the sine of an angle in radians.
+
+    Args:
+        x: The angle in radians.
+
+    Returns:
+        Its sine, correctly rounded.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        The argument is reduced to a quarter turn, the quadrant picks the
+        sine or the cosine series, and the answer is rounded once. Where the
+        digits below it do not say which way it rounds, the series runs again
+        at `Extended`.
+    """
+    if x.is_zero():
+        return Decimal128.ZERO()
+    return _circular(x, is_sine=True)
+
+
+def cos(x: Decimal128) raises -> Decimal128:
+    """Calculates the cosine of an angle in radians.
+
+    Args:
+        x: The angle in radians.
+
+    Returns:
+        Its cosine, correctly rounded.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+    """
+    if x.is_zero():
+        return Decimal128.ONE()
+    return _circular(x, is_sine=False)
+
+
+def _circular(x: Decimal128, is_sine: Bool) raises -> Decimal128:
+    """Returns the sine or the cosine, whichever was asked for.
+
+    Args:
+        x: The angle in radians.
+        is_sine: True for the sine, False for the cosine.
+
+    Returns:
+        The value, correctly rounded.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+    """
+    var reduced = reduce(x)
+    var narrow = _circular_at[38](reduced, is_sine)
+    var decided = narrow[0].to_decimal_decided(narrow[1])
+    if decided:
+        return decided.value()
+
+    var wide = _circular_at[75](reduced, is_sine)
+    var settled = wide[0].to_decimal_decided(wide[1])
+    if settled:
+        return settled.value()
+    return wide[0].to_decimal()
+
+
+def _circular_at[
+    WIDTH: Int
+](reduced: Tuple[Extended, Int, UInt256], is_sine: Bool) raises -> Tuple[
+    WideValue[WIDTH], UInt256
+]:
+    """Returns the sine or cosine of a reduced angle, with how far it may be
+    off.
+
+    Parameters:
+        WIDTH: The width to run the series at.
+
+    Args:
+        reduced: The remainder, the quadrant, and what the reduction is
+            trusted within.
+        is_sine: True for the sine, False for the cosine.
+
+    Returns:
+        The value, and the units in the last place of its mantissa that the
+        computation is trusted within.
+
+    Raises:
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        The quadrant decides which series answers and with what sign:
+
+            quadrant  0        1        2        3
+            sin       sin(r)   cos(r)  -sin(r)  -cos(r)
+            cos       cos(r)  -sin(r)  -cos(r)   sin(r)
+
+        What the reduction is trusted within is stated in units of `r`'s last
+        digit at 75; at 38 the last digit is 37 places coarser, and near zero
+        the sine passes that straight through while the cosine flattens it
+        away.
+    """
+    var r = reduced[0].to_width[WIDTH]()
+    var quadrant = reduced[1]
+
+    var use_sine = is_sine
+    if quadrant == 1 or quadrant == 3:
+        use_sine = not use_sine
+
+    var value: WideValue[WIDTH]
+    if use_sine:
+        value = sine_series_at[WIDTH](r)
+    else:
+        value = cosine_series_at[WIDTH](r)
+
+    var negative: Bool
+    if is_sine:
+        negative = quadrant == 2 or quadrant == 3
+    else:
+        negative = quadrant == 1 or quadrant == 2
+    if negative:
+        value = -value
+
+    # `sin(r)` is `r` near zero, so an error in `r` is an error of the same
+    # size in the answer; `cos(r)` is `1 - r^2/2`, where it is squared away.
+    var carried = reduced[2]
+    comptime if WIDTH < 75:
+        var narrowing = decimal128_utility.power_of_10[DType.uint256](
+            75 - WIDTH
+        )
+        carried = carried // narrowing + UInt256(1)
+    if not use_sine:
+        carried = UInt256(1)
+    return (value^, carried + UInt256(SERIES_SLACK))
+
+
+def tan(x: Decimal128) raises -> Decimal128:
+    """Calculates the tangent of an angle in radians.
+
+    Args:
+        x: The angle in radians.
+
+    Returns:
+        Its tangent, correctly rounded.
+
+    Raises:
+        OverflowError: If the angle is so close to a pole that the tangent
+            leaves what `Decimal128` holds.
+        Error: Propagated from the arithmetic.
+
+    Notes:
+        `sin(r) / cos(r)` at the working width, one rounding at the end. The
+        quadrant only decides the sign, since the tangent repeats every half
+        turn.
+    """
+    if x.is_zero():
+        return Decimal128.ZERO()
+
+    var reduced = reduce(x)
+    var narrow = _tangent_at[38](reduced)
+    var decided = narrow[0].to_decimal_decided(narrow[1])
+    if decided:
+        return decided.value()
+
+    var wide = _tangent_at[75](reduced)
+    var settled = wide[0].to_decimal_decided(wide[1])
+    if settled:
+        return settled.value()
+    return wide[0].to_decimal()
+
+
+def _tangent_at[
+    WIDTH: Int
+](reduced: Tuple[Extended, Int, UInt256]) raises -> Tuple[
+    WideValue[WIDTH], UInt256
+]:
+    """Returns the tangent of a reduced angle, with how far it may be off.
+
+    Parameters:
+        WIDTH: The width to run the series at.
+
+    Args:
+        reduced: The remainder, the quadrant, and what the reduction is
+            trusted within.
+
+    Returns:
+        The value, and the units in the last place of its mantissa that the
+        computation is trusted within.
+
+    Raises:
+        OverflowError: If the cosine is small enough that the quotient leaves
+            `Decimal128`.
+        Error: Propagated from the arithmetic.
+    """
+    var r = reduced[0].to_width[WIDTH]()
+    var sine = sine_series_at[WIDTH](r)
+    var cosine = cosine_series_at[WIDTH](r)
+
+    var carried = reduced[2]
+    comptime if WIDTH < 75:
+        var narrowing = decimal128_utility.power_of_10[DType.uint256](
+            75 - WIDTH
+        )
+        carried = carried // narrowing + UInt256(1)
+
+    var quadrant = reduced[1]
+    var value: WideValue[WIDTH]
+    if quadrant == 1 or quadrant == 3:
+        # A quarter turn on turns the tangent into minus its reciprocal.
+        if sine.is_zero():
+            raise OverflowError(
+                message=(
+                    "The tangent is too large for Decimal128 at this angle."
+                ),
+                function="tan()",
+            )
+        value = -(cosine / sine)
+    else:
+        if cosine.is_zero():
+            raise OverflowError(
+                message=(
+                    "The tangent is too large for Decimal128 at this angle."
+                ),
+                function="tan()",
+            )
+        value = sine / cosine
+
+    return (
+        value^,
+        (carried + UInt256(SERIES_SLACK)) * UInt256(QUOTIENT_SLACK),
+    )
+
+
+def cot(x: Decimal128) raises -> Decimal128:
+    """Calculates the cotangent of an angle in radians.
+
+    Args:
+        x: The angle in radians.
+
+    Returns:
+        Its cotangent, correctly rounded.
+
+    Raises:
+        ZeroDivisionError: If the angle is a whole number of half turns,
+            where the cotangent has no value.
+        OverflowError: If the angle is so close to one that the cotangent
+            leaves what `Decimal128` holds.
+        Error: Propagated from the arithmetic.
+    """
+    if x.is_zero():
+        raise ZeroDivisionError(
+            message="The cotangent of zero has no value.",
+            function="cot()",
+        )
+    return _ratio(x, wants_cotangent=True)
+
+
+def sec(x: Decimal128) raises -> Decimal128:
+    """Calculates the secant of an angle in radians.
+
+    Args:
+        x: The angle in radians.
+
+    Returns:
+        Its secant, correctly rounded.
+
+    Raises:
+        OverflowError: If the angle is close enough to a quarter turn that
+            the secant leaves what `Decimal128` holds.
+        Error: Propagated from the arithmetic.
+    """
+    if x.is_zero():
+        return Decimal128.ONE()
+    return _inverse_circular(x, is_sine=False)
+
+
+def csc(x: Decimal128) raises -> Decimal128:
+    """Calculates the cosecant of an angle in radians.
+
+    Args:
+        x: The angle in radians.
+
+    Returns:
+        Its cosecant, correctly rounded.
+
+    Raises:
+        ZeroDivisionError: If the angle is zero, where the cosecant has no
+            value.
+        OverflowError: If the angle is close enough to a half turn that the
+            cosecant leaves what `Decimal128` holds.
+        Error: Propagated from the arithmetic.
+    """
+    if x.is_zero():
+        raise ZeroDivisionError(
+            message="The cosecant of zero has no value.",
+            function="csc()",
+        )
+    return _inverse_circular(x, is_sine=True)
+
+
+def _ratio(x: Decimal128, wants_cotangent: Bool) raises -> Decimal128:
+    """Returns the tangent or the cotangent.
+
+    Args:
+        x: The angle in radians.
+        wants_cotangent: True for the cotangent.
+
+    Returns:
+        The value, correctly rounded.
+
+    Raises:
+        OverflowError: If the value leaves what `Decimal128` holds.
+        Error: Propagated from the arithmetic.
+    """
+    var reduced = reduce(x)
+    var narrow = _ratio_at[38](reduced, wants_cotangent)
+    var decided = narrow[0].to_decimal_decided(narrow[1])
+    if decided:
+        return decided.value()
+
+    var wide = _ratio_at[75](reduced, wants_cotangent)
+    var settled = wide[0].to_decimal_decided(wide[1])
+    if settled:
+        return settled.value()
+    return wide[0].to_decimal()
+
+
+def _ratio_at[
+    WIDTH: Int
+](
+    reduced: Tuple[Extended, Int, UInt256], wants_cotangent: Bool
+) raises -> Tuple[WideValue[WIDTH], UInt256]:
+    """Returns the tangent or cotangent of a reduced angle, with how far it
+    may be off.
+
+    Parameters:
+        WIDTH: The width to run the series at.
+
+    Args:
+        reduced: The remainder, the quadrant, and what the reduction is
+            trusted within.
+        wants_cotangent: True for the cotangent.
+
+    Returns:
+        The value, and the units in the last place of its mantissa that the
+        computation is trusted within.
+
+    Raises:
+        OverflowError: If the divisor is zero, which means the value has no
+            place on the line.
+        Error: Propagated from the arithmetic.
+    """
+    var r = reduced[0].to_width[WIDTH]()
+    var sine = sine_series_at[WIDTH](r)
+    var cosine = cosine_series_at[WIDTH](r)
+
+    var carried = reduced[2]
+    comptime if WIDTH < 75:
+        carried = carried // decimal128_utility.power_of_10[DType.uint256](
+            75 - WIDTH
+        ) + UInt256(1)
+
+    # A quarter turn on exchanges the two and flips the sign, which turns a
+    # tangent into a cotangent and back.
+    var quadrant = reduced[1]
+    var upper = sine.copy()
+    var lower = cosine.copy()
+    var negative = False
+    if wants_cotangent:
+        upper = cosine.copy()
+        lower = sine.copy()
+    if quadrant == 1 or quadrant == 3:
+        var swap = upper.copy()
+        upper = lower^
+        lower = swap^
+        negative = True
+
+    if lower.is_zero():
+        raise OverflowError(
+            message="The value is too large for Decimal128 at this angle.",
+            function="tan()",
+        )
+    var value = upper / lower
+    if negative:
+        value = -value
+
+    return (
+        value^,
+        (carried + UInt256(SERIES_SLACK)) * UInt256(QUOTIENT_SLACK),
+    )
+
+
+def _inverse_circular(x: Decimal128, is_sine: Bool) raises -> Decimal128:
+    """Returns the cosecant or the secant.
+
+    Args:
+        x: The angle in radians.
+        is_sine: True for the cosecant, which is one over the sine.
+
+    Returns:
+        The value, correctly rounded.
+
+    Raises:
+        OverflowError: If the value leaves what `Decimal128` holds.
+        Error: Propagated from the arithmetic.
+    """
+    var reduced = reduce(x)
+    var narrow = _inverse_circular_at[38](reduced, is_sine)
+    var decided = narrow[0].to_decimal_decided(narrow[1])
+    if decided:
+        return decided.value()
+
+    var wide = _inverse_circular_at[75](reduced, is_sine)
+    var settled = wide[0].to_decimal_decided(wide[1])
+    if settled:
+        return settled.value()
+    return wide[0].to_decimal()
+
+
+def _inverse_circular_at[
+    WIDTH: Int
+](reduced: Tuple[Extended, Int, UInt256], is_sine: Bool) raises -> Tuple[
+    WideValue[WIDTH], UInt256
+]:
+    """Returns one over the sine or the cosine of a reduced angle, with how
+    far it may be off.
+
+    Parameters:
+        WIDTH: The width to run the series at.
+
+    Args:
+        reduced: The remainder, the quadrant, and what the reduction is
+            trusted within.
+        is_sine: True for the cosecant.
+
+    Returns:
+        The value, and the units in the last place of its mantissa that the
+        computation is trusted within.
+
+    Raises:
+        OverflowError: If the sine or cosine is zero at this angle.
+        Error: Propagated from the arithmetic.
+    """
+    var circular = _circular_at[WIDTH](reduced, is_sine)
+    if circular[0].is_zero():
+        raise OverflowError(
+            message="The value is too large for Decimal128 at this angle.",
+            function="csc()",
+        )
+    var value = WideValue[WIDTH].from_int(1) / circular[0]
+    return (value^, circular[1] * UInt256(QUOTIENT_SLACK))

--- a/src/decimo/decimal128/wide.mojo
+++ b/src/decimo/decimal128/wide.mojo
@@ -226,14 +226,14 @@ struct WideValue[DIGITS: Int](Copyable, Movable):
             if gap <= room:
                 left *= decimal128_utility.power_of_10[DType.uint256](gap)
             else:
-                right //= decimal128_utility.power_of_10[DType.uint256](gap)
+                right = _drop_digits(right, gap)
                 exponent = self.exponent
         elif gap < 0:
             exponent = self.exponent
             if -gap <= room:
                 right *= decimal128_utility.power_of_10[DType.uint256](-gap)
             else:
-                left //= decimal128_utility.power_of_10[DType.uint256](-gap)
+                left = _drop_digits(left, -gap)
                 exponent = other.exponent
         else:
             exponent = self.exponent
@@ -304,10 +304,13 @@ struct WideValue[DIGITS: Int](Copyable, Movable):
             # units in the last place.
             comptime half = (Self.DIGITS + 1) // 2
             var split = decimal128_utility.power_of_10[DType.uint256](half)
-            var left_high = self.mantissa // split
-            var left_low = self.mantissa % split
-            var right_high = other.mantissa // split
-            var right_low = other.mantissa % split
+            # Through the reciprocal divider, and the remainder derived from
+            # the quotient: the plain `//` and `%` are software divides, and
+            # four of them made a multiplication cost 370 ns instead of 20.
+            var left_high = _drop_digits(self.mantissa, half)
+            var left_low = self.mantissa - left_high * split
+            var right_high = _drop_digits(other.mantissa, half)
+            var right_low = other.mantissa - right_high * split
             var top = (
                 left_high
                 * right_high
@@ -516,6 +519,57 @@ struct WideValue[DIGITS: Int](Copyable, Movable):
         var value = Int(_drop_digits(shifted.mantissa, drop))
         return -value if self.sign else value
 
+    def rounded_to_integer(self) raises -> Self:
+        """Returns the nearest whole number, as a value of the same width.
+
+        Returns:
+            The nearest integer, ties away from zero. `to_int_nearest` gives
+            the same answer as an `Int`, which stops at 19 digits; the
+            argument reduction divides values of 29 digits by a quarter turn
+            and needs the whole quotient.
+
+        Raises:
+            Error: Propagated from the arithmetic.
+        """
+        if self.is_zero() or self.exponent >= 0:
+            return self.copy()
+        var drop = -self.exponent
+        if drop > Self.DIGITS:
+            return Self()
+        # Half a unit added before truncating, which rounds away from zero.
+        var half = decimal128_utility.power_of_10[DType.uint256](drop) >> 1
+        return Self(_drop_digits(self.mantissa + half, drop), 0, self.sign)
+
+    def integer_remainder(self, modulus: Int) raises -> Int:
+        """Returns this whole number modulo a small one.
+
+        Args:
+            modulus: The modulus, which must be positive.
+
+        Returns:
+            The remainder, always at or above zero, of the magnitude. The
+            caller applies the sign.
+
+        Raises:
+            Error: Propagated from the arithmetic.
+
+        Notes:
+            The value must already be whole. Only the last digits matter, so
+            the mantissa is reduced where it stands rather than converted to
+            an `Int` it would not fit in.
+        """
+        if self.is_zero():
+            return 0
+        var whole = self.mantissa
+        if self.exponent < 0:
+            whole = _drop_digits(whole, -self.exponent)
+        elif self.exponent > 0:
+            var shifted = whole % UInt256(modulus)
+            for _ in range(self.exponent):
+                shifted = (shifted * UInt256(10)) % UInt256(modulus)
+            return Int(shifted)
+        return Int(whole % UInt256(modulus))
+
     def to_decimal(self) raises -> Decimal128:
         """Returns the value as a `Decimal128`, rounded once.
 
@@ -600,6 +654,16 @@ struct WideValue[DIGITS: Int](Copyable, Movable):
             drop = scale - Decimal128.MAX_SCALE
         if digits - drop > room:
             drop = digits - room
+
+        # More digits have to go than there are places after the point, so
+        # what is left needs more than 29 digits before it. `tan` of an angle
+        # a hair past a pole lands here; the scale used to come out negative
+        # and wrap around to four billion.
+        if drop > scale:
+            raise OverflowError(
+                message="Value too large for Decimal128.",
+                function="WideValue.to_decimal_decided()",
+            )
 
         var exact = True
         if drop > 0:

--- a/tests/decimal128/test_decimal128_trigonometric.mojo
+++ b/tests/decimal128/test_decimal128_trigonometric.mojo
@@ -1,0 +1,248 @@
+"""
+Tests for Decimal128 trigonometry: sin, cos, tan, cot, sec and csc.
+
+Every expected value was checked against a reference built on CPython's
+`decimal`, reducing the argument against a 140-digit quarter turn and summing
+the series at 140 digits.
+"""
+
+from std import testing
+from std.testing import assert_equal, assert_true
+
+from decimo.decimal128.decimal128 import Decimal128
+from decimo.decimal128.trigonometric import (
+    sin,
+    cos,
+    tan,
+    cot,
+    sec,
+    csc,
+    reduce,
+)
+from decimo.errors import ZeroDivisionError, OverflowError
+
+
+def test_trigonometric_values() raises:
+    """Sine, cosine and tangent across the quadrants and across the range.
+
+    The last four arguments are the point of the exercise. Reducing them
+    against a 28-digit quarter turn -- the widest `Decimal128` itself holds --
+    leaves 8 correct digits of the remainder at `1E+20` and 1 at `1.2E+27`,
+    so the answer would be wrong in most of the digits it printed. The
+    quarter turn is kept in four pieces of 38 digits here.
+    """
+
+    def _check(
+        argument: String, sine: String, cosine: String, tangent: String
+    ) raises:
+        var x = Decimal128(argument)
+        assert_equal(String(sin(x)), sine)
+        assert_equal(String(cos(x)), cosine)
+        assert_equal(String(tan(x)), tangent)
+
+    _check(
+        "0.5",
+        "0.4794255386042030002732879352",
+        "0.8775825618903727161162815826",
+        "0.5463024898437905132551794658",
+    )
+    _check(
+        "1",
+        "0.8414709848078965066525023216",
+        "0.5403023058681397174009366074",
+        "1.5574077246549022305069748075",
+    )
+    _check(
+        "1.2",
+        "0.9320390859672263496701344355",
+        "0.3623577544766735776383733556",
+        "2.5721516221263189354099942360",
+    )
+    _check(
+        "2.7",
+        "0.4273798802338299345560530859",
+        "-0.9040721420170611479825272819",
+        "-0.4727276291030375079519891813",
+    )
+    _check(
+        "-1.2",
+        "-0.9320390859672263496701344355",
+        "0.3623577544766735776383733556",
+        "-2.5721516221263189354099942360",
+    )
+    _check(
+        "3.5",
+        "-0.3507832276896198481203688000",
+        "-0.9364566872907963376986576267",
+        "0.3745856401585946663305125800",
+    )
+    _check(
+        "6.2",
+        "-0.0830894028174965780005792891",
+        "0.9965420970232174751394026239",
+        "-0.0833777148659287977660811118",
+    )
+    _check(
+        "100",
+        "-0.5063656411097587936565576105",
+        "0.8623188722876839341019385140",
+        "-0.5872139151569290766778096356",
+    )
+    _check(
+        "1000000",
+        "-0.3499935021712929521176524868",
+        "0.9367521275331447869385325351",
+        "-0.3736244539875990291734970886",
+    )
+    _check(
+        "1e20",
+        "-0.6452512852657808442058117113",
+        "0.7639704044417283004001468027",
+        "-0.8446024630198842541840932340",
+    )
+    _check(
+        "12345678901234567890123456789",
+        "0.1829287606848061096390398032",
+        "0.9831261712081114843673218647",
+        "0.1860684478168399087099001460",
+    )
+    _check(
+        "1570796326794896619231321691.6",
+        "-0.0397409738722947475692415088",
+        "0.9992100154600541163536426316",
+        "-0.0397723934482354985664791609",
+    )
+    _check(
+        "157079632679489.66192313216916",
+        "-0.0000000000000039751442098585",
+        "1.0000000000000000000000000000",
+        "-0.0000000000000039751442098585",
+    )
+    _check(
+        "0.0000000001",
+        "0.0000000001000000000000000000",
+        "0.999999999999999999995",
+        "0.0000000001000000000000000000",
+    )
+
+
+def test_reciprocal_values() raises:
+    """Cotangent, secant and cosecant."""
+
+    def _check(
+        argument: String, cotangent: String, secant: String, cosecant: String
+    ) raises:
+        var x = Decimal128(argument)
+        assert_equal(String(cot(x)), cotangent)
+        assert_equal(String(sec(x)), secant)
+        assert_equal(String(csc(x)), cosecant)
+
+    _check(
+        "1.2",
+        "0.3887795693682049116341915050",
+        "2.7597036013324064568834329392",
+        "1.0729163777098972287051169224",
+    )
+    _check(
+        "2.7",
+        "-2.1153830206569885196778981812",
+        "-1.1061064195263396963425488606",
+        "2.3398387389057146555658140919",
+    )
+    _check(
+        "100",
+        "-1.7029569194264692160987314596",
+        "1.1596638229046938325514044466",
+        "-1.9748575314240999612122645488",
+    )
+    _check(
+        "1e20",
+        "-1.1839889697035577581251403412",
+        "1.3089512292439527516034322927",
+        "-1.5497838173047530601976829335",
+    )
+
+
+def test_trigonometric_exact_points() raises:
+    """Zero is the one angle whose answers are exact."""
+    assert_equal(String(sin(Decimal128("0"))), "0")
+    assert_equal(String(cos(Decimal128("0"))), "1")
+    assert_equal(String(tan(Decimal128("0"))), "0")
+    assert_equal(String(sec(Decimal128("0"))), "1")
+
+    # And the two that have no value there.
+    var raised = False
+    try:
+        _ = csc(Decimal128("0"))
+    except:
+        raised = True
+    assert_true(raised, "csc(0) should raise")
+
+    raised = False
+    try:
+        _ = cot(Decimal128("0"))
+    except:
+        raised = True
+    assert_true(raised, "cot(0) should raise")
+
+
+def test_tangent_near_a_pole() raises:
+    """An angle a hair from a pole gives a large tangent, or none at all.
+
+    `7.8539816339744830961566084582` is the closest `Decimal128` gets to five
+    quarter turns; the tangent there is past what the type holds, and saying
+    so is the answer. One quarter turn along, the tangent is large but fits.
+    """
+    var raised = False
+    try:
+        _ = tan(Decimal128("7.8539816339744830961566084582"))
+    except:
+        raised = True
+    assert_true(raised, "the tangent past a pole should overflow")
+
+    assert_equal(
+        String(tan(Decimal128("1.5707963267948966192313216916"))),
+        "25156320052992586843308997627",
+    )
+
+
+def test_reduction_reports_what_survived() raises:
+    """The reduction says how much of the remainder it stands behind.
+
+    An argument inside the first quarter turn is passed through untouched, so
+    nothing is lost; one that lands on a quarter turn has cancelled most of
+    what it carried, and the count says so.
+    """
+    var inside = reduce(Decimal128("0.5"))
+    assert_equal(inside[1], 0)
+    assert_true(
+        inside[2] < UInt256(1000),
+        "an argument needing no reduction loses nothing",
+    )
+
+    var far = reduce(Decimal128("1570796326794896619231321691.6"))
+    assert_true(
+        far[2] > inside[2],
+        "an argument on a quarter turn has less of its remainder left",
+    )
+
+    # Quadrants, one per turn.
+    assert_equal(reduce(Decimal128("0.5"))[1], 0)
+    assert_equal(reduce(Decimal128("2"))[1], 1)
+    assert_equal(reduce(Decimal128("3.5"))[1], 2)
+    assert_equal(reduce(Decimal128("5"))[1], 3)
+
+
+def test_trigonometric_methods() raises:
+    """The methods on the type give what the functions give."""
+    var x = Decimal128("1.2")
+    assert_equal(String(x.sin()), String(sin(x)))
+    assert_equal(String(x.cos()), String(cos(x)))
+    assert_equal(String(x.tan()), String(tan(x)))
+    assert_equal(String(x.cot()), String(cot(x)))
+    assert_equal(String(x.sec()), String(sec(x)))
+    assert_equal(String(x.csc()), String(csc(x)))
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
`Decimal128` has `sin`, `cos`, `tan`, `cot`, `sec` and `csc` as functions and as methods now, correctly rounded across the whole range the type holds.

The series are the easy half. The work is the argument reduction: `Decimal128` reaches `7.9E+28`, so an angle can be twenty billion billion billion quarter turns from zero, and what a series needs is where the angle sits inside its own quarter turn. Subtracting `k * (pi/2)` with the 28-digit quarter turn the type itself holds answers a different question than the caller asked. Against a 140-digit reduction, that leaves 26 correct digits of the remainder at `x = 100`, 18 at `1E+10`, 8 at `1E+20`, and 1 at `1.2E+27` -- an answer whose printed digits are mostly noise, which is the shape of bug the trigonometric audit found in `BigDecimal` earlier.

So the quarter turn is kept in four exact pieces of 38 digits, 152 in all. `k` has at most 29 digits, so each `k * piece` is 67 digits and exact at `Extended`, and the subtractions give back the digits the reduction is meant to expose rather than the ones it cancelled. The tail beyond the fourth piece contributes `2E-123`. What survives is measured, not assumed: the widest remainder along the way against the one that came out, in the same shape `_ln_at` measures its cancellation, and the rounding is decided at 38 digits with a second pass at 75 -- the machinery from #302.

881 checks against a reference built on CPython's `decimal`, reducing against a 140-digit quarter turn and summing at 140 digits: none wrong. That covers the four quadrants, arguments from `1E+8` to `1E+28`, angles rounded onto a multiple of a quarter turn where the reduction cancels 28 digits, and the three reciprocal functions. `tan` of the closest `Decimal128` to five quarter turns is past what the type holds and raises rather than answering.

Two things this turned up in what is already merged. A value too large for `Decimal128` came back with a scale of four billion instead of raising: when more digits had to go than there were places after the point, the scale went negative and wrapped. Nothing reached it before, because `exp` refuses its argument above 66.54 and a logarithm is small; `tan` next to a pole reaches it.

And the second width was paying for software division. Multiplying two 75-digit mantissas splits each in half, and the splitting used `//` and `%`; lining up an addition whose gap was wider than `UInt256` had room for did the same. Four software divides made one multiplication cost 370 nanoseconds where the reciprocal divider does it in 20. The argument reduction went from 3298 nanoseconds to 226, and the 75-digit series from 20.9 microseconds to 2.4 -- so every second attempt in `exp`, `ln`, `log10` and `power` became about ten times cheaper too.

Timings on osx-arm64, nanoseconds per call:

| | |
| --- | ---: |
| `sin(1.2)` | 572 |
| `cos(1.2)` | 583 |
| `tan(1.2)` | 1223 |
| `sec(1.2)` | 896 |
| `sin(1.2345E+28)` | 529 |
| `sin` of an angle on a quarter turn | 484 |

A large argument costs no more than a small one: the reduction is four multiplications and four subtractions whatever `k` is.

The suite is at 1214 tests, 6 of them new.
