### PR TITLE
[ci] Split the Linux tests across the suite jobs

### DIFF
--- a/.github/actions/setup-decimo/action.yml
+++ b/.github/actions/setup-decimo/action.yml
@@ -56,34 +56,15 @@ runs:
         echo "compiler reports: $(pixi run mojo --print-cache-location 2>&1 | tail -1)"
         echo "we cache        : $PWD/.pixi/envs/default/share/max/cache/.mojo_cache"
 
-    # A `.mojoc` is compiled code and does not cross platforms, so the artifact
-    # the macOS build job uploads is only good on macOS. Linux compiles its
-    # own, which costs about ten seconds -- far less than the cold test
-    # compiles the cache above is there to avoid.
+    # Each platform's own package: a `.mojoc` is compiled code and does not
+    # cross platforms. It matters that this is a shared artifact rather than a
+    # per-job build -- the compilation cache keys on the package the test file
+    # imports, so two independently built `.mojoc` files miss it.
     - name: Download decimo.mojoc artifact
-      if: runner.os != 'Linux'
       uses: actions/download-artifact@v8
       with:
-        name: decimo-mojoc
+        name: decimo-mojoc-${{ runner.os }}
         path: .
     - name: Stage package next to tests
-      if: runner.os != 'Linux'
       shell: bash
       run: cp decimo.mojoc tests/
-    - name: Build the package for this platform
-      if: runner.os == 'Linux'
-      shell: bash
-      run: |
-        for attempt in 1 2 3; do
-          echo "=== build attempt $attempt ==="
-          if pixi run mojo precompile src/decimo -o tests/decimo.mojoc; then
-            echo "=== build succeeded on attempt $attempt ==="
-            break
-          fi
-          if [ "$attempt" -eq 3 ]; then
-            echo "=== build failed after 3 attempts ==="
-            exit 1
-          fi
-          echo "=== build crashed, retrying in 5s... ==="
-          sleep 5
-        done

--- a/.github/actions/setup-decimo/action.yml
+++ b/.github/actions/setup-decimo/action.yml
@@ -1,5 +1,5 @@
 name: Setup Decimo with Pixi
-description: Install pixi (cached), activate the Mojo environment, restore the Mojo compilation cache, and download the prebuilt decimo.mojoc artifact into tests/.
+description: Install pixi (cached), activate the Mojo environment, restore the Mojo compilation cache, and put a decimo.mojoc into tests/ -- the prebuilt artifact on macOS, a freshly compiled one on Linux.
 
 runs:
   using: composite
@@ -56,11 +56,34 @@ runs:
         echo "compiler reports: $(pixi run mojo --print-cache-location 2>&1 | tail -1)"
         echo "we cache        : $PWD/.pixi/envs/default/share/max/cache/.mojo_cache"
 
+    # A `.mojoc` is compiled code and does not cross platforms, so the artifact
+    # the macOS build job uploads is only good on macOS. Linux compiles its
+    # own, which costs about ten seconds -- far less than the cold test
+    # compiles the cache above is there to avoid.
     - name: Download decimo.mojoc artifact
+      if: runner.os != 'Linux'
       uses: actions/download-artifact@v8
       with:
         name: decimo-mojoc
         path: .
     - name: Stage package next to tests
+      if: runner.os != 'Linux'
       shell: bash
       run: cp decimo.mojoc tests/
+    - name: Build the package for this platform
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          echo "=== build attempt $attempt ==="
+          if pixi run mojo precompile src/decimo -o tests/decimo.mojoc; then
+            echo "=== build succeeded on attempt $attempt ==="
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "=== build failed after 3 attempts ==="
+            exit 1
+          fi
+          echo "=== build crashed, retrying in 5s... ==="
+          sleep 5
+        done

--- a/.github/workflows/prune_caches.yaml
+++ b/.github/workflows/prune_caches.yaml
@@ -1,0 +1,97 @@
+name: Prune stale caches
+
+# Every test run saves a cache entry per job, keyed by the commit, so a day of
+# pushes leaves a few hundred entries behind. Only the newest entry under each
+# key prefix is ever restored -- that is what `restore-keys` matches -- and the
+# rest sit there until GitHub's 10 GB per-repository limit starts evicting.
+#
+# It reached that limit: 9.95 GB across 177 entries, of which 155 were dead.
+# Once the limit is hit the eviction is LRU and indiscriminate, so a cache a
+# job had just written could be gone before the next run read it, and the Mojo
+# compilation cache stopped being reliable on either platform.
+#
+# This deletes everything but the newest entry under each prefix, after every
+# test run. It never deletes an entry a run is about to restore, because that
+# entry is by definition the newest one.
+
+on:
+  workflow_run:
+    workflows: ["Decimo Unit Tests"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  prune:
+    name: Prune stale caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Delete all but the newest cache under each key prefix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import subprocess
+
+          repo = os.environ["REPO"]
+
+
+          def api(*args: str) -> str:
+              """The response body, or an empty string if the call failed."""
+              done = subprocess.run(
+                  ["gh", "api", *args], capture_output=True, text=True
+              )
+              return done.stdout if done.returncode == 0 else ""
+
+
+          def delete(cache_id: int) -> bool:
+              """A successful DELETE returns 204 with no body, so check the code."""
+              done = subprocess.run(
+                  ["gh", "api", "-X", "DELETE",
+                   f"repos/{repo}/actions/caches/{cache_id}"],
+                  capture_output=True,
+                  text=True,
+              )
+              return done.returncode == 0
+
+
+          entries = []
+          for page in range(1, 21):
+              body = api(f"repos/{repo}/actions/caches?per_page=100&page={page}")
+              batch = json.loads(body)["actions_caches"] if body.strip() else []
+              if not batch:
+                  break
+              entries += batch
+
+          # The prefix is the key without its trailing commit sha, which is what
+          # `restore-keys` falls back to.
+          newest: dict[str, dict] = {}
+          for entry in entries:
+              prefix = entry["key"].rsplit("-", 1)[0]
+              current = newest.get(prefix)
+              if current is None or entry["last_accessed_at"] > current["last_accessed_at"]:
+                  newest[prefix] = entry
+
+          keep = {id(entry) for entry in newest.values()}
+          stale = [entry for entry in entries if id(entry) not in keep]
+
+          freed = 0
+          failed = 0
+          for entry in stale:
+              if delete(entry["id"]):
+                  freed += entry["size_in_bytes"]
+              else:
+                  failed += 1
+
+          total = sum(entry["size_in_bytes"] for entry in entries)
+          print(f"{len(entries)} entries, {total / 1024**3:.2f} GB")
+          print(f"kept {len(newest)}, deleted {len(stale) - failed}, freed {freed / 1024**3:.2f} GB")
+          if failed:
+              print(f"{failed} deletion(s) failed")
+          PYEOF

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -20,6 +20,17 @@ defaults:
 # (saves ~30s of `mojo precompile` per job × 10 jobs). The pixi environment
 # is cached by `prefix-dev/setup-pixi@v0.10.2`, so test jobs no longer
 # `curl | sh` and `pixi install` from scratch.
+#
+# The suites `tests/test.sh decimo` covers run on Linux as well as macOS, as
+# a matrix on each suite's own job rather than as one job running all of
+# them. That single job took 20 minutes where each macOS suite took under
+# one, and almost all of it was compiling test files: it had no Mojo
+# compilation cache, because the cache lives in `setup-decimo` alongside the
+# artifact download that only macOS can use, and `tests/test.sh` runs
+# sequentially under CI on the grounds that each suite is already its own
+# job -- which was true of every job except that one. Splitting it gives
+# both back. A `.mojoc` does not cross platforms, so the Linux legs compile
+# their own; that costs about ten seconds against the twenty minutes.
 
 jobs:
   # ── Gate: Format + Doc + Build package ───────────────────────────────────────
@@ -105,54 +116,15 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # ── The library on Linux ─────────────────────────────────────────────────────
-  #
-  # Everything else in this file runs on macOS, and the wheels now go out for
-  # Linux as well, so the library is compiled and its suites are run there
-  # too. One job rather than twelve: the point is that the platform works at
-  # all, not to parallelise it.
-  #
-  # It builds its own package instead of taking the artifact the macOS job
-  # uploads -- a `.mojoc` is compiled code and does not cross platforms --
-  # and so it does not use the shared setup action either.
-  test-linux:
-    name: Test on Linux
-    runs-on: ubuntu-22.04
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v7
-      - uses: prefix-dev/setup-pixi@v0.10.2
-        with:
-          cache: true
-          activate-environment: true
-      - name: Build package (with retry for Mojo compiler intermittent crashes)
-        run: |
-          for attempt in 1 2 3; do
-            echo "=== build attempt $attempt ==="
-            if pixi run mojo precompile src/decimo -o tests/decimo.mojoc; then
-              echo "=== build succeeded on attempt $attempt ==="
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "=== build failed after 3 attempts ==="
-              exit 1
-            fi
-            echo "=== build crashed, retrying in 5s... ==="
-            sleep 5
-          done
-      - name: Run the core suites
-        run: bash tests/test.sh decimo
-      - name: Build the Python extension and run its tests
-        run: |
-          pixi run mojo build python/decimo_module.mojo --emit shared-lib \
-            -I tests -o python/src/decimo/_decimo.so
-          pixi run python python/tests/test_decimo.py
-
   # ── Test: BigDecimal ─────────────────────────────────────────────────────────
   test-bigdecimal:
-    name: Test BigDecimal
+    name: Test BigDecimal (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -175,9 +147,13 @@ jobs:
 
   # ── Test: BigInt ─────────────────────────────────────────────────────────────
   test-bigint:
-    name: Test BigInt
+    name: Test BigInt (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -200,9 +176,13 @@ jobs:
 
   # ── Test: BigUint ────────────────────────────────────────────────────────────
   test-biguint:
-    name: Test BigUint
+    name: Test BigUint (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -225,9 +205,13 @@ jobs:
 
   # ── Test: BigInt10 ───────────────────────────────────────────────────────────
   test-bigint10:
-    name: Test BigInt10
+    name: Test BigInt10 (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -250,9 +234,13 @@ jobs:
 
   # ── Test: Decimal128 ─────────────────────────────────────────────────────────
   test-decimal128:
-    name: Test Decimal128
+    name: Test Decimal128 (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -275,9 +263,13 @@ jobs:
 
   # ── Test: Rational ──────────────────────────────────────────────────────────
   test-rational:
-    name: Test Rational
+    name: Test Rational (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -300,9 +292,13 @@ jobs:
 
   # ── Test: Expression engine ───────────────────────────────────────────────
   test-expression:
-    name: Test Expression
+    name: Test Expression (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -353,9 +349,13 @@ jobs:
   # conformance that no longer holds is a compile error rather than a failed
   # assertion, and only a job that builds them catches it.
   test-traits:
-    name: Test Traits
+    name: Test Traits (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
@@ -483,9 +483,13 @@ jobs:
 
   # ── Test: Python bindings ────────────────────────────────────────────────────
   test-python:
-    name: Test Python bindings
+    name: Test Python bindings (${{ matrix.os }})
     needs: build
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -26,11 +26,15 @@ defaults:
 # them. That single job took 20 minutes where each macOS suite took under
 # one, and almost all of it was compiling test files: it had no Mojo
 # compilation cache, because the cache lives in `setup-decimo` alongside the
-# artifact download that only macOS can use, and `tests/test.sh` runs
+# artifact download that only macOS could use, and `tests/test.sh` runs
 # sequentially under CI on the grounds that each suite is already its own
-# job -- which was true of every job except that one. Splitting it gives
-# both back. A `.mojoc` does not cross platforms, so the Linux legs compile
-# their own; that costs about ten seconds against the twenty minutes.
+# job -- which was true of every job except that one.
+#
+# `build-linux` exists so that the Linux legs share one package the way the
+# macOS legs do. Letting each build its own looked equivalent and was not:
+# the compilation cache keys on the package a test file imports, so two
+# independently built `.mojoc` files miss it, and every Linux test compiled
+# cold at 11 s a file against 1 s on macOS.
 
 jobs:
   # ── Gate: Format + Doc + Build package ───────────────────────────────────────
@@ -111,7 +115,49 @@ jobs:
       - name: Upload decimo.mojoc artifact
         uses: actions/upload-artifact@v7
         with:
-          name: decimo-mojoc
+          name: decimo-mojoc-${{ runner.os }}
+          path: decimo.mojoc
+          retention-days: 1
+          if-no-files-found: error
+
+  # ── Gate: build the package for Linux ────────────────────────────────────────
+  #
+  # A `.mojoc` is compiled code and does not cross platforms, so Linux cannot
+  # use the artifact the macOS job uploads. Building it once here rather than
+  # in every Linux test job is not about the eleven seconds it costs: the Mojo
+  # compilation cache keys on the package the test file imports, and two
+  # independently built `.mojoc` files are not reliably identical. Each job
+  # building its own meant every test compile missed the cache -- 11 s a file
+  # against 1 s on macOS, which downloads one shared artifact.
+  build-linux:
+    name: Build package (Linux)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: prefix-dev/setup-pixi@v0.10.2
+        with:
+          cache: true
+          activate-environment: true
+      - name: Build package (with retry for Mojo compiler intermittent crashes)
+        run: |
+          for attempt in 1 2 3; do
+            echo "=== build attempt $attempt ==="
+            if pixi run mojo precompile src/decimo -o decimo.mojoc; then
+              echo "=== build succeeded on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== build failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== build crashed, retrying in 5s... ==="
+            sleep 5
+          done
+      - name: Upload decimo.mojoc artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: decimo-mojoc-${{ runner.os }}
           path: decimo.mojoc
           retention-days: 1
           if-no-files-found: error
@@ -119,7 +165,7 @@ jobs:
   # ── Test: BigDecimal ─────────────────────────────────────────────────────────
   test-bigdecimal:
     name: Test BigDecimal (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -148,7 +194,7 @@ jobs:
   # ── Test: BigInt ─────────────────────────────────────────────────────────────
   test-bigint:
     name: Test BigInt (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -177,7 +223,7 @@ jobs:
   # ── Test: BigUint ────────────────────────────────────────────────────────────
   test-biguint:
     name: Test BigUint (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -206,7 +252,7 @@ jobs:
   # ── Test: BigInt10 ───────────────────────────────────────────────────────────
   test-bigint10:
     name: Test BigInt10 (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -235,7 +281,7 @@ jobs:
   # ── Test: Decimal128 ─────────────────────────────────────────────────────────
   test-decimal128:
     name: Test Decimal128 (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -264,7 +310,7 @@ jobs:
   # ── Test: Rational ──────────────────────────────────────────────────────────
   test-rational:
     name: Test Rational (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -293,7 +339,7 @@ jobs:
   # ── Test: Expression engine ───────────────────────────────────────────────
   test-expression:
     name: Test Expression (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -350,7 +396,7 @@ jobs:
   # assertion, and only a job that builds them catches it.
   test-traits:
     name: Test Traits (${{ matrix.os }})
-    needs: build
+    needs: [build, build-linux]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
`Test on Linux` took 20 minutes where every macOS suite job took under one, and 1173 of its 1231 seconds were spent compiling test files.

Three things were true of that job and of no other. It had no Mojo compilation cache: the cache lives in `.github/actions/setup-decimo`, next to the artifact download that only macOS could use, so the Linux job could not use the action at all. It ran all eight core suites in sequence. And `tests/test.sh` forces `DECIMO_TEST_JOBS=1` under CI on the grounds that each suite is already its own job there — which was true everywhere except here.

The suites `tests/test.sh decimo` covers now run as a matrix on their own jobs, `[macos-latest, ubuntu-22.04]`, and the standalone Linux job is gone. Coverage is unchanged: the same eight suites plus the Python bindings, which the old job also built and ran.

`build-linux` compiles the package once and uploads it, the way `build` does for macOS, and the artifact name carries the platform. Letting each Linux job build its own looked equivalent — it costs eleven seconds — and was not: the Mojo compilation cache keys on the package a test file imports, two independently built `.mojoc` files are not reliably identical, and every Linux test compiled cold at 11 s a file against 1 s on macOS.

`prune_caches.yaml` deletes every cache entry but the newest under each key prefix, after each test run. Only the newest is ever restored, since that is what `restore-keys` matches, so the rest accumulate: the repository had reached 9.95 GB of its 10 GB limit across 177 entries, of which 155 were dead. Past the limit the eviction is LRU and indiscriminate, and an entry a job had just written could be gone before the next run read it — which is why the compilation cache was unreliable on both platforms. Note this only starts working once it is on the default branch; `workflow_run` does not fire for a workflow that lives only on a branch.

Measured on the same commit, second run, per test file: BigDecimal on Linux 11.4 s a file before, 1.6 s after; the job itself 451 s to 66 s, against 51 s for the same suite on macOS.