### PR TITLE
[decimal128] Read and write the IEEE 754 decimal128 interchange format

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,24 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
 
 ### ⭐️ New in Unreleased
 
+1. **decimo reads and writes the IEEE 754 decimal128 interchange format.**
+   `decimo.ieee754` encodes and decodes the sixteen bytes in the binary
+   integer decimal layout -- what MongoDB's BSON `decimal128` and Intel's
+   library store -- with `Decimal128.to_ieee754()`,
+   `Decimal128.from_ieee754()`,
+   `BigDecimal.to_ieee754_decimal128()` and
+   `BigDecimal.from_ieee754_decimal128()` on top, and helpers for the bytes
+   in either order.
+
+   It is a codec and brings no IEEE arithmetic with it. Trailing zeros are
+   part of the encoding and are kept: `1.0` and `1` are one number and two
+   patterns. Every `Decimal128` fits the format; every decimal128 fits a
+   `BigDecimal` exactly. Coming the other way into a `Decimal128` rounds to
+   nearest and refuses what is too large, and an infinity or a NaN is
+   refused by name rather than turned into something else. Densely packed
+   decimal, the encoding IBM's hardware and `decNumber` use, is not read
+   here.
+
 1. **`Decimal128` has trigonometry.** `sin`, `cos`, `tan`, `cot`, `sec` and
    `csc`, as functions and as methods, correctly rounded across the whole
    range the type holds.

--- a/src/decimo/bigdecimal/bigdecimal.mojo
+++ b/src/decimo/bigdecimal/bigdecimal.mojo
@@ -31,6 +31,7 @@ from std import testing
 from decimo.errors import ConversionError, ValueError
 from decimo.traits import Numeric, Parsable, Rootable
 from decimo.rounding_mode import RoundingMode
+import decimo.ieee754 as ieee754
 from decimo.numerals.chinese import ChineseNumeralStyle
 from decimo.bigdecimal.exponential import MathCache
 from decimo.bigint.bigint import BigInt
@@ -2214,6 +2215,62 @@ struct BigDecimal(
         return bigdecimal_exponential.root(self, root, precision)
 
     @always_inline
+    def to_ieee754_decimal128(self) raises -> UInt128:
+        """Returns this value in the IEEE 754 decimal128 interchange format.
+
+        Returns:
+            The sixteen bytes, as one integer, in the binary integer decimal
+            encoding.
+
+        Raises:
+            ValueError: If the coefficient has more than 34 digits or the
+                exponent is outside the range the format holds, which is
+                -6176 to 6111. A `BigDecimal` has neither limit, so this is
+                the direction that can fail; round it first if the extra
+                digits are not wanted.
+
+        Notes:
+            Trailing zeros are kept: `1.0` and `1` are one number and two
+            encodings, and this writes the one it was given.
+        """
+        if self.coefficient.number_of_digits() > ieee754.DECIMAL128_PRECISION:
+            raise ValueError(
+                message=(
+                    "The coefficient has more than 34 digits, which"
+                    " decimal128 does not hold."
+                ),
+                function="BigDecimal.to_ieee754_decimal128()",
+            )
+        return ieee754.encode_decimal128(
+            self.sign, self.coefficient.to_uint128(), -self.scale
+        )
+
+    @staticmethod
+    def from_ieee754_decimal128(bits: UInt128) raises -> Self:
+        """Returns an IEEE 754 decimal128 as a `BigDecimal`.
+
+        Args:
+            bits: The sixteen bytes, as one integer, in the binary integer
+                decimal encoding.
+
+        Returns:
+            The same number, exactly, with the same trailing zeros.
+
+        Raises:
+            ValueError: If the bytes hold an infinity or a NaN, which this
+                type does not have.
+
+        Notes:
+            Nothing is lost in this direction: 34 digits and an exponent
+            inside 6144 are well within what a `BigDecimal` holds.
+        """
+        var parts = ieee754.decode_decimal128(bits)
+        return Self(
+            BigUInt.from_unsigned_integral_scalar(parts[1]),
+            -parts[2],
+            parts[0],
+        )
+
     def sqrt(self) raises -> Self:
         """Returns the square root of the BigDecimal number with default
         precision.

--- a/src/decimo/decimal128/decimal128.mojo
+++ b/src/decimo/decimal128/decimal128.mojo
@@ -34,6 +34,8 @@ import decimo.decimal128.constants as decimal128_constants
 import decimo.decimal128.exponential as decimal128_exponential
 import decimo.decimal128.rounding as decimal128_rounding
 import decimo.decimal128.trigonometric as decimal128_trigonometric
+import decimo.ieee754 as ieee754
+from decimo.decimal128.wide import Wide
 from decimo.rounding_mode import RoundingMode
 from decimo.errors import (
     ValueError,
@@ -2453,6 +2455,68 @@ struct Decimal128(
             ValueError: If `n` is non-positive, or `n` is even and the value is negative.
         """
         return decimal128_exponential.root(self, n)
+
+    def to_ieee754(self) raises -> UInt128:
+        """Returns this value in the IEEE 754 decimal128 interchange format.
+
+        Returns:
+            The sixteen bytes, as one integer, in the binary integer decimal
+            encoding. `decimal128_to_bytes` turns it into bytes in either
+            order.
+
+        Raises:
+            Error: Propagated from the encoding, which cannot fail for any
+                value this type holds: 29 digits and a scale of at most 28
+                sit well inside the 34 digits and the exponent range of the
+                format.
+
+        Notes:
+            The trailing zeros are kept. `Decimal128("1.0")` and
+            `Decimal128("1")` are the same number and different sixteen
+            bytes, which is what the format is for.
+        """
+        return ieee754.encode_decimal128(
+            self.is_negative(), self.coefficient(), -Int(self.scale())
+        )
+
+    @staticmethod
+    def from_ieee754(bits: UInt128) raises -> Self:
+        """Returns an IEEE 754 decimal128 as a `Decimal128`.
+
+        Args:
+            bits: The sixteen bytes, as one integer, in the binary integer
+                decimal encoding.
+
+        Returns:
+            The nearest `Decimal128`, ties to even.
+
+        Raises:
+            ValueError: If the bytes hold an infinity or a NaN.
+            OverflowError: If the number is larger than this type holds.
+
+        Notes:
+            The format reaches `1E+6144` and 34 digits where this type stops
+            at `7.9E+28` and 29, so this direction can round and can fail. A
+            value below the smallest scale rounds to zero rather than
+            failing.
+        """
+        var parts = ieee754.decode_decimal128(bits)
+        var coefficient = parts[1]
+        var exponent = parts[2]
+
+        # Written as this type writes it: keep it digit for digit, trailing
+        # zeros and all. `1.0` and `1` are one number and two encodings, and
+        # a codec that returned the other one would not be a codec.
+        if (
+            exponent <= 0
+            and exponent >= -Int(Self.MAX_SCALE)
+            and coefficient >> 96 == UInt128(0)
+        ):
+            return Self.from_uint128(coefficient, UInt32(-exponent), parts[0])
+
+        # Otherwise it has more digits, or a larger exponent, than this type
+        # holds, and it is rounded into range.
+        return Wide(UInt256(coefficient), exponent, parts[0]).to_decimal()
 
     @always_inline
     def sin(self) raises -> Self:

--- a/src/decimo/ieee754.mojo
+++ b/src/decimo/ieee754.mojo
@@ -1,0 +1,306 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2025-2026 Yuhao Zhu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+#
+# The IEEE 754 decimal128 interchange format
+#
+# ===----------------------------------------------------------------------=== #
+
+"""Reads and writes the IEEE 754 decimal128 interchange format.
+
+This is a codec and nothing else: sixteen bytes in, a sign, a coefficient and
+an exponent out, and back. It does not bring IEEE arithmetic with it, and it
+knows nothing about `Decimal128` or `BigDecimal` -- both hand it the three
+numbers they already hold.
+
+The format is a sign, a 34-digit coefficient and an exponent from -6176 to
+6111, written in the binary integer decimal encoding: the coefficient is one
+plain binary integer rather than the packed declets of the other encoding.
+That is what MongoDB's BSON `decimal128` and Intel's library use. IBM's
+hardware and `decNumber` use densely packed decimal, which this module does
+not read; it is a different arrangement of the same numbers, not a different
+set of them.
+
+A `Decimal128` always fits: 29 digits and a scale of at most 28 sit well
+inside 34 digits and the exponent range. Coming the other way needs rounding,
+and can be out of range entirely, so the conversion is allowed to fail.
+"""
+
+from std.builtin.simd import SIMD
+
+from decimo.errors import ValueError, OverflowError
+
+
+comptime DECIMAL128_PRECISION = 34
+"""Digits a decimal128 coefficient holds."""
+
+
+comptime DECIMAL128_BIAS = 6176
+"""What is added to the exponent before it is written."""
+
+
+comptime DECIMAL128_MAX_BIASED_EXPONENT = 12287
+"""The largest exponent field, which is 14 bits less one value."""
+
+
+comptime DECIMAL128_MAX_EXPONENT = 6111
+"""The largest exponent, which is `DECIMAL128_MAX_BIASED_EXPONENT - BIAS`."""
+
+
+comptime DECIMAL128_MIN_EXPONENT = -6176
+"""The smallest exponent, which is `-BIAS`."""
+
+
+comptime DECIMAL128_MAX_COEFFICIENT = UInt128(10) ** 34 - UInt128(1)
+"""The largest coefficient, `10^34 - 1`.
+
+It is below `2^113`, which is why an encoder never needs the second of the
+two coefficient layouts: every canonical coefficient fits in the 113 bits the
+first one gives it.
+
+The second layout begins the coefficient with an implied `100`, so the
+smallest value it can express is `2^113`, which is `1.038E+34` -- larger than
+any coefficient decimal128 allows. Every value written that way is therefore
+non-canonical, and the standard says a non-canonical coefficient reads as
+zero. A decoder still has to recognise the layout to answer zero rather than
+nonsense; the wider formats, where the same layout is ordinary, are not this
+module's concern.
+"""
+
+
+comptime _COEFFICIENT_MASK = (UInt128(1) << 113) - UInt128(1)
+comptime _LARGE_COEFFICIENT_MASK = (UInt128(1) << 111) - UInt128(1)
+comptime _LARGE_COEFFICIENT_PREFIX = UInt128(1) << 113
+comptime _EXPONENT_MASK = UInt128(0x3FFF)
+
+
+def encode_decimal128(
+    sign: Bool, coefficient: UInt128, exponent: Int
+) raises -> UInt128:
+    """Writes a number as a decimal128.
+
+    Args:
+        sign: True when the number is negative.
+        coefficient: The digits, at most `10^34 - 1`.
+        exponent: The power of ten they are multiplied by, from -6176 to
+            6111.
+
+    Returns:
+        The sixteen bytes, as one integer.
+
+    Raises:
+        ValueError: If the coefficient has more than 34 digits or the
+            exponent is outside what the format holds.
+
+    Notes:
+        Nothing is rounded here. The caller says which member of the cohort
+        it wants written -- `1E+1` and `10` are different sixteen bytes and
+        the same number -- and this writes that one.
+    """
+    if coefficient > DECIMAL128_MAX_COEFFICIENT:
+        raise ValueError(
+            message=(
+                "The coefficient has more than 34 digits, which decimal128"
+                " does not hold."
+            ),
+            function="encode_decimal128()",
+        )
+    if exponent < DECIMAL128_MIN_EXPONENT or exponent > DECIMAL128_MAX_EXPONENT:
+        raise ValueError(
+            message=(
+                "The exponent is outside the range decimal128 holds, which is"
+                " -6176 to 6111."
+            ),
+            function="encode_decimal128()",
+        )
+
+    var biased = UInt128(exponent + DECIMAL128_BIAS)
+    var bits = (biased << 113) | coefficient
+    if sign:
+        bits |= UInt128(1) << 127
+    return bits
+
+
+def decode_decimal128(bits: UInt128) raises -> Tuple[Bool, UInt128, Int]:
+    """Reads a decimal128 as a sign, a coefficient and an exponent.
+
+    Args:
+        bits: The sixteen bytes, as one integer.
+
+    Returns:
+        Whether the number is negative, its digits, and the power of ten they
+        are multiplied by.
+
+    Raises:
+        ValueError: If the bytes hold an infinity or a NaN, which neither
+            `Decimal128` nor `BigDecimal` has anywhere to put. Ask
+            `decimal128_is_infinity` or `decimal128_is_nan` first when the
+            source may contain them.
+
+    Notes:
+        A coefficient too large to be one -- which the second layout can
+        write and no canonical value uses -- reads as zero, as the standard
+        says it must.
+    """
+    if decimal128_is_infinity(bits):
+        raise ValueError(
+            message="The value is an infinity, which decimo does not hold.",
+            function="decode_decimal128()",
+        )
+    if decimal128_is_nan(bits):
+        raise ValueError(
+            message="The value is a NaN, which decimo does not hold.",
+            function="decode_decimal128()",
+        )
+
+    var sign = (bits >> 127) & UInt128(1) == UInt128(1)
+    var biased: UInt128
+    var coefficient: UInt128
+    if (bits >> 125) & UInt128(3) == UInt128(3):
+        # The second layout: the exponent sits two bits lower and the
+        # coefficient begins with an implied `100`.
+        biased = (bits >> 111) & _EXPONENT_MASK
+        coefficient = _LARGE_COEFFICIENT_PREFIX | (
+            bits & _LARGE_COEFFICIENT_MASK
+        )
+    else:
+        biased = (bits >> 113) & _EXPONENT_MASK
+        coefficient = bits & _COEFFICIENT_MASK
+
+    if coefficient > DECIMAL128_MAX_COEFFICIENT:
+        coefficient = UInt128(0)
+
+    return (sign, coefficient, Int(biased) - DECIMAL128_BIAS)
+
+
+def decimal128_is_infinity(bits: UInt128) -> Bool:
+    """Returns whether the bytes hold an infinity.
+
+    Args:
+        bits: The sixteen bytes, as one integer.
+
+    Returns:
+        True for either infinity.
+    """
+    return (bits >> 122) & UInt128(0x1F) == UInt128(0x1E)
+
+
+def decimal128_is_nan(bits: UInt128) -> Bool:
+    """Returns whether the bytes hold a NaN.
+
+    Args:
+        bits: The sixteen bytes, as one integer.
+
+    Returns:
+        True for a NaN of either kind.
+    """
+    return (bits >> 122) & UInt128(0x1F) == UInt128(0x1F)
+
+
+def decimal128_is_signaling_nan(bits: UInt128) -> Bool:
+    """Returns whether the bytes hold a signalling NaN.
+
+    Args:
+        bits: The sixteen bytes, as one integer.
+
+    Returns:
+        True for a signalling NaN.
+    """
+    return decimal128_is_nan(bits) and (bits >> 121) & UInt128(1) == UInt128(1)
+
+
+def decimal128_is_finite(bits: UInt128) -> Bool:
+    """Returns whether the bytes hold a number.
+
+    Args:
+        bits: The sixteen bytes, as one integer.
+
+    Returns:
+        True unless the value is an infinity or a NaN.
+    """
+    return (bits >> 122) & UInt128(0x1E) != UInt128(0x1E)
+
+
+def decimal128_infinity(sign: Bool = False) -> UInt128:
+    """Returns the bytes for an infinity.
+
+    Args:
+        sign: True for negative infinity.
+
+    Returns:
+        The sixteen bytes, as one integer.
+    """
+    var bits = UInt128(0x1E) << 122
+    if sign:
+        bits |= UInt128(1) << 127
+    return bits
+
+
+def decimal128_quiet_nan(sign: Bool = False) -> UInt128:
+    """Returns the bytes for a quiet NaN.
+
+    Args:
+        sign: True for the sign bit set, which a NaN may carry.
+
+    Returns:
+        The sixteen bytes, as one integer.
+    """
+    var bits = UInt128(0x1F) << 122
+    if sign:
+        bits |= UInt128(1) << 127
+    return bits
+
+
+def decimal128_to_bytes[
+    little_endian: Bool = True
+](bits: UInt128) -> InlineArray[UInt8, 16]:
+    """Returns a decimal128 as sixteen bytes.
+
+    Parameters:
+        little_endian: The byte order. BSON and Intel's library store these
+            little-endian, which is the default.
+
+    Args:
+        bits: The value, as one integer.
+
+    Returns:
+        The bytes.
+    """
+    var result = InlineArray[UInt8, 16](uninitialized=True)
+    for index in range(16):
+        var byte = UInt8((bits >> UInt128(8 * index)) & UInt128(0xFF))
+        result[index if little_endian else 15 - index] = byte
+    return result^
+
+
+def decimal128_from_bytes[
+    little_endian: Bool = True
+](bytes: InlineArray[UInt8, 16]) -> UInt128:
+    """Returns sixteen bytes as a decimal128.
+
+    Parameters:
+        little_endian: The byte order the bytes are in.
+
+    Args:
+        bytes: The bytes.
+
+    Returns:
+        The value, as one integer.
+    """
+    var bits = UInt128(0)
+    for index in range(16):
+        var byte = bytes[index if little_endian else 15 - index]
+        bits |= UInt128(byte) << UInt128(8 * index)
+    return bits

--- a/tests/bigdecimal/test_bigdecimal_ieee754.mojo
+++ b/tests/bigdecimal/test_bigdecimal_ieee754.mojo
@@ -1,0 +1,57 @@
+"""
+Tests for `BigDecimal` and the IEEE 754 decimal128 interchange format.
+
+Every decimal128 fits a `BigDecimal` exactly, so the round trip is bit for
+bit in both directions; the other way round can be refused.
+"""
+
+from std import testing
+from std.testing import assert_equal, assert_true
+
+from decimo.bigdecimal.bigdecimal import BigDecimal
+
+
+def test_round_trip_is_exact() raises:
+    """A decimal128 read and written again is the same sixteen bytes."""
+
+    def _check(bits: UInt128, text: String) raises:
+        var value = BigDecimal.from_ieee754_decimal128(bits)
+        assert_equal(String(value), text)
+        assert_equal(value.to_ieee754_decimal128(), bits)
+
+    _check(UInt128(0x30400000000000000000000000000001), "1")
+    _check(UInt128(0x303E000000000000000000000000000A), "1.0")
+    _check(UInt128(0xB0400000000000000000000000000001), "-1")
+    _check(UInt128(0x303A0000000000000000000000000001), "0.001")
+    # The whole coefficient, which `Decimal128` has no room for.
+    _check(
+        UInt128(0x3041ED09BEAD87C0378D8E63FFFFFFFF),
+        "9999999999999999999999999999999999",
+    )
+    # And both ends of the exponent.
+    _check(UInt128(0x5FFE0000000000000000000000000001), "1E+6111")
+    _check(UInt128(0x00000000000000000000000000000001), "1E-6176")
+
+
+def test_writing_refuses_what_the_format_cannot_hold() raises:
+    """A `BigDecimal` has neither the 34 digits nor the exponent range as a
+    limit, so this is the direction that can fail."""
+    var raised = False
+    try:
+        _ = BigDecimal(
+            "12345678901234567890123456789012345"
+        ).to_ieee754_decimal128()
+    except:
+        raised = True
+    assert_true(raised, "35 digits do not fit decimal128")
+
+    raised = False
+    try:
+        _ = BigDecimal("1E+7000").to_ieee754_decimal128()
+    except:
+        raised = True
+    assert_true(raised, "an exponent of 7000 does not fit decimal128")
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_ieee754.mojo
+++ b/tests/decimal128/test_decimal128_ieee754.mojo
@@ -1,0 +1,217 @@
+"""
+Tests for the IEEE 754 decimal128 interchange format: `decimo.ieee754` and
+the `Decimal128` conversions built on it.
+
+The hexadecimal patterns are the format's own, and the first few are the
+values MongoDB's BSON specification writes out for the same numbers.
+"""
+
+from std import testing
+from std.testing import assert_equal, assert_true, assert_false
+
+from decimo.decimal128.decimal128 import Decimal128
+from decimo.ieee754 import (
+    encode_decimal128,
+    decode_decimal128,
+    decimal128_is_finite,
+    decimal128_is_infinity,
+    decimal128_is_nan,
+    decimal128_is_signaling_nan,
+    decimal128_infinity,
+    decimal128_quiet_nan,
+    decimal128_to_bytes,
+    decimal128_from_bytes,
+    DECIMAL128_MAX_COEFFICIENT,
+)
+
+
+def test_known_patterns() raises:
+    """The sixteen bytes for numbers whose encoding is written down
+    elsewhere."""
+
+    def _check(text: String, bits: UInt128) raises:
+        assert_equal(Decimal128(text).to_ieee754(), bits)
+        assert_equal(String(Decimal128.from_ieee754(bits)), text)
+
+    _check("1", UInt128(0x30400000000000000000000000000001))
+    _check("0", UInt128(0x30400000000000000000000000000000))
+    _check("-1", UInt128(0xB0400000000000000000000000000001))
+    _check("0.001", UInt128(0x303A0000000000000000000000000001))
+    # A trailing zero is part of the encoding, not noise to be tidied away:
+    # `1.0` and `1` are one number and two patterns.
+    _check("1.0", UInt128(0x303E000000000000000000000000000A))
+    _check(
+        "12345678901234567890123456789",
+        UInt128(0x3040000027E41B3246BEC9B16E398115),
+    )
+    _check(
+        "0.0000000000000000000000000001",
+        UInt128(0x30080000000000000000000000000001),
+    )
+
+    # Negative zero keeps its sign.
+    assert_equal(
+        Decimal128("-0").to_ieee754(),
+        UInt128(0xB0400000000000000000000000000000),
+    )
+
+
+def test_round_trip_through_the_format() raises:
+    """Every value this type holds comes back as itself, digit for digit."""
+
+    def _check(text: String) raises:
+        var value = Decimal128(text)
+        assert_equal(String(Decimal128.from_ieee754(value.to_ieee754())), text)
+
+    _check("0")
+    _check("1")
+    _check("-1")
+    _check("79228162514264337593543950335")
+    _check("-79228162514264337593543950335")
+    _check("0.0000000000000000000000000001")
+    _check("7.9228162514264337593543950335")
+    _check("123.4500")
+    _check("-0.000000000000000000000000000")
+
+
+def test_encoding_refuses_what_the_format_cannot_hold() raises:
+    """The coefficient stops at 34 digits and the exponent at 6111."""
+    var raised = False
+    try:
+        _ = encode_decimal128(False, DECIMAL128_MAX_COEFFICIENT + UInt128(1), 0)
+    except:
+        raised = True
+    assert_true(raised, "35 digits should be refused")
+
+    raised = False
+    try:
+        _ = encode_decimal128(False, UInt128(1), 6112)
+    except:
+        raised = True
+    assert_true(raised, "an exponent above 6111 should be refused")
+
+    raised = False
+    try:
+        _ = encode_decimal128(False, UInt128(1), -6177)
+    except:
+        raised = True
+    assert_true(raised, "an exponent below -6176 should be refused")
+
+    # The two ends themselves are fine.
+    _ = encode_decimal128(False, DECIMAL128_MAX_COEFFICIENT, 6111)
+    _ = encode_decimal128(True, DECIMAL128_MAX_COEFFICIENT, -6176)
+
+
+def test_decoding_into_a_smaller_type() raises:
+    """The format reaches further than `Decimal128`, so this direction rounds
+    and can fail."""
+
+    def _refuses(bits: UInt128) raises:
+        var raised = False
+        try:
+            _ = Decimal128.from_ieee754(bits)
+        except:
+            raised = True
+        assert_true(raised, "the value is past what Decimal128 holds")
+
+    # 34 digits, and a hundred orders of magnitude too far.
+    _refuses(UInt128(0x3041ED09BEAD87C0378D8E63FFFFFFFF))
+    _refuses(UInt128(0x31080000000000000000000000000001))
+    _refuses(UInt128(0x5FFE0000000000000000000000000001))
+
+    # Below the smallest scale, the answer is zero rather than a refusal.
+    assert_equal(
+        String(
+            Decimal128.from_ieee754(UInt128(0x01600000000000000000000000000001))
+        ),
+        "0.0000000000000000000000000000",
+    )
+
+    # And what does fit is rounded to nearest, ties to even.
+    assert_equal(
+        String(
+            Decimal128.from_ieee754(UInt128(0x303A009BD30A3C645943DD1690A03BFB))
+        ),
+        "12345678901234567890123456789",
+    )
+    assert_equal(
+        String(
+            Decimal128.from_ieee754(UInt128(0x303A009BD30A3C645943DD1690A03BFC))
+        ),
+        "12345678901234567890123456790",
+    )
+    assert_equal(
+        String(
+            Decimal128.from_ieee754(UInt128(0x30040000000000000000000000000033))
+        ),
+        "0.0000000000000000000000000001",
+    )
+
+
+def test_infinities_and_nans() raises:
+    """The format has them; decimo does not, and says so."""
+    var infinity = decimal128_infinity()
+    var negative_infinity = decimal128_infinity(sign=True)
+    var nan = decimal128_quiet_nan()
+
+    assert_equal(infinity, UInt128(0x78000000000000000000000000000000))
+    assert_equal(nan, UInt128(0x7C000000000000000000000000000000))
+
+    assert_true(decimal128_is_infinity(infinity))
+    assert_true(decimal128_is_infinity(negative_infinity))
+    assert_true(decimal128_is_nan(nan))
+    assert_false(decimal128_is_finite(infinity))
+    assert_false(decimal128_is_finite(nan))
+    assert_true(decimal128_is_finite(Decimal128("1").to_ieee754()))
+
+    var signaling = UInt128(0x7E000000000000000000000000000000)
+    assert_true(decimal128_is_nan(signaling))
+    assert_true(decimal128_is_signaling_nan(signaling))
+    assert_false(decimal128_is_signaling_nan(nan))
+
+    for bits in [infinity, negative_infinity, nan, signaling]:
+        var raised = False
+        try:
+            _ = decode_decimal128(bits)
+        except:
+            raised = True
+        assert_true(raised, "decoding one of these should raise")
+
+
+def test_the_second_coefficient_layout_reads_as_zero() raises:
+    """The layout that begins the coefficient with an implied `100`.
+
+    Its smallest value is `2^113`, which is `1.038E+34` and larger than any
+    coefficient decimal128 allows, so every value written that way is
+    non-canonical -- and the standard says a non-canonical coefficient is
+    zero.
+    """
+    var parts = decode_decimal128(UInt128(0x6C100000000000000000000000000000))
+    assert_equal(parts[1], UInt128(0))
+    assert_equal(
+        String(
+            Decimal128.from_ieee754(UInt128(0x6C100000000000000000000000000000))
+        ),
+        "0",
+    )
+
+
+def test_bytes_in_either_order() raises:
+    """Sixteen bytes, little-endian as BSON writes them or the other way."""
+    var bits = Decimal128("1").to_ieee754()
+    var little = decimal128_to_bytes(bits)
+    var big = decimal128_to_bytes[little_endian=False](bits)
+
+    assert_equal(little[0], UInt8(1))
+    assert_equal(little[14], UInt8(0x40))
+    assert_equal(little[15], UInt8(0x30))
+    assert_equal(big[0], UInt8(0x30))
+    assert_equal(big[1], UInt8(0x40))
+    assert_equal(big[15], UInt8(1))
+
+    assert_equal(decimal128_from_bytes(little), bits)
+    assert_equal(decimal128_from_bytes[little_endian=False](big), bits)
+
+
+def main() raises:
+    testing.TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
decimo now reads and writes the IEEE 754 decimal128 interchange format. `decimo.ieee754` is a codec and nothing else: sixteen bytes in, a sign, a coefficient and an exponent out, and back. It brings no IEEE arithmetic with it and knows nothing about either decimal type -- both hand it the three numbers they already hold.

The encoding is the binary integer decimal layout, where the coefficient is one plain binary integer. That is what MongoDB's BSON `decimal128` and Intel's library store, and `Decimal128("1").to_ieee754()` is `0x30400000000000000000000000000001`, the pattern the BSON specification writes for the same number. Densely packed decimal, the encoding IBM's hardware and `decNumber` use, is not read here: it is a different arrangement of the same numbers, and I would rather leave it out than guess at the declet tables.

Four conversions sit on top: `Decimal128.to_ieee754()` and `from_ieee754()`, `BigDecimal.to_ieee754_decimal128()` and `from_ieee754_decimal128()`. There are helpers for the bytes in either order, since BSON stores them little-endian, and predicates for the infinities and NaNs the format has and decimo does not.

Which direction can fail depends on which type. Every `Decimal128` fits: 29 digits and a scale of at most 28 sit well inside 34 digits and an exponent range of 6144. Every decimal128 fits a `BigDecimal` exactly, so that round trip is bit for bit both ways. Reading a decimal128 into a `Decimal128` is the direction that rounds -- to nearest, ties to even -- and it refuses what is too large rather than wrapping. An infinity or a NaN is refused by name, and `decimal128_is_infinity` and `decimal128_is_nan` let a caller ask before decoding.

Trailing zeros are part of the encoding and are kept. `1.0` and `1` are one number and two patterns, and a codec that tidied one into the other would not be a codec: an earlier draft did exactly that, because it decoded through the same conversion `sqrt` uses, which strips zeros it knows to be exact.

One thing worth writing down, since it decides how the decoder behaves: the format has two coefficient layouts, and decimal128 only ever uses the first. The second begins the coefficient with an implied `100`, so the smallest value it can express is `2^113`, which is `1.038E+34` -- larger than the largest coefficient the format allows, `10^34 - 1`. Every value written that way is therefore non-canonical, and the standard says a non-canonical coefficient reads as zero. The decoder recognises the layout so it can answer zero rather than nonsense; an encoder never needs it.

Checked against an independent implementation of the format written from its description: 200 values encoded from `Decimal128` matched pattern for pattern and round-tripped back unchanged, and 125 decimal128 values -- including a 34-digit coefficient at both ends of the exponent range -- round-tripped through `BigDecimal` bit for bit. The known BSON patterns for 1, 0, -0, -1, 0.001, 1.0, infinity and NaN are in the tests as written constants.

Encoding costs 1.7 nanoseconds and decoding 1.9.

The suite is at 1223 tests, 9 of them new.
