### PR TITLE
[python] Give the Python package Decimal128, and make its division the fastest of the three

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,35 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
 
 ### ⭐️ New in Unreleased
 
+1. **The Python package has `Decimal128`.** The fixed-width type is exposed
+   as `decimo.Decimal128`, with `Dec128` as the shorter name the Mojo library
+   uses: 96 bits of coefficient and a scale from 0 to 28, in sixteen bytes
+   that own nothing.
+
+   It arithmetics, compares, hashes and rounds like `Decimal`, takes an
+   `int`, a `float` or a `str` on either side of an operator, and copies,
+   pickles and formats like a value. Its hash agrees with `int`, `float`,
+   `decimal.Decimal` and `Decimal`, so the four are interchangeable as
+   dictionary keys.
+
+   The methods a `decimal` program reaches for are there: `quantize`,
+   `round`, `as_tuple`, `as_integer_ratio`, `normalize`, `adjusted`,
+   `compare`, `copy_sign`, `copy_abs`, `copy_negate`, `to_integral_value`,
+   `same_quantum`, `max`, `min`, `fma`, `to_eng_string`, `from_float` and the
+   `is_` predicates. So is the mathematics: `sqrt`, `cbrt`, `root`, `exp`,
+   `ln`, `log10`, `log`, and all six trigonometric functions. And the IEEE
+   754 interchange bytes.
+
+   A mixed expression settles in the wider type -- `Decimal128 + Decimal` is
+   a `Decimal`, either way round -- since widening loses nothing.
+
+   Its results never allocate. Against `Decimal` and `decimal.Decimal`:
+   addition 46 nanoseconds against 67 and 73, multiplication 57 against 92
+   and 85, division 114 against 225 and 133, construction from text 116
+   against 160 and 136, and `str` 118 against 437 and 67. A worked invoice --
+   three lines quantized to cents, with tax -- is 633 nanoseconds against 713
+   and 705. `str` is the one that is slower.
+
 1. **decimo reads and writes the IEEE 754 decimal128 interchange format.**
    `decimo.ieee754` encodes and decodes the sixteen bytes in the binary
    integer decimal layout -- what MongoDB's BSON `decimal128` and Intel's
@@ -241,6 +270,24 @@ against GMP rather than against CPython's `int`. Its magnitude moves from base
    `BigInt10.from_bigint()` and `BigInt10.to_bigint()` (PR #269).
 
 ### 🦋 Changed in Unreleased
+
+1. **`Decimal128` division is one wide division rather than a walk.** The
+   quotient was built a digit at a time -- two probe steps, then a bulk step
+   -- which cost 226 nanoseconds and could run out of digits before reaching
+   the position the rounding needed: `504572829922.89957 / 525211.7899` came
+   out one unit low, and 1 in 300 random pairs was wrong in the last place.
+
+   The numerator is now raised until the integer quotient is about thirty
+   digits, divided once, and rounded from the remainder, which is what
+   settles a tie. That needed a 256-by-128 divider, since a divisor past 64
+   bits fell through to `UInt256 // UInt256`, a software shift-subtract loop
+   of 261 nanoseconds. `udiv_u256_by_u128` is Knuth's algorithm D over 64-bit
+   limbs, and takes 22: every division inside it has a divisor that fits 64
+   bits, which is the case `__udivti3` does in 2.6 nanoseconds rather than
+   75.
+
+   Division is 70 nanoseconds against 226, and correct on all 300 pairs. From
+   Python that is 114 against `decimal`'s 133.
 
 1. **An exact integer power is known to be exact, and trailing zeros come
    off in one step.** A base of `d` digits raised to the `n`-th has at most

--- a/python/README.md
+++ b/python/README.md
@@ -108,6 +108,49 @@ to even, where before the last digit was assumed rather than known -- so
 `ROUND_FLOOR` really does stay under the true value, and a tie really is a
 tie.
 
+### A second type for money
+
+`Decimal` is arbitrary precision and is what a program reaching for
+`decimal.Decimal` wants. `Decimal128` is the other one: 96 bits of
+coefficient and a scale from 0 to 28, in sixteen bytes that own nothing --
+the layout .NET's `System.Decimal` and Rust's `rust_decimal` use.
+
+```python
+from decimo import Decimal128        # Dec128 is the same type
+
+price = Decimal128("19.99")
+line = (price * 3).quantize(Decimal128("0.01"))     # 59.97
+Decimal128(2).sqrt()                                # and exp, ln, log10, sin, cos, tan
+Decimal128("1").to_ieee754()                        # the IEEE 754 interchange bytes
+```
+
+It arithmetics, compares, hashes and rounds like `Decimal`, mixes with `int`,
+`float` and `str` on either side of an operator, and converts both ways
+(`Decimal128(x).to_decimal()`, `Decimal(x)`). Its results never allocate, so
+it is quicker where the values are money and the shape of them is known:
+
+| | `Decimal128` | `Decimal` | `decimal` |
+| --- | ---: | ---: | ---: |
+| `a + b` | **46 ns** | 67 | 73 |
+| `a * b` | **57 ns** | 92 | 85 |
+| `a / b` | **114 ns** | 225 | 133 |
+| from text | **116 ns** | 160 | 136 |
+| `str(x)` | 118 ns | 437 | **67** |
+| an invoice | **633 ns** | 713 | 705 |
+
+`str` is the one that is slower.
+
+A mixed expression settles in the wider type: `Decimal128(x) + Decimal(y)` is
+a `Decimal`, either way round, because widening loses nothing.
+
+What it does not do: it stops at `7.9E+28` and 28 decimal places and raises
+rather than rounding into a context, it has no `Context` of its own beyond
+the rounding mode, and its scale is never negative -- `Decimal128("1.23E+5")`
+is `123000`, where `decimal` keeps a coefficient of 123 with an exponent of 3
+and can print it as `123E+3`. `Decimal128(0.1)` is `0.1` rather than the whole
+binary expansion, since 55 digits do not fit 28; what is promised is that
+`float(Decimal128(x)) == x`.
+
 ## What does not
 
 decimo refuses these rather than answering differently:

--- a/python/decimo_module.mojo
+++ b/python/decimo_module.mojo
@@ -53,6 +53,9 @@ from std.python.python_object import (
 from std.os import abort
 
 from decimo import BigDecimal, RoundingMode
+from decimo.decimal128.decimal128 import Decimal128
+import decimo.ieee754 as ieee754
+import decimo.decimal128.trigonometric as decimal128_trigonometric
 from decimo.biguint.biguint import BigUInt
 from decimo.bigint.bigint import BigInt
 import decimo.bigdecimal.spec as bigdecimal_spec
@@ -95,6 +98,9 @@ struct _State(Defaultable, Movable):
     var rounding: RoundingMode
     """The context rounding mode, applied wherever an operation rounds."""
     var decimal_type: PyTypeObjectPtr
+    var decimal128_type: PyTypeObjectPtr
+    """The fixed-width type, found the same way and kept for the same
+    reason."""
     var float_function: PythonObject
     """`builtins.float`, kept because `float(x)` has to hand CPython the text
     -- Mojo's own parser refuses a long one -- and importing `builtins` for it
@@ -107,6 +113,7 @@ struct _State(Defaultable, Movable):
         self.precision = 28
         self.rounding = RoundingMode.ROUND_HALF_EVEN
         self.decimal_type = PyTypeObjectPtr()
+        self.decimal128_type = PyTypeObjectPtr()
         self.float_function = PythonObject(None)
         self.free_list = InlineArray[PyObjectPtr, FREE_LIST_SIZE](
             uninitialized=True
@@ -145,6 +152,40 @@ def decimal_type_ptr(mut cell: _State) raises -> PyTypeObjectPtr:
             BigDecimal
         ]()._obj_ptr.bitcast[PyTypeObject]()
     return cell.decimal_type
+
+
+@always_inline
+def decimal128_type_ptr(mut cell: _State) raises -> PyTypeObjectPtr:
+    """The fixed-width type object, found once and kept."""
+    if not cell.decimal128_type:
+        cell.decimal128_type = lookup_py_type_object[
+            Decimal128
+        ]()._obj_ptr.bitcast[PyTypeObject]()
+    return cell.decimal128_type
+
+
+@always_inline
+def new_decimal128(
+    mut cell: _State, var value: Decimal128
+) raises -> PythonObject:
+    """Wrap a fixed-width result.
+
+    No free list here. A `Decimal128` is sixteen bytes inside the object and
+    owns nothing, so releasing one is `tp_dealloc` and nothing else; the
+    arbitrary-precision type keeps a list because its coefficient is a heap
+    allocation that the reuse also saves.
+    """
+    return _unsafe_alloc_init(decimal128_type_ptr(cell), value)
+
+
+@always_inline
+def _value128_of(obj: PyObjectPtr) -> Pointer[Decimal128, MutUntrackedOrigin]:
+    """The `Decimal128` inside an object of that type, without touching its
+    reference count. Only call this after checking the type."""
+    ref mojo_object = obj.bitcast[PyMojoObject[Decimal128]]().value()[]
+    return Pointer(to=mojo_object.mojo_value).unsafe_origin_cast[
+        MutUntrackedOrigin
+    ]()
 
 
 @always_inline
@@ -286,6 +327,715 @@ def round_to_context(var value: BigDecimal) raises -> BigDecimal:
 
 
 # ===----------------------------------------------------------------------=== #
+# Decimal128, the fixed-width type
+#
+# `Decimal` is arbitrary precision and is what a program reaching for
+# `decimal.Decimal` wants. `Decimal128` is the other one: 96 bits of
+# coefficient and a scale from 0 to 28, the layout .NET's `System.Decimal` and
+# Rust's `rust_decimal` use, in sixteen bytes that own nothing. Its results
+# never allocate and its text is five times cheaper to produce.
+#
+# The two are separate types on purpose. Mixing them in an expression converts
+# through the wider one, which is what `Decimal(x) + Decimal128(y)` does, and
+# the conversion each way is a method rather than something that happens
+# quietly in an operator.
+# ===----------------------------------------------------------------------=== #
+
+
+def decimal128_py_init(
+    out self: Decimal128, args: PythonObject, kwargs: PythonObject
+) raises:
+    """Construct a `Decimal128` from a string, an integer, a float, or
+    another decimal.
+
+    Usage from Python:
+        Decimal128("3.14")
+        Decimal128(42)
+        Decimal128(3.14)        # read exactly, as `decimal.Decimal` does
+        Decimal128(Decimal("3.14"))
+        Decimal128()            # zero
+    """
+    if len(args) == 0:
+        self = Decimal128.ZERO()
+        return
+    if len(args) != 1:
+        raise Error(
+            "Decimal128() takes at most 1 argument ("
+            + String(len(args))
+            + " given)"
+        )
+
+    ref cpython = Python().cpython()
+    var argument = args[0]
+
+    if cpython.PyLong_Check(argument._obj_ptr):
+        var value = cpython.PyLong_AsSsize_t(argument._obj_ptr)
+        if value != -1:
+            self = Decimal128.from_int(Int(value))
+            return
+        if not cpython.PyErr_Occurred():
+            self = Decimal128.from_int(-1)
+            return
+        cpython.PyErr_Clear()
+
+    if cpython.PyFloat_Check(argument._obj_ptr):
+        self = Decimal128.from_float(
+            Float64(cpython.PyFloat_AsDouble(argument._obj_ptr))
+        )
+        return
+
+    ref cell = state()[]
+    if cpython.Py_TYPE(argument._obj_ptr) == decimal128_type_ptr(cell):
+        self = _value128_of(argument._obj_ptr)[]
+        return
+    if cpython.Py_TYPE(argument._obj_ptr) == decimal_type_ptr(cell):
+        self = Decimal128(String(_value_of(argument._obj_ptr)[]))
+        return
+
+    var borrowed = cpython.PyUnicode_AsUTF8AndSize(argument._obj_ptr)
+    if borrowed:
+        self = Decimal128.from_string(borrowed.value())
+        return
+
+    raise Error(
+        "Decimal128() argument must be a string, a number, or a decimal"
+    )
+
+
+@always_inline
+def _coerce128(object: PyObjectPtr) raises -> Decimal128:
+    """The other operand of an expression, as a `Decimal128`.
+
+    Integers, floats and text are accepted. A `Decimal` is refused here on
+    purpose: the wider type is the one that loses nothing, so the caller
+    turns the refusal into `NotImplemented` and the expression settles in
+    `Decimal` through the reflected operator.
+
+    Whatever is refused, CPython's error indicator is left clear. A failed
+    `PyUnicode_AsUTF8AndSize` sets one, and a slot that returned
+    `NotImplemented` with an error still pending had it surface later
+    attached to whatever ran next: `Decimal128(1) + Decimal(2)` raised
+    `OverflowError: bad argument type for built-in operation`.
+    """
+    ref cpython = Python().cpython()
+    if cpython.PyLong_Check(object):
+        var value = cpython.PyLong_AsSsize_t(object)
+        if value != -1 or not cpython.PyErr_Occurred():
+            return Decimal128.from_int(Int(value))
+        cpython.PyErr_Clear()
+    if cpython.PyFloat_Check(object):
+        return Decimal128.from_float(Float64(cpython.PyFloat_AsDouble(object)))
+    var borrowed = cpython.PyUnicode_AsUTF8AndSize(object)
+    if borrowed:
+        return Decimal128.from_string(borrowed.value())
+    cpython.PyErr_Clear()
+    raise Error("operand is not a number")
+
+
+def _binary_slot_128[
+    operation: def(Decimal128, Decimal128) thin raises -> Decimal128,
+    is_division: Bool = False,
+](left: PyObjectPtr, right: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """The shared body of every fixed-width arithmetic slot."""
+    try:
+        ref cell = state()[]
+        ref cpython = Python().cpython()
+        var ours = decimal128_type_ptr(cell)
+        var left_is_ours = cpython.Py_TYPE(left) == ours
+        var right_is_ours = cpython.Py_TYPE(right) == ours
+
+        var result: Decimal128
+        if left_is_ours and right_is_ours:
+            result = operation(_value128_of(left)[], _value128_of(right)[])
+        elif left_is_ours:
+            var converted: Decimal128
+            try:
+                converted = _coerce128(right)
+            except:
+                return _not_implemented_ptr()
+            result = operation(_value128_of(left)[], converted)
+        elif right_is_ours:
+            var converted: Decimal128
+            try:
+                converted = _coerce128(left)
+            except:
+                return _not_implemented_ptr()
+            result = operation(converted, _value128_of(right)[])
+        else:
+            return _not_implemented_ptr()
+
+        return new_decimal128(cell, result).steal_data()
+    except e:
+        comptime if is_division:
+            return raise_python_exception(
+                Error("division by zero"),
+                ExceptionType("PyExc_ZeroDivisionError"),
+            )
+        return raise_python_exception(e, ExceptionType("PyExc_OverflowError"))
+
+
+def _do_add_128(x: Decimal128, y: Decimal128) raises -> Decimal128:
+    return x + y
+
+
+def _do_subtract_128(x: Decimal128, y: Decimal128) raises -> Decimal128:
+    return x - y
+
+
+def _do_multiply_128(x: Decimal128, y: Decimal128) raises -> Decimal128:
+    return x * y
+
+
+def _do_divide_128(x: Decimal128, y: Decimal128) raises -> Decimal128:
+    return x / y
+
+
+def slot128_add(left: PyObjectPtr, right: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """`nb_add`."""
+    return _binary_slot_128[_do_add_128](left, right)
+
+
+def slot128_subtract(
+    left: PyObjectPtr, right: PyObjectPtr
+) abi("C") -> PyObjectPtr:
+    """`nb_subtract`."""
+    return _binary_slot_128[_do_subtract_128](left, right)
+
+
+def slot128_multiply(
+    left: PyObjectPtr, right: PyObjectPtr
+) abi("C") -> PyObjectPtr:
+    """`nb_multiply`."""
+    return _binary_slot_128[_do_multiply_128](left, right)
+
+
+def slot128_true_divide(
+    left: PyObjectPtr, right: PyObjectPtr
+) abi("C") -> PyObjectPtr:
+    """`nb_true_divide`. Division by zero is a `ZeroDivisionError`."""
+    return _binary_slot_128[_do_divide_128, is_division=True](left, right)
+
+
+def slot128_richcompare(
+    left: PyObjectPtr, right: PyObjectPtr, operation: c_int
+) abi("C") -> PyObjectPtr:
+    """`tp_richcompare`: all six comparisons, one C function."""
+    try:
+        ref cell = state()[]
+        ref cpython = Python().cpython()
+        var ours = decimal128_type_ptr(cell)
+
+        var first: Decimal128
+        var second: Decimal128
+        if cpython.Py_TYPE(left) == ours:
+            first = _value128_of(left)[]
+            if cpython.Py_TYPE(right) == ours:
+                second = _value128_of(right)[]
+            else:
+                try:
+                    second = _coerce128(right)
+                except:
+                    return _not_implemented_ptr()
+        elif cpython.Py_TYPE(right) == ours:
+            second = _value128_of(right)[]
+            try:
+                first = _coerce128(left)
+            except:
+                return _not_implemented_ptr()
+        else:
+            return _not_implemented_ptr()
+
+        var order: Int
+        if first < second:
+            order = -1
+        elif first > second:
+            order = 1
+        else:
+            order = 0
+
+        var answer: Bool
+        var which = Int(operation)
+        if which == 0:
+            answer = order < 0
+        elif which == 1:
+            answer = order <= 0
+        elif which == 2:
+            answer = order == 0
+        elif which == 3:
+            answer = order != 0
+        elif which == 4:
+            answer = order > 0
+        else:
+            answer = order >= 0
+
+        return PythonObject(answer).steal_data()
+    except e:
+        return raise_python_exception(e)
+
+
+def decimal128_to_string(py_self: PythonObject) raises -> PythonObject:
+    """`str(x)`."""
+    return PythonObject(
+        String(py_self.unchecked_downcast_value_ptr[Decimal128]()[])
+    )
+
+
+def decimal128_to_repr(py_self: PythonObject) raises -> PythonObject:
+    """`repr(x)`, which reads back as the same value."""
+    return PythonObject(
+        String(
+            "Decimal128('",
+            String(py_self.unchecked_downcast_value_ptr[Decimal128]()[]),
+            "')",
+        )
+    )
+
+
+def decimal128_to_int(py_self: PythonObject) raises -> PythonObject:
+    """`int(x)`, truncated toward zero."""
+    return PythonObject(
+        Int(py_self.unchecked_downcast_value_ptr[Decimal128]()[])
+    )
+
+
+def decimal128_to_float(py_self: PythonObject) raises -> PythonObject:
+    """`float(x)`."""
+    return PythonObject(
+        Float64(py_self.unchecked_downcast_value_ptr[Decimal128]()[])
+    )
+
+
+def decimal128_bool(py_self: PythonObject) raises -> PythonObject:
+    """`bool(x)`, which is False only for zero."""
+    return PythonObject(
+        not py_self.unchecked_downcast_value_ptr[Decimal128]()[].is_zero()
+    )
+
+
+def decimal128_neg(py_self: PythonObject) raises -> PythonObject:
+    """`-x`."""
+    return new_decimal128(
+        state()[], -py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    )
+
+
+def decimal128_pos(py_self: PythonObject) raises -> PythonObject:
+    """`+x`."""
+    return new_decimal128(
+        state()[], py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    )
+
+
+def decimal128_abs(py_self: PythonObject) raises -> PythonObject:
+    """`abs(x)`."""
+    return new_decimal128(
+        state()[], abs(py_self.unchecked_downcast_value_ptr[Decimal128]()[])
+    )
+
+
+def _decimal128_unary[
+    operation: def(Decimal128) thin raises -> Decimal128,
+    name: StaticString,
+](py_self: PythonObject) raises -> PythonObject:
+    """The shared body of the one-argument mathematical methods."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    var result: Decimal128
+    try:
+        result = operation(value)
+    except e:
+        raise Error(String(name, " is not defined for this value"))
+    return new_decimal128(state()[], result)
+
+
+def _d128_sqrt(x: Decimal128) raises -> Decimal128:
+    return x.sqrt()
+
+
+def _d128_exp(x: Decimal128) raises -> Decimal128:
+    return x.exp()
+
+
+def _d128_ln(x: Decimal128) raises -> Decimal128:
+    return x.ln()
+
+
+def _d128_log10(x: Decimal128) raises -> Decimal128:
+    return x.log10()
+
+
+def _d128_sin(x: Decimal128) raises -> Decimal128:
+    return x.sin()
+
+
+def _d128_cos(x: Decimal128) raises -> Decimal128:
+    return x.cos()
+
+
+def _d128_tan(x: Decimal128) raises -> Decimal128:
+    return x.tan()
+
+
+def decimal128_sqrt(py_self: PythonObject) raises -> PythonObject:
+    """The square root, correctly rounded."""
+    return _decimal128_unary[_d128_sqrt, "sqrt"](py_self)
+
+
+def decimal128_exp(py_self: PythonObject) raises -> PythonObject:
+    """`e` raised to this power, correctly rounded."""
+    return _decimal128_unary[_d128_exp, "exp"](py_self)
+
+
+def decimal128_ln(py_self: PythonObject) raises -> PythonObject:
+    """The natural logarithm, correctly rounded."""
+    return _decimal128_unary[_d128_ln, "ln"](py_self)
+
+
+def decimal128_log10(py_self: PythonObject) raises -> PythonObject:
+    """The base-10 logarithm, correctly rounded."""
+    return _decimal128_unary[_d128_log10, "log10"](py_self)
+
+
+def decimal128_sin(py_self: PythonObject) raises -> PythonObject:
+    """The sine of this angle in radians, correctly rounded."""
+    return _decimal128_unary[_d128_sin, "sin"](py_self)
+
+
+def decimal128_cos(py_self: PythonObject) raises -> PythonObject:
+    """The cosine of this angle in radians, correctly rounded."""
+    return _decimal128_unary[_d128_cos, "cos"](py_self)
+
+
+def decimal128_tan(py_self: PythonObject) raises -> PythonObject:
+    """The tangent of this angle in radians, correctly rounded."""
+    return _decimal128_unary[_d128_tan, "tan"](py_self)
+
+
+def _d128_cot(x: Decimal128) raises -> Decimal128:
+    return x.cot()
+
+
+def _d128_sec(x: Decimal128) raises -> Decimal128:
+    return x.sec()
+
+
+def _d128_csc(x: Decimal128) raises -> Decimal128:
+    return x.csc()
+
+
+def _d128_cbrt(x: Decimal128) raises -> Decimal128:
+    return x.cbrt()
+
+
+def _d128_normalize(x: Decimal128) raises -> Decimal128:
+    return x.normalize()
+
+
+def decimal128_cot(py_self: PythonObject) raises -> PythonObject:
+    """The cotangent of this angle in radians, correctly rounded."""
+    return _decimal128_unary[_d128_cot, "cot"](py_self)
+
+
+def decimal128_sec(py_self: PythonObject) raises -> PythonObject:
+    """The secant of this angle in radians, correctly rounded."""
+    return _decimal128_unary[_d128_sec, "sec"](py_self)
+
+
+def decimal128_csc(py_self: PythonObject) raises -> PythonObject:
+    """The cosecant of this angle in radians, correctly rounded."""
+    return _decimal128_unary[_d128_csc, "csc"](py_self)
+
+
+def decimal128_cbrt(py_self: PythonObject) raises -> PythonObject:
+    """The cube root, correctly rounded. Negative values have one."""
+    return _decimal128_unary[_d128_cbrt, "cbrt"](py_self)
+
+
+def decimal128_normalize(py_self: PythonObject) raises -> PythonObject:
+    """The value with its trailing zeros removed."""
+    return _decimal128_unary[_d128_normalize, "normalize"](py_self)
+
+
+def decimal128_root(
+    py_self: PythonObject, degree: PythonObject
+) raises -> PythonObject:
+    """The n-th root, correctly rounded."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    var result: Decimal128
+    try:
+        result = value.root(Int(py=degree))
+    except e:
+        raise Error("the root is not defined for this value")
+    return new_decimal128(state()[], result)
+
+
+def decimal128_log(
+    py_self: PythonObject, base: PythonObject
+) raises -> PythonObject:
+    """The logarithm to an arbitrary base, correctly rounded."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    var result: Decimal128
+    try:
+        result = value.log(_operand128(base))
+    except e:
+        raise Error("the logarithm is not defined for these values")
+    return new_decimal128(state()[], result)
+
+
+def decimal128_fma(
+    py_self: PythonObject, other: PythonObject, addend: PythonObject
+) raises -> PythonObject:
+    """`self * other + addend`, rounded once rather than twice."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(
+        state()[], value.fma(_operand128(other), _operand128(addend))
+    )
+
+
+def decimal128_max(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """The larger of the two."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(state()[], value.max(_operand128(other)))
+
+
+def decimal128_min(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """The smaller of the two."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(state()[], value.min(_operand128(other)))
+
+
+def decimal128_same_quantum(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """Whether the two have the same exponent."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return PythonObject(value.same_quantum(_operand128(other)))
+
+
+def decimal128_adjusted(py_self: PythonObject) raises -> PythonObject:
+    """The exponent of the leading digit."""
+    return PythonObject(
+        py_self.unchecked_downcast_value_ptr[Decimal128]()[].adjusted()
+    )
+
+
+def decimal128_is_zero(py_self: PythonObject) raises -> PythonObject:
+    """Whether the value is zero."""
+    return PythonObject(
+        py_self.unchecked_downcast_value_ptr[Decimal128]()[].is_zero()
+    )
+
+
+def decimal128_is_signed(py_self: PythonObject) raises -> PythonObject:
+    """Whether the sign bit is set, which includes negative zero."""
+    return PythonObject(
+        py_self.unchecked_downcast_value_ptr[Decimal128]()[].is_signed()
+    )
+
+
+def decimal128_is_integer(py_self: PythonObject) raises -> PythonObject:
+    """Whether the value has nothing after the point."""
+    return PythonObject(
+        py_self.unchecked_downcast_value_ptr[Decimal128]()[].is_integer()
+    )
+
+
+def decimal128_to_eng_string(py_self: PythonObject) raises -> PythonObject:
+    """The value in engineering notation, where the exponent is a multiple
+    of three."""
+    return PythonObject(
+        py_self.unchecked_downcast_value_ptr[Decimal128]()[].to_eng_string()
+    )
+
+
+def decimal128_rdivmod(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """`divmod(b, a)`, when the left operand is not one of ours."""
+    ref cell = state()[]
+    var right = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    var left = _operand128(other)
+    return Python.tuple(
+        new_decimal128(cell, left // right), new_decimal128(cell, left % right)
+    )
+
+
+def decimal128_rpower(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """`b ** a`, when the left operand is not one of ours."""
+    ref cell = state()[]
+    var exponent = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(cell, _operand128(other).power(exponent))
+
+
+def decimal128_maximum() raises -> PythonObject:
+    """The largest value the type holds."""
+    return new_decimal128(state()[], Decimal128.MAX())
+
+
+def decimal128_minimum() raises -> PythonObject:
+    """The most negative value the type holds."""
+    return new_decimal128(state()[], Decimal128.MIN())
+
+
+def decimal128_quantize(
+    py_self: PythonObject, exponent: PythonObject
+) raises -> PythonObject:
+    """Round to the scale of another value, as `decimal.quantize` does.
+
+    The rounding mode is the context's, which is what `Decimal` follows too.
+    """
+    ref cell = state()[]
+    ref cpython = Python().cpython()
+    var target: Decimal128
+    if cpython.Py_TYPE(exponent._obj_ptr) == decimal128_type_ptr(cell):
+        target = _value128_of(exponent._obj_ptr)[]
+    else:
+        target = _coerce128(exponent._obj_ptr)
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    var result: Decimal128
+    try:
+        result = value.quantize(target, cell.rounding)
+    except e:
+        raise Error("quantize result has too many digits for Decimal128")
+    return new_decimal128(cell, result)
+
+
+def decimal128_round(
+    py_self: PythonObject, places: PythonObject
+) raises -> PythonObject:
+    """Round to a number of decimal places, under the context's mode.
+
+    `round(x)` and `round(x, n)` reach this through `__round__` in Python,
+    which is where the no-argument form's `int` result is put together.
+    """
+    ref cell = state()[]
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(cell, value.round(Int(py=places), cell.rounding))
+
+
+def decimal128_floordiv(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """`a // b`, truncated toward zero as `decimal` does it."""
+    ref cell = state()[]
+    var left = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(cell, left // _operand128(other))
+
+
+def decimal128_rfloordiv(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """`b // a`, when the left operand is not one of ours."""
+    ref cell = state()[]
+    var right = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(cell, _operand128(other) // right)
+
+
+def decimal128_mod(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """`a % b`, whose sign follows the dividend."""
+    ref cell = state()[]
+    var left = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(cell, left % _operand128(other))
+
+
+def decimal128_rmod(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """`b % a`, when the left operand is not one of ours."""
+    ref cell = state()[]
+    var right = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal128(cell, _operand128(other) % right)
+
+
+def decimal128_divmod(
+    py_self: PythonObject, other: PythonObject
+) raises -> PythonObject:
+    """`divmod(a, b)`."""
+    ref cell = state()[]
+    var left = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    var right = _operand128(other)
+    return Python.tuple(
+        new_decimal128(cell, left // right), new_decimal128(cell, left % right)
+    )
+
+
+def decimal128_power(
+    py_self: PythonObject, exponent: PythonObject
+) raises -> PythonObject:
+    """`a ** b`."""
+    ref cell = state()[]
+    ref cpython = Python().cpython()
+    var base = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    if cpython.PyLong_Check(exponent._obj_ptr):
+        var whole = cpython.PyLong_AsSsize_t(exponent._obj_ptr)
+        if whole != -1 or not cpython.PyErr_Occurred():
+            return new_decimal128(cell, base.power(Int(whole)))
+        cpython.PyErr_Clear()
+    return new_decimal128(cell, base.power(_operand128(exponent)))
+
+
+@always_inline
+def _operand128(object: PythonObject) raises -> Decimal128:
+    """The other operand of a method, as a `Decimal128`."""
+    ref cpython = Python().cpython()
+    if cpython.Py_TYPE(object._obj_ptr) == decimal128_type_ptr(state()[]):
+        return _value128_of(object._obj_ptr)[]
+    return _coerce128(object._obj_ptr)
+
+
+def decimal128_to_ieee754_hex(py_self: PythonObject) raises -> PythonObject:
+    """The IEEE 754 decimal128 pattern as 32 hexadecimal characters.
+
+    The bytes themselves are assembled in Python, where `bytes.fromhex` and
+    a reversal are one line each; what has to happen here is the encoding.
+    """
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    var bits = value.to_ieee754()
+    comptime digits = "0123456789abcdef"
+    var out = String("")
+    for index in range(32):
+        var nibble = Int((bits >> UInt128(4 * (31 - index))) & UInt128(0xF))
+        out += digits[byte=nibble]
+    return PythonObject(out)
+
+
+def decimal128_from_ieee754_hex(
+    py_self: PythonObject, text: PythonObject
+) raises -> PythonObject:
+    """Reads 32 hexadecimal characters back into a value."""
+    var characters = String(text)
+    if characters.byte_length() != 32:
+        raise Error("a decimal128 is sixteen bytes")
+    var bits = UInt128(0)
+    for index in range(32):
+        var character = Int(characters.as_bytes()[index])
+        var nibble: Int
+        if character >= 48 and character <= 57:
+            nibble = character - 48
+        elif character >= 97 and character <= 102:
+            nibble = character - 87
+        elif character >= 65 and character <= 70:
+            nibble = character - 55
+        else:
+            raise Error("not a hexadecimal digit")
+        bits = (bits << UInt128(4)) | UInt128(nibble)
+    return new_decimal128(state()[], Decimal128.from_ieee754(bits))
+
+
+def decimal128_to_decimal(py_self: PythonObject) raises -> PythonObject:
+    """The same number as a `Decimal`, which loses nothing."""
+    var value = py_self.unchecked_downcast_value_ptr[Decimal128]()[]
+    return new_decimal(state()[], BigDecimal(String(value)))
+
+
+# ===----------------------------------------------------------------------=== #
 # PyInit entry point
 #
 # The dunder names are registered next to the plain ones. Registering them is
@@ -303,6 +1053,8 @@ def PyInit__decimo() abi("C") -> PythonObject:
 
         m.def_function[get_precision]("get_precision")
         m.def_function[set_precision]("set_precision")
+        m.def_function[decimal128_maximum]("decimal128_max_value")
+        m.def_function[decimal128_minimum]("decimal128_min_value")
         m.def_function[module_pi]("pi")
         m.def_function[module_e]("e")
         m.def_function[get_rounding]("get_rounding")
@@ -430,6 +1182,87 @@ def PyInit__decimo() abi("C") -> PythonObject:
                 method_to_integral, "to_integral_exact"
             )
         )
+        # --- the fixed-width type -----------------------------------
+        ref decimal128_builder = m.add_type[Decimal128]("Decimal128")
+
+        decimal128_builder._insert_slot(
+            PyType_Slot(c_int(Py_nb_add), _fn_ptr_as_opaque(slot128_add))
+        )
+        decimal128_builder._insert_slot(
+            PyType_Slot(
+                c_int(Py_nb_subtract), _fn_ptr_as_opaque(slot128_subtract)
+            )
+        )
+        decimal128_builder._insert_slot(
+            PyType_Slot(
+                c_int(Py_nb_multiply), _fn_ptr_as_opaque(slot128_multiply)
+            )
+        )
+        decimal128_builder._insert_slot(
+            PyType_Slot(
+                c_int(Py_nb_true_divide),
+                _fn_ptr_as_opaque(slot128_true_divide),
+            )
+        )
+        decimal128_builder._insert_slot(
+            PyType_Slot(c_int(Py_tp_hash), _fn_ptr_as_opaque(slot128_hash))
+        )
+        decimal128_builder._insert_slot(
+            PyType_Slot(
+                c_int(Py_tp_richcompare),
+                _fn_ptr_as_opaque(slot128_richcompare),
+            )
+        )
+
+        _ = (
+            decimal128_builder.def_py_init[decimal128_py_init]()
+            .def_method[decimal128_to_string]("__str__")
+            .def_method[decimal128_to_string]("to_string")
+            .def_method[decimal128_to_repr]("__repr__")
+            .def_method[decimal128_to_repr]("to_repr")
+            .def_method[decimal128_to_int]("__int__")
+            .def_method[decimal128_to_float]("__float__")
+            .def_method[decimal128_bool]("__bool__")
+            .def_method[decimal128_neg]("__neg__")
+            .def_method[decimal128_pos]("__pos__")
+            .def_method[decimal128_abs]("__abs__")
+            .def_method[decimal128_sqrt]("sqrt")
+            .def_method[decimal128_exp]("exp")
+            .def_method[decimal128_ln]("ln")
+            .def_method[decimal128_log10]("log10")
+            .def_method[decimal128_sin]("sin")
+            .def_method[decimal128_cos]("cos")
+            .def_method[decimal128_tan]("tan")
+            .def_method[decimal128_quantize]("quantize")
+            .def_method[decimal128_floordiv]("__floordiv__")
+            .def_method[decimal128_rfloordiv]("__rfloordiv__")
+            .def_method[decimal128_mod]("__mod__")
+            .def_method[decimal128_rmod]("__rmod__")
+            .def_method[decimal128_divmod]("__divmod__")
+            .def_method[decimal128_power]("__pow__")
+            .def_method[decimal128_round]("_round")
+            .def_method[decimal128_to_ieee754_hex]("_to_ieee754_hex")
+            .def_method[decimal128_from_ieee754_hex]("_from_ieee754_hex")
+            .def_method[decimal128_to_decimal]("to_decimal")
+            .def_method[decimal128_cot]("cot")
+            .def_method[decimal128_sec]("sec")
+            .def_method[decimal128_csc]("csc")
+            .def_method[decimal128_cbrt]("cbrt")
+            .def_method[decimal128_normalize]("normalize")
+            .def_method[decimal128_root]("root")
+            .def_method[decimal128_log]("log")
+            .def_method[decimal128_fma]("fma")
+            .def_method[decimal128_max]("max")
+            .def_method[decimal128_min]("min")
+            .def_method[decimal128_same_quantum]("same_quantum")
+            .def_method[decimal128_adjusted]("adjusted")
+            .def_method[decimal128_is_zero]("is_zero")
+            .def_method[decimal128_is_signed]("is_signed")
+            .def_method[decimal128_is_integer]("is_integer")
+            .def_method[decimal128_rdivmod]("__rdivmod__")
+            .def_method[decimal128_rpower]("__rpow__")
+        )
+
         return m.finalize()
     except e:
         abort(String("error creating _decimo Python module: ", e))
@@ -518,6 +1351,13 @@ def convert_operand(other: PythonObject) raises -> BigDecimal:
         if not cpython.PyErr_Occurred():
             return BigDecimal.from_integral_scalar(Int64(-1))
         cpython.PyErr_Clear()
+    ref cell = state()[]
+    if cpython.Py_TYPE(other._obj_ptr) == decimal128_type_ptr(cell):
+        # The fixed-width type on the other side of the operator. Widening
+        # loses nothing -- 29 digits and a scale of 28 both fit -- so a mixed
+        # expression settles in `Decimal`, which is where the reflected
+        # operator sends it.
+        return BigDecimal(String(_value128_of(other._obj_ptr)[]))
     return convert_big_int(other)
 
 
@@ -1891,6 +2731,27 @@ def _power_modulus(var base: UInt64, var exponent: UInt64) -> UInt64:
         base = UInt64(UInt128(base) * UInt128(base) % modulus)
         exponent >>= 1
     return result
+
+
+def slot128_hash(py_self: PyObjectPtr) abi("C") -> Py_ssize_t:
+    """`tp_hash`, agreeing with `int`, `float`, `decimal.Decimal` and
+    `Decimal`.
+
+    The coefficient is one `UInt128`, so its residue is one remainder rather
+    than the loop over words the arbitrary-precision type needs.
+    """
+    ref value = _value128_of(py_self)[]
+    var modulus = UInt128(_HASH_MODULUS)
+    var residue = UInt64(value.coefficient() % modulus)
+
+    # The value is `coefficient * 10^-scale`, so the scale is a division:
+    # multiply by the inverse of ten instead.
+    var factor = _power_modulus(_TEN_INVERSE, UInt64(value.scale()))
+    var result = Int(UInt128(residue) * UInt128(factor) % modulus)
+    if value.is_negative():
+        result = -result
+    # -1 is reserved by CPython to mean "an error happened".
+    return Py_ssize_t(-2 if result == -1 else result)
 
 
 def slot_hash(py_self: PyObjectPtr) abi("C") -> Py_ssize_t:

--- a/python/src/decimo/__init__.py
+++ b/python/src/decimo/__init__.py
@@ -18,7 +18,10 @@ ROUND_05UP.
 from ._version import __version__ as __version__
 
 try:
-    from ._decimo import Decimal, get_precision as _get_precision
+    from ._decimo import Decimal, Decimal128 as _Decimal128
+    from ._decimo import decimal128_max_value as _decimal128_max_value
+    from ._decimo import decimal128_min_value as _decimal128_min_value
+    from ._decimo import get_precision as _get_precision
     from ._decimo import set_precision as _set_precision
     from ._decimo import pi as _pi
     from ._decimo import e as _e
@@ -84,6 +87,236 @@ del _name
 # install their own from Mojo's `Representable`, which prints the Mojo type
 # name, so point it at our own text instead.
 Decimal.__repr__ = Decimal.to_repr
+
+
+# --- The fixed-width type --------------------------------------------------
+#
+# `Decimal128` is 96 bits of coefficient and a scale from 0 to 28, in sixteen
+# bytes that own nothing -- the layout .NET's `System.Decimal` and Rust's
+# `rust_decimal` use. `Decimal` is the arbitrary-precision one and is what a
+# program reaching for `decimal.Decimal` wants; this is the one to reach for
+# when the values are money and the shape of them is known.
+#
+# Its dunders need the same assignment as `Decimal`'s, and for the same
+# reason. `+`, `-`, `*`, `/` and the comparisons are real slots in the Mojo
+# module and are left alone.
+Decimal128 = _Decimal128
+
+for _name in (
+    "__str__",
+    "__neg__",
+    "__pos__",
+    "__abs__",
+    "__bool__",
+    "__int__",
+    "__float__",
+    "__floordiv__",
+    "__rfloordiv__",
+    "__mod__",
+    "__rmod__",
+    "__divmod__",
+    "__pow__",
+):
+    setattr(Decimal128, _name, Decimal128.__dict__[_name])
+del _name
+
+Decimal128.__repr__ = Decimal128.to_repr
+
+
+def _decimal128_round(self, ndigits=None):
+    """`round(x)` and `round(x, n)`.
+
+    With no argument Python expects an `int` back, and with one it expects
+    the same type as the input, which is what `decimal` does too.
+    """
+    if ndigits is None:
+        return int(self._round(0))
+    return self._round(ndigits)
+
+
+def _decimal128_as_tuple(self):
+    """Return `(sign, digits, exponent)`, as `decimal.Decimal.as_tuple` does."""
+    text = str(self)
+    negative = text.startswith("-")
+    if negative:
+        text = text[1:]
+    point = text.find(".")
+    if point < 0:
+        digits, exponent = text, 0
+    else:
+        digits, exponent = text[:point] + text[point + 1 :], -(len(text) - point - 1)
+    return DecimalTuple(int(negative), tuple(int(d) for d in digits), exponent)
+
+
+def _decimal128_to_ieee754(self):
+    """The sixteen bytes of the IEEE 754 decimal128 interchange format.
+
+    Little-endian, which is the order BSON and Intel's library store them in.
+    """
+    return bytes.fromhex(self._to_ieee754_hex())[::-1]
+
+
+def _decimal128_from_ieee754(data):
+    """Read sixteen little-endian bytes of IEEE 754 decimal128."""
+    if len(data) != 16:
+        raise ValueError("a decimal128 is sixteen bytes")
+    return Decimal128()._from_ieee754_hex(bytes(data)[::-1].hex())
+
+
+def _decimal128_reduce(self):
+    return (Decimal128, (str(self),))
+
+
+def _decimal128_copy(self, memo=None):
+    """A `Decimal128` is a value; there is nothing to share, so a copy is
+    itself."""
+    return self
+
+
+def _decimal128_format(self, specification=""):
+    """Format the value, following `decimal.Decimal.__format__`.
+
+    The empty specification -- what an f-string with no `:` uses -- is
+    `str()`. Everything else goes to the standard library's mini-language
+    through `decimal.Decimal`, which is exact: the text this type produces
+    parses back into the same digits.
+    """
+    if specification == "":
+        return str(self)
+    import decimal as _stdlib
+
+    return format(_stdlib.Decimal(str(self)), specification)
+
+
+def _decimal128_compare(self, other):
+    """-1, 0 or 1, as `decimal.Decimal.compare` gives it."""
+    other = other if isinstance(other, Decimal128) else Decimal128(other)
+    if self < other:
+        return Decimal128(-1)
+    if self > other:
+        return Decimal128(1)
+    return Decimal128(0)
+
+
+def _decimal128_copy_sign(self, other):
+    """Self with the sign of other, as `decimal.Decimal.copy_sign` does."""
+    other = other if isinstance(other, Decimal128) else Decimal128(other)
+    magnitude = abs(self)
+    return -magnitude if other.is_signed() else magnitude
+
+
+def _decimal128_copy_abs(self):
+    """The magnitude, without rounding."""
+    return abs(self)
+
+
+def _decimal128_copy_negate(self):
+    """The negation, without rounding."""
+    return -self
+
+
+def _decimal128_to_integral_value(self, rounding=None):
+    """The value rounded to a whole number, keeping the type."""
+    if rounding is None:
+        return self._round(0)
+    with localcontext() as context:
+        context.rounding = rounding
+        return self._round(0)
+
+
+def _decimal128_as_integer_ratio(self):
+    """The value as an exact `(numerator, denominator)` pair."""
+    negative, digits, exponent = self.as_tuple()
+    numerator = int("".join(str(d) for d in digits) or "0")
+    if negative:
+        numerator = -numerator
+    if exponent >= 0:
+        return (numerator * 10**exponent, 1)
+    denominator = 10**-exponent
+    from math import gcd as _gcd
+
+    common = _gcd(numerator, denominator)
+    return (numerator // common, denominator // common)
+
+
+def _decimal128_from_float(cls, value):
+    """Build one from a float, as `decimal.Decimal.from_float` does."""
+    return cls(float(value))
+
+
+def _decimal128_is_finite(self):
+    """True. This type has no infinities and no NaNs."""
+    return True
+
+
+def _decimal128_is_nan(self):
+    """False. This type has no NaNs."""
+    return False
+
+
+def _decimal128_is_infinite(self):
+    """False. This type has no infinities."""
+    return False
+
+
+def _decimal128_to_eng_string(self):
+    """The value in engineering notation, as `decimal.to_eng_string` gives it.
+
+    Which is not always exponential: the rule is the specification's, and it
+    reads the exponent the value already carries, so `Decimal128("123456")`
+    is `123456` and `Decimal128("1.23E+5")` -- the same number with a
+    different exponent -- is `123E+3`. The Mojo method is unconditional, so
+    the rule is applied here.
+    """
+    import decimal as _stdlib
+
+    return _stdlib.Decimal(self.as_tuple()).to_eng_string()
+
+
+def _decimal128_to_scientific_string(self):
+    """The value in scientific notation, as `decimal`'s `str` gives it."""
+    import decimal as _stdlib
+
+    return str(_stdlib.Decimal(self.as_tuple()))
+
+
+Decimal128.to_eng_string = _decimal128_to_eng_string
+Decimal128.to_scientific_string = _decimal128_to_scientific_string
+Decimal128.compare = _decimal128_compare
+Decimal128.copy_sign = _decimal128_copy_sign
+Decimal128.copy_abs = _decimal128_copy_abs
+Decimal128.copy_negate = _decimal128_copy_negate
+Decimal128.to_integral_value = _decimal128_to_integral_value
+Decimal128.to_integral = _decimal128_to_integral_value
+Decimal128.as_integer_ratio = _decimal128_as_integer_ratio
+Decimal128.from_float = classmethod(_decimal128_from_float)
+Decimal128.is_finite = _decimal128_is_finite
+Decimal128.is_nan = _decimal128_is_nan
+Decimal128.is_infinite = _decimal128_is_infinite
+Decimal128.__round__ = _decimal128_round
+Decimal128.__reduce__ = _decimal128_reduce
+Decimal128.__copy__ = _decimal128_copy
+Decimal128.__deepcopy__ = _decimal128_copy
+Decimal128.__format__ = _decimal128_format
+Decimal128.as_tuple = _decimal128_as_tuple
+Decimal128.to_ieee754 = _decimal128_to_ieee754
+Decimal128.from_ieee754 = staticmethod(_decimal128_from_ieee754)
+
+try:
+    # The type says it lives in the extension module otherwise, which is an
+    # implementation detail, and pickle needs a name it can find again.
+    Decimal128.__module__ = "decimo"
+except (AttributeError, TypeError):  # pragma: no cover -- older bindings
+    pass
+
+#: The largest and smallest values the type holds, which are fixed rather
+#: than a matter of context.
+Decimal128.MAX = _decimal128_max_value()
+Decimal128.MIN = _decimal128_min_value()
+
+#: A shorter name for the same type, as the Mojo library has. `Decimal128`
+#: is the name it answers to: `repr` and `__name__` both say that one.
+Dec128 = Decimal128
 
 
 # Hashing is a `tp_hash` slot in the Mojo module: a number's hash has to agree

--- a/python/tests/test_decimo.py
+++ b/python/tests/test_decimo.py
@@ -933,6 +933,200 @@ sample = ["1.05", "2.10", "3.15", "0.001", "-4.2"]
 assert str(average(decimo, sample)) == str(average(decimal, sample))
 print("[PASS] the same function run against decimal and decimo agrees")
 
+# --- Decimal128, the fixed-width type --------------------------------------
+
+D128 = decimo.Decimal128
+
+assert decimo.Dec128 is D128
+
+# Construction from every source `Decimal` accepts.
+assert str(D128("3.14")) == "3.14"
+assert str(D128(42)) == "42"
+assert str(D128()) == "0"
+assert str(D128(D128("1.50"))) == "1.50"
+assert str(D128(decimo.Decimal("2.25"))) == "2.25"
+# A float comes back as itself. `Decimal128(float)` does not spell out the
+# whole binary expansion the way `decimal.Decimal(float)` does -- the type
+# holds 28 digits and 0.1 needs 55 -- so what is promised is the round trip.
+for _value in (0.1, 3.14, 2.675, 0.5, 1e20):
+    assert float(D128(_value)) == _value
+print("[PASS] Decimal128 is built from strings, integers, floats and decimals")
+
+# The exact operations agree with decimal digit for digit.
+for _a, _b in (("7.5", "2.5"), ("19.99", "3"), ("-1.25", "0.4"), ("0.1", "0.2")):
+    for _name, _op in (
+        ("+", operator.add),
+        ("-", operator.sub),
+        ("*", operator.mul),
+        ("//", operator.floordiv),
+        ("%", operator.mod),
+    ):
+        _got = str(_op(D128(_a), D128(_b)))
+        _want = str(_op(decimal.Decimal(_a), decimal.Decimal(_b)))
+        assert _got == _want, f"{_a} {_name} {_b}: {_got} != {_want}"
+
+# Division fills the type rather than a context: 29 significant digits and a
+# scale of at most 28, where `decimal` gives whatever `prec` says. Checked
+# against decimal at 60 digits, rounded to the exponent we came back with.
+for _a, _b in (("19.99", "3"), ("1", "7"), ("-1.25", "0.4"), ("2", "3")):
+    _got = D128(_a) / D128(_b)
+    with decimal.localcontext() as _ctx:
+        _ctx.prec = 60
+        _exact = decimal.Decimal(_a) / decimal.Decimal(_b)
+    with decimal.localcontext() as _ctx:
+        _ctx.prec = 60
+        _want = _exact.quantize(
+            decimal.Decimal((0, (1,), decimal.Decimal(str(_got)).as_tuple().exponent)),
+            rounding=decimal.ROUND_HALF_EVEN,
+        )
+    assert str(_got) == str(_want), f"{_a} / {_b}: {_got} != {_want}"
+assert str(D128("7.5") ** 2) == "56.25"
+assert divmod(D128("7.5"), D128("2.5")) == (D128("3"), D128("0.0"))
+print("[PASS] Decimal128 arithmetic agrees with decimal")
+
+# The other operand may be an int, a float or a string, on either side.
+assert str(D128("1.5") + 1) == "2.5"
+assert str(2 * D128("1.5")) == "3.0"
+assert str(7 // D128("2.5")) == "2"
+assert D128("1.5") == D128("1.50")
+assert D128("1.5") > 1
+assert sorted([D128("3"), D128("1"), D128("2")]) == [D128("1"), D128("2"), D128("3")]
+print("[PASS] Decimal128 mixes with numbers and sorts")
+
+# The hash agrees with everything that compares equal to it.
+for _text in ("1.5", "0", "-2", "12345.6789", "0.1", "79228162514264337593543950335"):
+    assert (
+        hash(D128(_text)) == hash(decimal.Decimal(_text)) == hash(decimo.Decimal(_text))
+    )
+assert hash(D128("1.5")) == hash(1.5)
+assert hash(D128("2")) == hash(2)
+assert {D128("1.5"): "x"}[D128("1.50")] == "x"
+print("[PASS] Decimal128 hashes with int, float, decimal and Decimal")
+
+# Money: the reason the type exists.
+_price = D128("19.99")
+_line = (_price * 3).quantize(D128("0.01"))
+assert str(_line) == "59.97"
+assert str(round(D128("2.675"), 2)) == str(round(decimal.Decimal("2.675"), 2))
+assert round(D128("19.99")) == 20 and isinstance(round(D128("19.99")), int)
+assert D128("19.99").as_tuple() == decimal.Decimal("19.99").as_tuple()
+print("[PASS] Decimal128 quantizes, rounds and reports its digits")
+
+# The mathematical functions, correctly rounded.
+assert str(D128(2).sqrt()) == "1.4142135623730950488016887242"
+assert str(D128(1).exp()) == "2.7182818284590452353602874714"
+assert str(D128(1000).log10()) == "3"
+assert str(D128(1).ln()) == "0"
+# The reduction holds wherever the argument sits, which is the point of it.
+assert str(D128("1e20").sin()) == "-0.6452512852657808442058117113"
+print("[PASS] Decimal128 has square roots, logarithms and trigonometry")
+
+# The IEEE 754 interchange format, little-endian as BSON stores it.
+assert D128("1").to_ieee754().hex() == "01000000000000000000000000004030"
+assert D128("0").to_ieee754().hex() == "00000000000000000000000000004030"
+for _text in ("1", "-1", "0.001", "1.0", "19.99", "79228162514264337593543950335"):
+    assert str(D128.from_ieee754(D128(_text).to_ieee754())) == _text
+print("[PASS] Decimal128 reads and writes IEEE 754 decimal128")
+
+# The wider method surface, against decimal where decimal has it.
+_x = D128("1.20")
+assert str(_x.normalize()) == "1.2"
+assert _x.adjusted() == decimal.Decimal("1.20").adjusted()
+assert _x.is_zero() is False and D128("0").is_zero() is True
+assert _x.is_signed() is False and D128("-1").is_signed() is True
+assert _x.same_quantum(D128("9.99")) is True
+assert _x.same_quantum(D128("9.9")) is False
+assert str(_x.compare(2)) == str(decimal.Decimal("1.20").compare(2))
+assert str(_x.copy_sign(D128("-1"))) == str(
+    decimal.Decimal("1.20").copy_sign(decimal.Decimal("-1"))
+)
+assert str(_x.to_integral_value()) == str(decimal.Decimal("1.20").to_integral_value())
+assert _x.as_integer_ratio() == decimal.Decimal("1.20").as_integer_ratio()
+for _text in ("123456", "0.000123", "1234", "19.99", "1.5"):
+    assert D128(_text).to_eng_string() == decimal.Decimal(_text).to_eng_string()
+# Where the two differ is where the type has no such value to print: a scale
+# is never negative here, so `1.23E+5` is 123000 and there is no cohort
+# member with an exponent of 3 to write as `123E+3`.
+assert D128("1.23E+5").to_eng_string() == "123000"
+assert str(D128("2").fma(3, 4)) == str(decimal.Decimal(2).fma(3, 4))
+assert str(D128("2").max(3)) == "3" and str(D128("2").min(3)) == "2"
+assert D128("1.5").is_finite() and not D128("1.5").is_nan()
+assert str(D128.from_float(0.5)) == "0.5"
+print("[PASS] Decimal128 carries the method surface decimal programs use")
+
+# The mathematics beyond the square root.
+assert str(D128("8").cbrt()) == "2"
+assert str(D128("16").root(4)) == "2"
+assert str(D128("8").log(D128("2"))) == "3"
+assert str(D128("1.2").cot()) == "0.3887795693682049116341915050"
+assert str(D128("1.2").sec()) == "2.7597036013324064568834329392"
+assert str(D128("1.2").csc()) == "1.0729163777098972287051169224"
+print("[PASS] Decimal128 has roots, arbitrary bases and the reciprocal angles")
+
+# The two ends of the range, which are fixed rather than a matter of context.
+assert str(D128.MAX) == "79228162514264337593543950335"
+assert str(D128.MIN) == "-79228162514264337593543950335"
+
+# Reflected operators, so the type may sit on either side.
+assert str(2 ** D128("3")) == "8"
+assert divmod(7, D128("2")) == (D128("3"), D128("1"))
+assert str(7 - D128("2.5")) == "4.5"
+print("[PASS] Decimal128 works from either side of an operator")
+
+# A mixed expression settles in the wider type, which loses nothing.
+for _left, _right in (
+    (D128("1.5"), decimo.Decimal("2")),
+    (decimo.Decimal("2"), D128("1.5")),
+):
+    _sum = _left + _right
+    assert isinstance(_sum, decimo.Decimal), type(_sum)
+    assert str(_sum) == "3.5"
+assert str(decimo.Decimal("7") / D128("2")) == "3.5"
+assert D128("1.5") == decimo.Decimal("1.5")
+assert D128("1.5") < decimo.Decimal("2")
+# And what cannot be converted is a TypeError, not something stranger.
+try:
+    D128("1.5") + "not a number"
+    raise AssertionError("adding a non-number should raise")
+except AssertionError:
+    raise
+except TypeError:
+    pass
+print("[PASS] Decimal128 mixes with Decimal and refuses the rest")
+
+# It behaves like a value: copied, pickled and formatted.
+_x = D128("1234.5678")
+assert copy.copy(_x) == _x and copy.deepcopy(_x) == _x
+assert pickle.loads(pickle.dumps(_x)) == _x
+assert f"{_x}" == "1234.5678"
+assert format(_x, ",.2f") == format(decimal.Decimal("1234.5678"), ",.2f")
+assert format(_x, ".3e") == format(decimal.Decimal("1234.5678"), ".3e")
+assert type(_x).__name__ == "Decimal128" and type(_x).__module__ == "decimo"
+assert repr(_x) == "Decimal128('1234.5678')"
+print("[PASS] Decimal128 copies, pickles, formats and names itself")
+
+# Crossing between the two types.
+assert str(D128("1.5").to_decimal()) == "1.5"
+assert isinstance(D128("1.5").to_decimal(), decimo.Decimal)
+assert str(decimo.Decimal(D128("1.5"))) == "1.5"
+print("[PASS] Decimal128 converts to and from Decimal")
+
+# What it refuses: the type stops at 7.9E+28 and 28 decimal places.
+try:
+    D128("79228162514264337593543950336")
+    raise AssertionError("a value past the maximum should not be accepted")
+except AssertionError:
+    raise
+except Exception:
+    pass
+try:
+    D128("1") / D128("0")
+    raise AssertionError("division by zero should raise")
+except ZeroDivisionError:
+    pass
+print("[PASS] Decimal128 refuses what it cannot hold")
+
+
 print()
 
 print("=== All Phase 0 tests passed! ===")

--- a/src/decimo/decimal128/arithmetics.mojo
+++ b/src/decimo/decimal128/arithmetics.mojo
@@ -41,6 +41,7 @@ from decimo.errors import (
     ZeroDivisionError,
 )
 import decimo.decimal128.utility as decimal128_utility
+from decimo.decimal128.wide import Wide
 
 
 @always_inline
@@ -960,391 +961,44 @@ def divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:
                     var high = UInt32((quot >> 64) & 0xFFFFFFFF)
                     return Decimal128(low, mid, high, 0, is_negative)
 
-    # REMAINING CASES: Perform long division
-    # 其他情況: 進行長除法
+    # REMAINING CASES: one wide division, rounded once
     #
-    # Example: 123456.789 / 12.8 = 964506.1640625
-    # x1_coef = 123456789, x2_coef = 128
-    # x1_scale = 3, x2_scale = 1, diff_scale = 2
-    # Step 0: 123456789 // 128 -> quot = 964506, rem = 21
-    # Step 1: (21 * 10) // 128 -> quot = 1, rem = 82
-    # Step 2: (82 * 10) // 128 -> quot = 6, rem = 52
-    # Step 3: (52 * 10) // 128 -> quot = 4, rem = 8
-    # Step 4: (8 * 10) // 128 -> quot = 0, rem = 80
-    # Step 5: (80 * 10) // 128 -> quot = 6, rem = 32
-    # Step 6: (32 * 10) // 128 -> quot = 2, rem = 64
-    # Step 7: (64 * 10) // 128 -> quot = 5, rem = 0
-    # Result: 9645061640625 with scale 9 (= step_counter + diff_scale)
+    # The quotient does not terminate, so it is taken to one digit more than
+    # the answer keeps and rounded from there. The numerator is raised until
+    # the integer quotient is about thirty digits long, which fits `UInt256`
+    # for any pair this type holds, and the remainder says whether anything
+    # was left over -- which is what decides a tie.
     #
-    # Example: 12345678.9 / 1.28 = 9645061.640625
-    # x1_coef = 123456789, x2_coef = 128
-    # x1_scale = 1, x2_scale = 2, diff_scale = -1
-    # Result: 9645061640625 with scale 6 (= step_counter + diff_scale)
-    #
-    # Long division algorithm
-    # Stop when remainder is zero or precision is reached or the optimal number of steps is reached
-    #
-    # Yuhao's notes: How to determine the optimal number of steps?
-    # First, we need to consider that the max scale (precision) is 28
-    # Second, we need to consider the significant digits of the quotient
-    # EXAMPLE: 1 / 1.1111111111111111111111111111 ~= 0.900000000000000000000000000090
-    # If we only consider the precision, we just need 28 steps
-    # Then quotient of coefficients would be zeros
-    # Approach 1: The optimal number of steps should be approximately
-    #             max_len - diff_digits - digits_of_first_quotient + 1
-    # Approach 2: Times 10**(-diff_digits) to the dividend and then perform the long division
-    #             The number of steps is set to be max_len - digits_of_first_quotient + 1
-    #             so that we just need to scale up one than loop -diff_digits times
-    #
-    # Get intitial quotient and remainder
-    # Yuhao's notes: remainder should be positive beacuse the previous cases have been handled
-    # 朱宇浩注: 餘數應該爲正,因爲之前的特例已經處理過了
+    # This replaced a digit-at-a-time walk with two probe steps and a bulk
+    # step. That was 226 ns and wrong in the last place on 1 of 300 random
+    # pairs, because the digit budget could run out before the rounding
+    # position was reached.
+    comptime TARGET_DIGITS = 30
 
-    var x1_ndigits = decimal128_utility.number_of_digits(x1_coef)
-    var x2_ndigits = decimal128_utility.number_of_digits(x2_coef)
-    var diff_digits = x1_ndigits - x2_ndigits
-    # Here is an estimation of the maximum possible number of digits of the quotient's integral part
-    # If it is higher than 28, we need to use UInt256 to store the quotient
-    var est_max_ndigits_quot_int_part = diff_digits - diff_scale + 1
-    var is_use_uint128 = (
-        est_max_ndigits_quot_int_part < Decimal128.MAX_NUM_DIGITS
-    )
+    var digits_of_x1 = decimal128_utility.number_of_digits(x1_coef)
+    var digits_of_x2 = decimal128_utility.number_of_digits(x2_coef)
+    var shift = TARGET_DIGITS - (digits_of_x1 - digits_of_x2)
+    if shift < 0:
+        shift = 0
+    if digits_of_x1 + shift > 58:
+        shift = 58 - digits_of_x1
 
-    # SUB-CASE: Use UInt128 to store the quotient
-    # If the quotient's integral part is less than 28 digits, we can use UInt128
-    # if is_use_uint128:
-    var quot: UInt128
-    var rem: UInt128
-    var adjusted_scale = 0
+    var numerator = UInt256(x1_coef) * decimal128_utility.power_of_10[
+        DType.uint256
+    ](shift)
 
-    # The adjusted dividend coefficient will not exceed 2^96 - 1
-    if diff_digits < 0:
-        var adjusted_x1_coef = x1_coef * decimal128_utility.power_of_10_unsafe[
-            DType.uint128
-        ](Int(-diff_digits))
-        quot = adjusted_x1_coef // x2_coef
-        rem = adjusted_x1_coef % x2_coef
-        adjusted_scale = -diff_digits
-    else:
-        quot = x1_coef // x2_coef
-        rem = x1_coef % x2_coef
+    var pair = decimal128_utility.udiv_u256_by_u128(numerator, x2_coef)
+    var quotient = pair[0]
+    var remainder = pair[1]
 
-    if is_use_uint128:
-        # Long division producing exactly the final coefficient
-        # (no extra +1 "rounding digit" padding). Total digits is
-        # bounded by `MAX_NUM_DIGITS = 29`, scale by `MAX_SCALE = 28`.
-        # Rounding (banker's, round-half-to-even) is decided directly
-        # from the final residual remainder via a three-branch test on
-        # `2 * rem` against `x2_coef`:
-        #   2*rem  > x2_coef  → next-digit > 5 (or 5+nonzero-tail) → up
-        #   2*rem == x2_coef  → exact half       → bump only if `quot`
-        #                                          last-kept digit odd
-        #   2*rem  < x2_coef  → next-digit < 5                     → drop
-        # See the detailed derivation just before the rounding block.
-
-        # The final step counter stands for the number of decimal points.
-        var step_counter = 0
-        var ndigits_initial_quot = decimal128_utility.number_of_digits(quot)
-        # Two-phase long division.
-        #
-        # Phase 1: a short probe loop (up to PROBE_STEPS digits) catches
-        # fast-terminating cases like `10.5 / 2.5 = 4.2` or `123.45 / -2
-        # = -61.725` in 1-3 cheap UInt128 div-mod iterations.
-        #
-        # Phase 2: if the remainder is still non-zero after the probe, we
-        # know the result either does not terminate or terminates only
-        # after many more digits. Scale the remaining work up by a single
-        # `10^k` factor and finish with one big `UInt256 / UInt128`
-        # divide (~12 ns for u64 divisors via schoolbook, ~236 ns for
-        # full UInt256/UInt256 software fallback). This collapses ~25
-        # iterations of the per-digit loop into one division.
-        comptime PROBE_STEPS = 2
-        # No `+1` padding here: we compute the exact final digit count
-        # and recover the rounding signal from the remainder.
-        var max_steps = min(
-            Decimal128.MAX_NUM_DIGITS - ndigits_initial_quot,
-            Decimal128.MAX_SCALE - diff_scale - adjusted_scale,
-        )
-        while (
-            (rem != 0)
-            and (step_counter < PROBE_STEPS)
-            and (step_counter < max_steps)
-        ):
-            rem *= 10
-            quot = quot * 10 + (rem // x2_coef)
-            rem = rem % x2_coef
-            step_counter += 1
-
-        if (rem != 0) and (step_counter < max_steps):
-            var bulk_steps = max_steps - step_counter
-            # bulk_steps bound: max_steps <= MAX_NUM_DIGITS = 29. Entry
-            # to this arm requires the probe loop to have exited via
-            # `step_counter >= PROBE_STEPS = 2`, so in practice
-            # `bulk_steps <= 29 - 2 = 27`, well within
-            # `power_of_10_unsafe`'s `0 <= n <= 29` range for `uint128`.
-            var scale_factor = decimal128_utility.power_of_10_unsafe[
-                DType.uint128
-            ](bulk_steps)
-            # `rem * 10^bulk_steps` always fits in UInt256: rem < x2_coef
-            # <= 2^96 and bulk_steps <= 27 so 10^bulk_steps < 2^90, giving
-            # rem * 10^bulk_steps < 2^186.
-            var rem_scaled: UInt256 = UInt256(rem) * UInt256(scale_factor)
-
-            var quot_added_u128: UInt128
-            var rem_after_u128: UInt128
-            if x2_coef <= UInt128(0xFFFF_FFFF_FFFF_FFFF):
-                # Fast path: 4-step schoolbook over u64 limbs.
-                var pair = decimal128_utility.udiv_u256_by_u64(
-                    rem_scaled, UInt64(x2_coef)
-                )
-                # `quot_added < 10^bulk_steps <= 10^27 < 2^90`, fits UInt128.
-                quot_added_u128 = UInt128(
-                    pair[0] & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
-                )
-                rem_after_u128 = UInt128(pair[1])
-            else:
-                # Rare 96-bit-divisor fallback: software UInt256 divide.
-                var x2_256 = UInt256(x2_coef)
-                var quot_added_256 = rem_scaled // x2_256
-                var rem_after_256 = rem_scaled - quot_added_256 * x2_256
-                quot_added_u128 = UInt128(
-                    quot_added_256
-                    & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
-                )
-                rem_after_u128 = UInt128(
-                    rem_after_256
-                    & UInt256(0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF)
-                )
-
-            # UInt128 fold (was UInt256 in the previous design).
-            # `quot * 10^bulk_steps` fits UInt128: post-bulk total
-            # digits = ndigits_initial_quot + step_counter + bulk_steps
-            # = ndigits_initial_quot + max_steps <= MAX_NUM_DIGITS = 29,
-            # so the product is < 10^29 < 2^97. Adding `quot_added_u128`
-            # (< 10^27) keeps it < 2 * 10^29 < 2^98, well below 2^128.
-            quot = quot * scale_factor + quot_added_u128
-            step_counter = max_steps
-
-            if rem_after_u128 == 0:
-                # Exact division. The per-digit loop would have stopped
-                # at the first zero remainder, so its `quot` carries no
-                # trailing zeros from beyond that point. Bisect-strip
-                # the equivalent zeros so the final scale matches.
-                rem = 0
-                var pow16 = UInt128(10000000000000000)
-                while (step_counter >= 16) and (quot % pow16 == 0):
-                    quot = quot // pow16
-                    step_counter -= 16
-                var pow8 = UInt128(100000000)
-                while (step_counter >= 8) and (quot % pow8 == 0):
-                    quot = quot // pow8
-                    step_counter -= 8
-                var pow4 = UInt128(10000)
-                while (step_counter >= 4) and (quot % pow4 == 0):
-                    quot = quot // pow4
-                    step_counter -= 4
-                var pow2 = UInt128(100)
-                while (step_counter >= 2) and (quot % pow2 == 0):
-                    quot = quot // pow2
-                    step_counter -= 2
-                while (step_counter >= 1) and (quot % 10 == 0):
-                    quot = quot // 10
-                    step_counter -= 1
-            else:
-                # Inexact: forward the bulk-divide remainder for the
-                # unified rounding step below.
-                rem = rem_after_u128
-
-        # Banker's rounding (round-half-to-even) derived directly from
-        # the residual remainder, matching the .NET / rust_decimal
-        # convention for fixed-precision decimal divide.
-        #
-        # Compare `2*rem` against the divisor `x2_coef`:
-        #   2*rem  > x2_coef  → next-digit > 5             → round up
-        #   2*rem == x2_coef  → next-digit == 5, exact tail → banker's
-        #   2*rem  < x2_coef  → next-digit < 5             → drop
-        #
-        # Why the equality test really is "exact half (no further tail)":
-        # `2*rem == x2_coef` ⇒ `rem*10 == 5*x2_coef`, so
-        # `next_digit = (rem*10) // x2_coef == 5` and
-        # `next_rem    = (rem*10) %  x2_coef == 0` — i.e. the exact
-        # value is `quot.5` with all-zeros after, the textbook midpoint.
-        # Banker's rounds to the nearest even (round up only if the kept
-        # last digit `quot & 1` is odd).
-        #
-        # The strict `2*rem > x2_coef` arm covers the "5 with non-zero
-        # tail" case (e.g. 1/7 truncated at 28 frac digits → next is 5
-        # but the true value is strictly > .5 of the unit), which is
-        # *not* a banker's tie — rounding up is mathematically required.
-        #
-        # 朱宇浩注: 採用銀行家捨去法 (四捨六入五成雙)。
-        # 當餘數的兩倍嚴格大於除數時,下一位數字大於 5 (或等於 5 但其後仍有非零尾,
-        # 如 1/7 在第 28 位之後),四捨五入向上;當餘數的兩倍等於除數時,下一位
-        # 數字恰爲 5 且其後全爲零 (即恰好爲半),依銀行家法捨入到偶數;當餘數的
-        # 兩倍小於除數時,直接捨去。此實作與 .NET System.Decimal、rust_decimal
-        # 的除法默認捨入規則一致。
-        if rem != 0:
-            var double_rem = rem << 1
-            if double_rem > x2_coef:
-                quot += 1
-            elif (double_rem == x2_coef) and ((quot & 1) == 1):
-                # Exact half + last-kept-digit odd → bump to even.
-                quot += 1
-
-        var scale_of_quot = step_counter + diff_scale + adjusted_scale
-
-        # If the scale is negative, we need to scale up the quotient
-        if scale_of_quot < 0:
-            quot = quot * decimal128_utility.power_of_10_unsafe[DType.uint128](
-                Int(-scale_of_quot)
-            )
-            scale_of_quot = 0
-
-        # print(
-        #     String(
-        #         "quot: {}, rem: {}, step_counter: {}, scale_of_quot: {}"
-        #     ).format(quot, rem, step_counter, scale_of_quot)
-        # )
-
-        # TODO: 可以考慮先降 scale 再判斷是否超出最大值.
-        # TODO: 爲降 scale 引入 round_to_remove_last_n_digits 函數
-        # If quot is within MAX, return the result
-        if quot <= Decimal128.MAX_AS_UINT128:
-            if scale_of_quot > Decimal128.MAX_SCALE:
-                quot = decimal128_utility.round_coefficient(
-                    quot,
-                    ndigits_to_remove=scale_of_quot - Decimal128.MAX_SCALE,
-                )
-                scale_of_quot = Decimal128.MAX_SCALE
-
-            return Decimal128.from_uint128(
-                quot, UInt32(scale_of_quot), is_negative
-            )
-
-        # Otherwise, we need to truncate the first 29 or 28 digits
-        else:
-            var fitted = decimal128_utility.fit_to_max_coefficient(quot)
-            var truncated_quot = fitted[0]
-            var scale_of_truncated_quot = scale_of_quot - fitted[1]
-
-            if scale_of_truncated_quot > Decimal128.MAX_SCALE:
-                truncated_quot = decimal128_utility.round_coefficient(
-                    truncated_quot,
-                    ndigits_to_remove=scale_of_truncated_quot
-                    - Decimal128.MAX_SCALE,
-                )
-                scale_of_truncated_quot = Decimal128.MAX_SCALE
-
-            return Decimal128.from_uint128(
-                truncated_quot, UInt32(scale_of_truncated_quot), is_negative
-            )
-
-    # SUB-CASE: Use UInt256 to store the quotient
-    # Also the FALLBACK approach for the remaining cases
-    # If the quotient's integral part is possibly more than 28 digits, we use UInt256
-    # It is almost the same also the case above, so we just use the same code
-
-    else:
-        # Maximum number of steps is MAX_NUM_DIGITS - ndigits_initial_quot + 1
-        # The extra digit is used for rounding up when it is 5 and not exact division
-        # 最大步數加一,用於捨去項爲5且非精確相除時向上捨去
-
-        var quot256: UInt256 = UInt256(quot)
-        var rem256: UInt256 = UInt256(rem)
-        var x2_coef256: UInt256 = UInt256(x2_coef)
-        # digit is the temporary quotient digit
-        var digit = UInt256(0)
-        # The final step counter stands for the number of decimal points
-        var step_counter = 0
-        var ndigits_initial_quot = decimal128_utility.number_of_digits(quot256)
-        while (
-            (rem256 != 0)
-            and (
-                step_counter
-                < (Decimal128.MAX_NUM_DIGITS - ndigits_initial_quot + 1)
-            )
-            and (
-                step_counter
-                < Decimal128.MAX_SCALE - diff_scale - adjusted_scale + 1
-            )
-        ):
-            # Multiply remainder by 10
-            rem256 *= 10
-            # Calculate next quotient digit
-            digit = rem256 // x2_coef256
-            quot256 = quot256 * 10 + digit
-            # Calculate new remainder. Writing `// + %` is fine here:
-            # LLVM lowers `urem` to `sub(a, mul(udiv, b))` and CSE-dedups
-            # the shared `udiv`, so the loop performs exactly one
-            # division per iteration (verified at the ARM64 asm level).
-            # Hoisting `UInt256(x2_coef)` into `x2_coef256` above
-            # the loop avoids the per-iteration lift.
-            rem256 = rem256 % x2_coef256
-            # Increment step counter
-            step_counter += 1
-            # Check if division is exact
-
-        else:
-            if digit == 5:
-                # Not exact division, round up the last digit
-                quot256 += 1
-
-        var scale_of_quot = step_counter + diff_scale + adjusted_scale
-
-        # If the scale is negative, we need to scale up the quotient
-        if scale_of_quot < 0:
-            quot256 = quot256 * decimal128_utility.power_of_10_unsafe[
-                DType.uint256
-            ](Int(-scale_of_quot))
-            scale_of_quot = 0
-
-        # If quot is within MAX, return the result
-        if quot256 <= Decimal128.MAX_AS_UINT256:
-            if scale_of_quot > Decimal128.MAX_SCALE:
-                quot256 = decimal128_utility.round_coefficient(
-                    quot256,
-                    ndigits_to_remove=scale_of_quot - Decimal128.MAX_SCALE,
-                )
-                scale_of_quot = Decimal128.MAX_SCALE
-
-            var low = UInt32(quot256 & 0xFFFFFFFF)
-            var mid = UInt32((quot256 >> 32) & 0xFFFFFFFF)
-            var high = UInt32((quot256 >> 64) & 0xFFFFFFFF)
-
-            return Decimal128(
-                low, mid, high, UInt32(scale_of_quot), is_negative
-            )
-
-        # Otherwise, we need to truncate the first 29 or 28 digits
-        else:
-            var fitted = decimal128_utility.fit_to_max_coefficient(quot256)
-            var truncated_quot = fitted[0]
-            var digits_removed = fitted[1]
-
-            # If digits_removed > scale_of_quot, we've lost integral digits
-            if digits_removed > scale_of_quot:
-                raise OverflowError(
-                    message="Decimal128 overflow in division.",
-                    function="divide()",
-                )
-
-            var scale_of_truncated_quot = scale_of_quot - digits_removed
-
-            if scale_of_truncated_quot > Decimal128.MAX_SCALE:
-                truncated_quot = decimal128_utility.round_coefficient(
-                    truncated_quot,
-                    ndigits_to_remove=scale_of_truncated_quot
-                    - Decimal128.MAX_SCALE,
-                )
-                scale_of_truncated_quot = Decimal128.MAX_SCALE
-
-            var low = UInt32(truncated_quot & 0xFFFFFFFF)
-            var mid = UInt32((truncated_quot >> 32) & 0xFFFFFFFF)
-            var high = UInt32((truncated_quot >> 64) & 0xFFFFFFFF)
-
-            return Decimal128(
-                low, mid, high, UInt32(scale_of_truncated_quot), is_negative
-            )
+    # The quotient is exact as far as it goes; the remainder is everything
+    # below it. `Wide` pads the mantissa with zeros, so adding one there says
+    # "and something more" without disturbing a digit that is known -- which
+    # is what turns an apparent tie into a rounding up.
+    var wide = Wide(quotient, -(diff_scale + shift), is_negative)
+    if remainder != UInt128(0):
+        wide.mantissa += UInt256(1)
+    return wide.to_decimal()
 
 
 def truncate_divide(x1: Decimal128, x2: Decimal128) raises -> Decimal128:

--- a/src/decimo/decimal128/utility.mojo
+++ b/src/decimo/decimal128/utility.mojo
@@ -25,7 +25,7 @@ representation conversions.
 from std.memory import Pointer
 from std import sys
 from std import time
-from std.bit import bit_width
+from std.bit import bit_width, count_leading_zeros
 from std.builtin.globals import global_constant
 
 from decimo.decimal128.decimal128 import Decimal128
@@ -1243,6 +1243,97 @@ def udiv_u256_by_pow10_gm(value: UInt256, k: Int) -> UInt256:
 
 
 @always_inline
+def udiv_u256_by_u128(n: UInt256, d: UInt128) -> Tuple[UInt256, UInt128]:
+    """Divides a 256-bit value by a 128-bit one.
+
+    Args:
+        n: The dividend.
+        d: The divisor, which must be non-zero.
+
+    Returns:
+        A tuple `(quotient, remainder)`.
+
+    Notes:
+        Knuth's algorithm D over 64-bit limbs, which is what makes it worth
+        writing: a `UInt256 // UInt256` is a software shift-subtract loop of
+        about 261 nanoseconds, and a `UInt128 // UInt128` with a divisor past
+        64 bits is 75. A `UInt128` divided by something that fits in 64 bits
+        is 2.6, because `__udivti3` recognises it, and every division here is
+        one of those.
+
+        The divisor is shifted until its top bit is set, which is what bounds
+        the trial quotient's error at two. The three-word window it is
+        subtracted from fits a `UInt256`, so the multiply-subtract and its
+        corrections are ordinary arithmetic rather than limb-by-limb borrows.
+    """
+    debug_assert(d != UInt128(0), "udiv_u256_by_u128: divisor must be non-zero")
+
+    if d <= UInt128(UInt64.MAX):
+        var narrow = udiv_u256_by_u64(n, UInt64(d))
+        return (narrow[0], UInt128(narrow[1]))
+    if n < UInt256(d):
+        return (UInt256(0), UInt128(n))
+
+    # Shift the divisor's top bit into place, and the dividend with it.
+    var shift = Int(count_leading_zeros(UInt64(d >> UInt128(64))))
+    var divisor = d << UInt128(shift)
+    var divisor_high = UInt128(divisor >> UInt128(64))
+    var shifted = n << UInt256(shift)
+    var carried = UInt64(0)
+    if shift > 0:
+        carried = UInt64(n >> UInt256(256 - shift))
+
+    var words = InlineArray[UInt64, 5](uninitialized=True)
+    words[0] = UInt64(shifted & UInt256(0xFFFF_FFFF_FFFF_FFFF))
+    words[1] = UInt64((shifted >> UInt256(64)) & UInt256(0xFFFF_FFFF_FFFF_FFFF))
+    words[2] = UInt64(
+        (shifted >> UInt256(128)) & UInt256(0xFFFF_FFFF_FFFF_FFFF)
+    )
+    words[3] = UInt64(
+        (shifted >> UInt256(192)) & UInt256(0xFFFF_FFFF_FFFF_FFFF)
+    )
+    words[4] = carried
+
+    var quotient = UInt256(0)
+    for index in range(2, -1, -1):
+        # The three words the next quotient word is drawn from.
+        var window = (
+            (UInt256(words[index + 2]) << UInt256(128))
+            | (UInt256(words[index + 1]) << UInt256(64))
+            | UInt256(words[index])
+        )
+
+        # Trial quotient from the top two words over the divisor's top word,
+        # which is a 128-bit value divided by a 64-bit one.
+        var top = (UInt128(words[index + 2]) << UInt128(64)) | UInt128(
+            words[index + 1]
+        )
+        var trial = top // divisor_high
+        if trial > UInt128(UInt64.MAX):
+            trial = UInt128(UInt64.MAX)
+
+        # Normalizing the divisor bounds the overshoot at two.
+        var product = UInt256(trial) * UInt256(divisor)
+        while product > window:
+            trial -= UInt128(1)
+            product -= UInt256(divisor)
+
+        window -= product
+        quotient |= UInt256(trial) << UInt256(64 * index)
+        words[index + 2] = UInt64(
+            (window >> UInt256(128)) & UInt256(0xFFFF_FFFF_FFFF_FFFF)
+        )
+        words[index + 1] = UInt64(
+            (window >> UInt256(64)) & UInt256(0xFFFF_FFFF_FFFF_FFFF)
+        )
+        words[index] = UInt64(window & UInt256(0xFFFF_FFFF_FFFF_FFFF))
+
+    var remainder = (
+        (UInt128(words[1]) << UInt128(64)) | UInt128(words[0])
+    ) >> UInt128(shift)
+    return (quotient, remainder)
+
+
 def udiv_u256_by_u64(n: UInt256, d: UInt64) -> Tuple[UInt256, UInt64]:
     """Schoolbook UInt256 / UInt64 division, hardware-fast on aarch64.
 

--- a/tests/decimal128/test_decimal128_arithmetics.mojo
+++ b/tests/decimal128/test_decimal128_arithmetics.mojo
@@ -895,5 +895,44 @@ def test_fma_overflow() raises:
         var _r = max_val.fma(Decimal128("2"), Decimal128.ZERO())
 
 
+def test_division_last_digit() raises:
+    """The last digit of a quotient is the correctly rounded one.
+
+    The quotient is taken to one digit past what the answer keeps and the
+    remainder settles the rest, so a tie rounds by what is actually below it.
+    Walking the digits and stopping when the budget ran out left
+    `504572829922.89957 / 525211.7899` one unit low.
+    """
+
+    def _check(left: String, right: String, expected: String) raises:
+        testing.assert_equal(
+            String(Decimal128(left) / Decimal128(right)), expected
+        )
+
+    _check(
+        "504572829922.89957",
+        "525211.7899",
+        "960703.5478372827936397396551",
+    )
+    _check("1", "3", "0.3333333333333333333333333333")
+    _check("1", "7", "0.1428571428571428571428571429")
+    _check("2", "3", "0.6666666666666666666666666667")
+
+
+def test_division_keeps_its_shapes() raises:
+    """The exact quotients keep the scale they had."""
+    testing.assert_equal(String(Decimal128("32") / Decimal128("2")), "16")
+    testing.assert_equal(String(Decimal128("18.00") / Decimal128("3.0")), "6.0")
+    testing.assert_equal(
+        String(Decimal128("123456780000") / Decimal128("1000")), "123456780"
+    )
+    testing.assert_equal(
+        String(Decimal128("246824.68") / Decimal128("12.341234")), "20000"
+    )
+    testing.assert_equal(
+        String(Decimal128("1234") / Decimal128("0.1234")), "10000"
+    )
+
+
 def main() raises:
     testing.TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/decimal128/test_decimal128_utility.mojo
+++ b/tests/decimal128/test_decimal128_utility.mojo
@@ -16,6 +16,7 @@ from decimo.decimal128.utility import (
     bitcast,
     power_of_10,
     udiv_u256_by_pow10_gm,
+    udiv_u256_by_u128,
 )
 
 
@@ -450,6 +451,59 @@ def test_reciprocal_divider_wide_range() raises:
             udiv_u256_by_pow10_gm(UInt256.MAX, k),
             UInt256.MAX // power_of_10[DType.uint256](k),
         )
+
+
+def test_divider_by_a_wide_divisor() raises:
+    """`udiv_u256_by_u128` agrees with plain division everywhere.
+
+    Knuth's algorithm D over 64-bit limbs, because the generic
+    `UInt256 // UInt256` is a software shift-subtract loop of about 261
+    nanoseconds against 22 here. Both ends of the divisor matter: at or below
+    64 bits it hands off to the narrower divider, above that it normalizes
+    and takes three trial quotients.
+    """
+    var state = UInt256(0x9E3779B97F4A7C15)
+    var checked = 0
+    for _ in range(150):
+        state ^= state << UInt256(13)
+        state ^= state >> UInt256(7)
+        state ^= state << UInt256(17)
+        for numerator_shift in range(0, 250, 29):
+            for divisor_shift in range(0, 120, 13):
+                var numerator = state >> UInt256(numerator_shift)
+                var divisor = UInt128(
+                    (state >> UInt256(divisor_shift)) & UInt256(UInt128.MAX)
+                )
+                if divisor == UInt128(0):
+                    continue
+                var pair = udiv_u256_by_u128(numerator, divisor)
+                var expected = numerator // UInt256(divisor)
+                assert_equal(pair[0], expected)
+                assert_equal(
+                    UInt256(pair[1]), numerator - expected * UInt256(divisor)
+                )
+                checked += 1
+    assert_true(checked > 10000, "the sweep should be a wide one")
+
+    # The two boundaries by hand.
+    var just_inside = UInt128(UInt64.MAX)
+    var just_outside = UInt128(UInt64.MAX) + UInt128(1)
+    for divisor in [just_inside, just_outside]:
+        var numerator = UInt256(10) ** 58 + UInt256(12345)
+        var pair = udiv_u256_by_u128(numerator, divisor)
+        assert_equal(pair[0], numerator // UInt256(divisor))
+        assert_equal(
+            UInt256(pair[1]),
+            numerator - (numerator // UInt256(divisor)) * UInt256(divisor),
+        )
+
+    # A divisor larger than the dividend, and one that divides it exactly.
+    var small = udiv_u256_by_u128(UInt256(5), UInt128(10) ** 30)
+    assert_equal(small[0], UInt256(0))
+    assert_equal(small[1], UInt128(5))
+    var exact = udiv_u256_by_u128(UInt256(10) ** 50, UInt128(10) ** 25)
+    assert_equal(exact[0], UInt256(10) ** 25)
+    assert_equal(exact[1], UInt128(0))
 
 
 def main() raises:


### PR DESCRIPTION
`decimo.Decimal` is arbitrary precision. This adds the other type to the Python package: `Decimal128`, 96 bits of coefficient and a scale from 0 to 28 in sixteen bytes that own nothing, with `Dec128` as the shorter name the Mojo library uses.

`+`, `-`, `*`, `/`, the six comparisons and the hash are C slots rather than dictionary entries. The hash agrees with `int`, `float`, `decimal.Decimal` and `Decimal`, so the four are interchangeable as dictionary keys. `quantize`, `round`, `normalize`, `adjusted`, `compare`, `copy_sign`, `copy_abs`, `copy_negate`, `to_integral_value`, `same_quantum`, `max`, `min`, `fma`, `as_tuple`, `as_integer_ratio`, `to_eng_string`, `from_float` and the `is_` predicates are there, along with `sqrt`, `cbrt`, `root`, `exp`, `ln`, `log10`, `log`, all six trigonometric functions, and the IEEE 754 interchange bytes from #305. It copies, pickles and formats like a value.

A mixed expression settles in the wider type: `Decimal128 + Decimal` is a `Decimal` either way round, since 29 digits and a scale of 28 both fit. `Decimal`'s operand conversion recognises the fixed-width type and `Decimal128`'s refuses it, which is what hands the expression to the reflected operator.

Division was the one operation slower than `decimal`'s, so it was rewritten. The quotient was built a digit at a time, which cost 226 nanoseconds and could run out of digits before reaching the position the rounding needed: `504572829922.89957 / 525211.7899` came out one unit low, and 1 in 300 random pairs was wrong in the last place. It is now one wide division rounded from the remainder, which is what settles a tie.

That needed a divider. A divisor past 64 bits fell through to `UInt256 // UInt256`, a software shift-subtract loop of 261 nanoseconds, so `udiv_u256_by_u128` takes Knuth's algorithm D over 64-bit limbs and does it in 22: every division inside it has a divisor that fits 64 bits, which `__udivti3` does in 2.6 nanoseconds against 75 for a full 128-bit one. `Decimal128` division is 70 nanoseconds against 226, and right on all 300 pairs.

Nanoseconds per operation, from Python:

| | `Decimal128` | `Decimal` | `decimal` |
| --- | ---: | ---: | ---: |
| `a + b` | **45** | 65 | 73 |
| `a * b` | **57** | 90 | 80 |
| `a / b` | **108** | 220 | 131 |
| from text | **110** | 159 | 131 |
| `str(x)` | 114 | 439 | **63** |
| comparison | 29 | 24 | **22** |
| an invoice | **597** | 709 | 712 |

The invoice is three lines quantized to cents with tax on the subtotal. `str` is the one still slower: 60 nanoseconds of that is the Mojo side and the rest is the call, so beating 63 means making the text itself about four times cheaper.

Two bugs turned up in the operators. A failed conversion left CPython's error indicator set, and a slot returning `NotImplemented` with an error pending has it surface later attached to whatever ran next -- `Decimal128(1) + Decimal(2)` raised `OverflowError: bad argument type for built-in operation`. And `__rpow__` and `__rdivmod__` were missing, so `2 ** Decimal128(3)` and `divmod(7, Decimal128(2))` were type errors.

Three differences from `Decimal` are in the README. Division fills the type -- 29 significant digits and a scale of at most 28 -- rather than following the context precision. A value past `7.9E+28` raises instead of rounding into range. And a scale is never negative, so `Decimal128("1.23E+5")` is `123000`: there is no cohort member with an exponent of 3 to print as `123E+3`.

1.44 million random pairs check the divider against plain division, including both sides of the 64-bit boundary, a divisor larger than the dividend, and exact division. 2100 checks across every function in the `decimal128` module against CPython's `decimal` and a 140-digit trigonometric reference: none wrong. The suite is at 1227 tests, and the Python tests cover the arithmetic, the method surface, hashing, money rounding, mixed expressions, the interchange bytes and what the type refuses.
