### PR TITLE
[core] Speed up addition and in-place subtraction

### DIFF
--- a/docs/internal/todo.md
+++ b/docs/internal/todo.md
@@ -159,13 +159,46 @@ Ordered by what actually moves:
    Which leaves lazy reduction -- keeping residues in `[0, 2^64)` and
    canonicalizing rarely -- as the only cheap idea left, worth maybe 1.15x,
    and Schonhage-Strassen as the only one that would actually close the gap.
-3. **Break the carry chain in add and subtract.** We are latency-bound on it,
-   not throughput-bound: 1038 words at 10 000 digits is 519 limbs and 271 ns,
-   which is 1.8 cycles a limb, where GMP's `ADCS` chain runs at 1.0. Widen the
-   words into 64-bit SIMD lanes to manufacture the slack that base 10^9 gives
-   `BigUInt` for free, sum ignoring carry, then propagate. A lane only
-   propagates when its digit is all ones, so the second pass can be a mask
-   test that almost never fires rather than `BigUInt`'s serial walk.
+3. **Break the carry chain in add and subtract.** **Addition done 20260902;
+   `_subtract_words()` still runs one borrow chain.** `_add_words()` cuts the
+   array into four segments
+   that add with no carry in, interleaved in one loop so the core can
+   actually overlap them, and stitches the segment carries afterwards. The
+   stitch is cheap because a carry only travels while it meets words of all
+   ones. Four loops rather than one interleaved loop would not have worked:
+   the reorder window does not span a segment.
+
+   `BigInt` addition, ns per word, four chains against one:
+
+   | words | one chain | four | |
+   | ----: | --------: | ---: | --- |
+   |    26 |     1.142 | 1.115 | below the cutoff, same path |
+   |    37 |     0.927 | 0.828 | 1.12x |
+   |    63 |     0.696 | 0.601 | 1.16x |
+   |   125 |     0.664 | 0.443 | 1.50x |
+   |   260 |     0.578 | 0.362 | 1.60x |
+   |  5 191 |    0.499 | 0.319 | 1.56x |
+
+   That is 1.75 cycles a word down to about 1.05, which is where GMP's
+   `ADCS` chain runs. `_ADD_SEGMENT_MIN` is 32 words; under it the setup and
+   the stitch cost more than the shorter chain buys.
+
+   **Subtraction is the same shape and has not been done.**
+   `_subtract_words()` carries the borrow the same way and should take the
+   same treatment; the stitch is a borrow that travels while it meets words
+   of zero rather than of all ones.
+
+   **The gain does not reach multiplication or division.** Measured with the
+   path on and off and the package rebuilt between: multiply and divide move
+   by at most 3% at every size, which is noise. Additions are simply a small
+   share of what those spend, and at a million digits multiplication is the
+   transform, which does no bignum addition at all. Worth knowing before
+   anyone prices the next carry-chain idea by what the recursion might
+   inherit.
+
+   Checked over 1 196 adversarial cases -- `2^(64k) - 1` for every `k` from
+   1 to 299, where the carry has to ripple across every possible segment
+   boundary and out of the top -- plus the full suite.
 4. **Multiplication thresholds.** `CUTOFF_KARATSUBA` is 64 words, which is
    1233 decimal digits; GMP switches around 500. Our Comba is good enough that
    schoolbook at 104 words is only 1.91x of GMP's Karatsuba, so this is worth
@@ -214,33 +247,153 @@ Three things measured the wrong way round here, so they are not retried:
 
 ## Now
 
-Ordered by value. Division from Python is the only operation still behind
-CPython's `decimal`, and it is the first item.
+Ordered by value. The Python package is where the library is still behind
+CPython's `decimal`, and the first item is why: the extension build runs the
+same code at about 2.8x. The Mojo library itself is ahead of libmpdec on
+every operation but division and parsing, where it is 1.16x and 1.23x.
 
-1. **`divide`, 1.24x at 9 digits and 1.38x at 28.** The only operator still
-   outside 1.2x. 138.8 ns against 100.3, of which ~109 is Mojo and ~30 the
-   call. Inside the Mojo half: 4.6 ns padding, 15.7 normalizing, ~60 in
-   Knuth D over five quotient words, ~15 rounding and construction. Four
-   things were tried and did not help -- calling Knuth D without the second
-   dispatch (neutral; the compiler had already inlined it), padding by digits
-   instead of whole words (worse, because `multiply_by_power_of_base` only
-   prepends zero words while `multiply_by_power_of_ten` walks the number),
-   hoisting the estimator's invariants (neutral), and raising the inline
-   capacity past ten (no gain). Base 10^18 has since landed, so what is left
-   is Newton reciprocal division.
-2. **`parse`, 1.28x slower than libmpdec at 9 digits.** The digit-list detour
-   is gone: a plain string goes straight into the words through
-   `_from_plain_string()`. What is left has not been taken apart.
+1. **The extension build runs the same Mojo code at about 2.8x (20260902).**
+   Not a `divide` problem or a `parse` problem, and not interop per call.
+   The same source, the same loop, no Python inside it, parsing ten-byte
+   decimals:
 
-3. **Newton reciprocal division**, worth ~115 ms of `pi(10^6)` as well as
-   item 1. See `bigint_enhancement.md` T-D4.
-4. **`subtract_inplace()`** builds a negated copy of its right operand to flip
-   a sign: `x -= y` is 5.2x slower than libmpdec in place, where `x += y` is
-   1.3x *faster*. See `bigdecimal_enhancement.md` H#21.
-5. **A cheaper NTT butterfly** -- precomputed (Shoup) twiddles and radix-4.
-   Needed for goal 1: `pi(10^6)` at 1.2x of mpmath+GMP wants roughly 2.5x here
-   on top of item 5.
-6. **Audit the remaining `UInt128` and `UInt256` uses.** Three of the day's
+   | where                                | ns   |
+   | ------------------------------------ | ---- |
+   | `mojo run`                           | 21.4 |
+   | `mojo build`, executable             | 25.0 |
+   | plain `.so`, called through `ctypes` | 20.6 |
+   | `_decimo.so`, the Python extension   | 58.5 |
+
+   Both `.so` files are loaded into a CPython process, so the host and its
+   allocator are the same in the two bottom rows. A plain shared library is
+   as fast as an executable, so this is not shared-library codegen either.
+
+   **It lands on memory, not on instructions.** A loop of integer arithmetic
+   that never touches the heap is 1.365 ns in the plain library and 1.749 in
+   the extension -- 1.28x. The parse, which allocates, is 2.84x. The
+   extension is 1.48 MB against the plain library's 108 KB for the same
+   parse code, which points at code layout and instruction cache rather than
+   at the arithmetic.
+
+   Ruled out: optimization level (`mojo build` defaults to `-O3`); the
+   `decimo.mojoc` boundary (`-I src` against the sources gives 44.07 against
+   43.75, so no cross-module inlining is lost); the per-call binding (~8 ns
+   between the in-library loop and one `Decimal("...")`); reading the
+   `_Global`; the `PythonObject` subscript in the constructor
+   (`PyObject_Length` plus `PyTuple_GetItem` measured neutral); the
+   `try`/`except` around the parse (~3 ns); the block pool (keeping the
+   parsed values rather than dropping them costs 2.3 ns); and a wrong
+   constructor overload (`__init__` takes a `StringSlice`, and there is no
+   `String` overload to fall into).
+
+   Next: a minimal repro for upstream -- one `.so` built plain and one built
+   as an extension from the same file. 2.8x across everything the package
+   does dwarfs what the individual operations have left, so it is worth
+   asking before spending more here.
+
+2. **`Decimal(x)` where `x` is already a `Decimal`: 71.1 ns against 35.0
+   (20260902).** The widest single gap left in the Python package, and the
+   one place where CPython's constructor is *faster* than its own no-argument
+   one. Ours costs 18.1 ns over `Decimal()`; theirs costs less than nothing.
+   Not taken apart yet.
+
+   For scale, the rest of the constructor, decimo against `decimal`:
+   `Decimal()` 53.0 against 74.4 and `Decimal(0)` 59.4 against 84.4 -- both
+   ahead -- while `Decimal("1.99999999")` is 124.5 against 107.6. The
+   marginal cost per digit is already even (14.1 ns against 15.2 from `"0"`
+   to nine digits); it is the fixed cost of the string path that is behind,
+   and item 1 is most of it.
+
+3. **`true_divide` keeps 90 digits to answer 28 (20260902).** At 100-digit
+   operands and a precision of 28, division from Python is 2.15x `decimal`
+   where 28 digits is 1.05x. The truncation path does fire -- 6 divisor words
+   against a `needed_divisor_words` of 5 -- but `ceildiv(p, 18) + 2 + G` with
+   `G = 1` still keeps five base-10^18 words, which is 90 digits. The error
+   bound in the comment above `TRUNCATION_GUARD` justifies the `+2`, and `G`
+   has already come down from 4, so anything further has to be argued against
+   the tie-detection fallback rather than guessed.
+
+4. ~~**Newton reciprocal division.**~~ **Dropped 20260902: our division is
+   already cheaper than the replacement.** The case for it was that division
+   cost 4.9 same-size multiplications, measured just after the transform
+   landed. Base 2^64, base 10^18, the Knuth D work and the block pool have
+   all landed since, and a 2n-by-n division now costs:
+
+   | digits    | multiply | divide  | div/mul |
+   | --------- | -------- | ------- | ------- |
+   | 1 000     | 1.06 us  | 1.80 us | 1.70    |
+   | 10 000    | 46.6 us  | 76.7 us | 1.64    |
+   | 100 000   | 1.23 ms  | 3.12 ms | 2.53    |
+   | 1 000 000 | 25.0 ms  | 81.3 ms | 3.25    |
+
+   A Barrett divide is a Newton reciprocal, about 3 M(n) with precision
+   doubling, plus two multiplications for the quotient and remainder: 4 to 5
+   M(n) for a one-shot division, and only amortised to ~2 M(n) when the same
+   divisor is reused, which the binary splitting in `pi()` never does. At
+   3.25 M(n) we are already under that, and under GMP's own 2.6 ratio at the
+   small end.
+
+   This is what the `BigInt` against GMP section above already concluded from
+   the other direction -- "neither needs a new division algorithm" -- and
+   `internal_notes.md`'s "worth about 20% now" is the stale half of the
+   record. The lever for division is item 6: it is built out of
+   multiplications and inherits whatever they gain.
+5. ~~**`subtract_inplace()`** builds a negated copy of its right operand.~~
+   **Done 20260902.** It built a whole `BigDecimal` with a copied coefficient
+   just to flip one sign bit, and the copy costs an allocation as soon as the
+   coefficient outgrows the inline words. The sign is an argument now:
+   `add_inplace_signed()` carries the body and both `add_inplace()` and
+   `subtract_inplace()` delegate to it.
+
+   | digits | `x += y` | `x -= y` before | after | ratio to add |
+   | -----: | -------: | --------------: | ----: | -----------: |
+   |      9 |  4.45 ns |         5.85 ns | 4.40  |         0.99 |
+   |     28 |  5.68    |         6.82    | 5.73  |         1.01 |
+   |    100 |  8.16    |        27.03    | 8.18  |         1.00 |
+   |  1 000 | 27.45    |        46.65    | 27.45 |         1.00 |
+
+   Subtraction costs what addition costs now, which is what it should: they
+   do the same arithmetic. The hundred-digit row is 3.3x because that is
+   where the coefficient stops fitting inline -- six base-10^18 words -- so
+   the copy was reaching the allocator. Checked against the out-of-place
+   `subtract()` and `add()` over 196 pairs covering both signs, zero, unequal
+   scales and both magnitude orders.
+6. ~~**Radix-4 for the NTT.**~~ **Dropped 20260902: the multiply it was
+   meant to remove is not expensive.** The case rested on two legs. The first
+   was already weak in our own notes -- the butterfly is not memory-bound
+   (2^15 costs 1.29 ns and 2^19 costs 1.40, a 9% spread over 16x the working
+   set), so halving the passes buys little. The second was that radix-4 turns
+   a quarter of the twiddle multiplies into a shift, because `2^96 = -1` for
+   this prime makes the fourth root of unity `2^48`.
+
+   The arithmetic checks out -- `2^96 mod P = P - 1`, `(2^48)^2 = -1`,
+   `(2^48)^4 = 1` -- and a shift-based `x * 2^48 mod P` written from
+   `2^64 = 2^32 - 1` and `2^96 = -1` agrees with `mod_mul` on every value
+   tried. It is just not faster:
+
+   | | latency (serial) | throughput (4 chains) |
+   | ----------------- | ------- | ------- |
+   | `mod_mul(x, w4)`  | 2.18 ns | 0.703 ns |
+   | shift-based `w4`  | 2.61 ns | 0.749 ns |
+
+   Both ways round it loses. `mul` and `umulh` are pipelined and the shift
+   path has more dependent operations, so replacing a general modular
+   multiply with the "cheap" one makes the butterfly slower, not faster.
+   Radix-4 would therefore remove no multiplies at all, leaving only the
+   pass-count saving that leg one already priced at a few percent.
+
+   The deeper reason to stop: `mod_mul` is 0.70 ns of throughput, about two
+   cycles. A 64-bit modular multiply has nothing left in it. **Shoup
+   twiddles are separately impossible here** -- `2P` does not fit a `UInt64`
+   for a prime this close to `2^64`, and overflows on a measured 25% of
+   values.
+
+   What is left for the transform is lazy reduction (~1.15x) and, to actually
+   close the gap to GMP, Schonhage-Strassen, which multiplies by a root of
+   unity with a bit shift because its modulus is chosen so that this is free.
+   Ours is not.
+
+7. **Audit the remaining `UInt128` and `UInt256` uses.** Three of the day's
    biggest wins were removing one. The rule: 128-bit as an *accumulator* is
    fine, because a 64x64 multiply is one instruction; 128-bit or 256-bit as
    the *left side of a divide by a variable* is a call to a software helper,
@@ -261,13 +414,13 @@ CPython's `decimal`, and it is the first item.
 
    The hand-rolled reciprocal is *slower* than what the compiler emits for a
    constant. Reach for it only when the divisor is a runtime value.
-7. ~~**Base 10^18 for `BigUInt`.**~~ **Done 20260828 (#288).** A 28-digit
+8. ~~**Base 10^18 for `BigUInt`.**~~ **Done 20260828 (#288).** A 28-digit
    value is two words where it used to be four, the same as libmpdec.
    Measured on the same operands, base 10^9 over base 10^18: add 1.06x to
    1.54x, multiply up to 2.91x, divide up to 2.16x. The traps the type
    checker could not see are recorded in `docs/plans/bigint_enhancement.md`
    under T-W1.
-8. ~~**`floor_divide()` 2n-by-n scaling** in `BigUInt`~~ -- answered below.
+9. ~~**`floor_divide()` 2n-by-n scaling** in `BigUInt`~~ -- answered below.
 
 ## Blocked on the language
 
@@ -291,6 +444,33 @@ Nothing to do here until Mojo grows the feature.
 
 ## Features, not yet started
 
+- [ ] Finish `BigDecimal`'s `decimal` method surface. Issue #175 tracked this
+      and is closed; what its list still showed as missing has mostly landed,
+      much of it in v0.14.0's `bigdecimal/spec.mojo`. What is left, sorted by
+      whether it is work:
+
+      *Real work.* `__hash__` -- the Python binding has a `tp_hash` slot but
+      the Mojo type has none, so `BigDecimal` cannot be a dictionary key in
+      Mojo. `as_integer_ratio`. `to_integral_value` and `to_integral_exact`:
+      `rounding.mojo` has `quantize`, `round` and `round_to_precision_inplace`
+      and nothing that rounds to an integer under the context.
+
+      *One line each*, because decimo has no NaN or infinity and one canonical
+      form: `canonical`, `is_canonical`, `is_finite` (always true), `is_nan`,
+      `is_snan`, `is_qnan` (always false), `radix` (always 10).
+
+      *Blocked on a decision.* `is_normal` and `is_subnormal` need a smallest
+      exponent, and decimo's exponents are unbounded. The Python layer answers
+      them with an `Emin` it keeps itself; Mojo would need the same or an
+      argument.
+
+      *Not applicable.* `__complex__` and `conjugate` -- Mojo has no complex
+      type.
+
+      Renamed rather than missing, in case the old names are wanted as
+      aliases: `max_mag` is `max_absolute`, `min_mag` is `min_absolute`,
+      `is_signed` is `is_negative`.
+
 - [ ] Expose the trigonometric functions on `decimo.Decimal` in Python. The
       Mojo `BigDecimal` has `sin`, `cos`, `tan`, `cot`, `csc`, `sec` and
       `arctan`, each with the `_rounded` variant that v0.14.0 added, and the
@@ -309,6 +489,22 @@ Nothing to do here until Mojo grows the feature.
       that an implicit conversion is not required.
 
 ## Investigations
+
+- [ ] (20260902) conda-forge, once Mojo is on it. `mojo`, `max`, `modular` and
+      `mojo-compiler` are all 404 on conda-forge; Mojo ships only from
+      Modular's own channel. A conda-forge package may depend only on
+      conda-forge, so their CI cannot build the extension, and repackaging the
+      wheel is not something they take for a compiled extension. Not a
+      difficulty, a wall.
+
+      Answered for now: **do not**. The Mojo library is already a conda
+      package -- `modular-community` is a conda channel -- and `pip install
+      decimo` works inside a conda environment, since the wheel carries its
+      own Mojo runtime. A private channel on anaconda.org would add a release
+      step that nothing discovers, and every extra channel is another place
+      that quietly falls behind: Homebrew sat four months and three releases
+      out of date. Revisit if Mojo reaches conda-forge, where the feedstock
+      bot would carry the maintenance.
 
 - [x] (20260826) Check the `floor_divide()` function of `BigUInt`: 2n-by-n,
       4n-by-n and 8n-by-n divisions looked as though they slowed down

--- a/docs/plans/bigdecimal_enhancement.md
+++ b/docs/plans/bigdecimal_enhancement.md
@@ -235,10 +235,11 @@ kernels (parse/render are precision-insensitive ops).
 |     | with debug asserts                            | outside the package opens these modules, so the prefix buys   |
 |     |                                               | nothing and the house style avoids it. Replacing raises with  |
 |     |                                               | debug asserts on hot paths stays OPEN.                        |
-| 21  | More inplace variants for `BigUInt`           | OPEN — and one concrete instance measured (20260826):         |
-|     | and `BigDecimal`                              | `subtract_inplace()` builds a whole negated copy of its right |
-|     |                                               | operand to flip a sign, so `x -= y` is 5.2× slower than       |
-|     |                                               | libmpdec in place, where `x += y` is 1.3× *faster*.           |
+| 21  | More inplace variants for `BigUInt`           | OPEN — the measured instance is FIXED (20260902):             |
+|     | and `BigDecimal`                              | `subtract_inplace()` copied the whole coefficient to flip a   |
+|     |                                               | sign. The sign is an argument now (`add_inplace_signed()`),   |
+|     |                                               | and `x -= y` costs what `x += y` costs at every size; it was  |
+|     |                                               | 3.3× at a hundred digits, where the copy reached the heap.    |
 | 22  | Zero-copy scale alignment via word-offset     | DISPROVEN — see T-API2                                        |
 |     | add/sub                                       |                                                               |
 | 23  | Drop multiply pre-scaling; adjust scale       | OPEN — see T-API2.M                                           |

--- a/docs/plans/bigint_enhancement.md
+++ b/docs/plans/bigint_enhancement.md
@@ -196,8 +196,15 @@ base case is cheaper. The 2n-by-n / 4n-by-n / 8n-by-n slowdown already
 noted for `BigUInt` in `todo.md` may share this root and should be checked
 together.
 
-**T-D4 — reciprocal / Barrett divide. Deferred.** Not worth it before
-Toom-3 (Lesson 9).
+**T-D4 — reciprocal / Barrett divide. Dropped (20260902).** The condition
+Lesson 9 set was met -- the transform landed and division rose to 4.9x a
+same-size multiply -- but everything since has undone it. Base 2^64, base
+10^18, the Knuth D multiply-subtract and the block pool bring a 2n-by-n
+division to 1.64x a same-size multiply at 10 000 digits and 3.25x at a
+million. A Barrett divide is a Newton reciprocal (~3 M(n) with precision
+doubling) plus two multiplications, so 4 to 5 M(n) unless the divisor is
+reused, which binary splitting never does. We are already under that. See
+`docs/internal/todo.md`, item 4.
 
 ### to_string, 50–1000 digits (3.4× py)
 
@@ -479,4 +486,4 @@ and fix the base-conversion and SIMD fallout behind the test suite.
 | T-E1  | `reciprocal_sqrt_fixed_point()` binary recip. sqrt | DONE 2026-08-24 — enables T-PI4        |
 | T-M5  | NTT multiply over `2^64 - 2^32 + 1`                | DONE 2026-08-25 — 2.3× at 104 200w     |
 | T-M6  | Share the transform with base-10^9                 | DONE 2026-08-26 — `biguint/ntt.mojo`   |
-| T-D4  | Reciprocal-Newton divide                           | NEXT — NTT landed; B-Z now 4.9× mul    |
+| T-D4  | Reciprocal-Newton divide                           | DROPPED 20260902 — divide now 3.25× mul|

--- a/src/decimo/bigdecimal/arithmetics.mojo
+++ b/src/decimo/bigdecimal/arithmetics.mojo
@@ -404,6 +404,35 @@ def add_inplace(
     Raises:
         Error: If an arithmetic error occurs during computation.
     """
+    add_inplace_signed(x1, x2, x2.sign, precision, rounding_mode)
+
+
+def add_inplace_signed(
+    mut x1: BigDecimal,
+    x2: BigDecimal,
+    x2_sign: Bool,
+    precision: Int = 0,
+    rounding_mode: RoundingMode = RoundingMode.ROUND_HALF_EVEN,
+) raises:
+    """Adds `x2` to `x1` in place, reading `x2`'s sign from `x2_sign`.
+
+    The sign is an argument so that subtraction does not have to build a
+    negated `x2` to get one. `subtract_inplace()` used to copy the whole
+    coefficient for that, which costs an allocation as soon as it outgrows
+    the inline words: `x -= y` was 3.5x `x += y` at a hundred digits, where
+    the two do the same arithmetic.
+
+    Args:
+        x1: The accumulator, modified in place.
+        x2: The value to add. Its own `sign` field is ignored.
+        x2_sign: The sign to treat `x2` as having.
+        precision: Optional target significant-digit precision. When `0`
+            the in-place sum is exact; when `>0` it is rounded in place.
+        rounding_mode: How to round when `precision > 0`.
+
+    Raises:
+        Error: If an arithmetic error occurs during computation.
+    """
     var max_scale = max(x1.scale, x2.scale)
     var scale_factor1 = (max_scale - x1.scale) if x1.scale < max_scale else 0
     var scale_factor2 = (max_scale - x2.scale) if x2.scale < max_scale else 0
@@ -418,7 +447,7 @@ def add_inplace(
                 scale_factor2
             )
             x1.scale = max_scale
-            x1.sign = x2.sign
+            x1.sign = x2_sign
     elif x2.coefficient.is_zero():
         if scale_factor1 > 0:
             x1.coefficient.multiply_by_power_of_ten_inplace(scale_factor1)
@@ -428,7 +457,7 @@ def add_inplace(
         if scale_factor1 > 0:
             x1.coefficient.multiply_by_power_of_ten_inplace(scale_factor1)
 
-        if x1.sign == x2.sign:
+        if x1.sign == x2_sign:
             # Same sign: add magnitudes (use inplace add on x1's coefficient)
             if scale_factor2 == 0:
                 biguint_arithmetics.add_inplace(x1.coefficient, x2.coefficient)
@@ -454,7 +483,7 @@ def add_inplace(
                 biguint_arithmetics.subtract_inplace(coef2, x1.coefficient)
                 x1.coefficient = coef2^
                 x1.scale = max_scale
-                x1.sign = x2.sign
+                x1.sign = x2_sign
             else:
                 x1.coefficient = BigUInt.zero()
                 x1.scale = max_scale
@@ -494,13 +523,9 @@ def subtract_inplace(
     Raises:
         Error: If an arithmetic error occurs during computation.
     """
-    # Create a negated view of x2 and use add_inplace
-    var neg_x2 = BigDecimal(
-        coefficient=x2.coefficient.copy(),
-        scale=x2.scale,
-        sign=not x2.sign,
-    )
-    add_inplace(x1, neg_x2, precision, rounding_mode)
+    # Subtracting is adding with the other sign, and the sign travels as an
+    # argument rather than as a negated copy of `x2`.
+    add_inplace_signed(x1, x2, not x2.sign, precision, rounding_mode)
 
 
 def true_divide(

--- a/src/decimo/bigint/arithmetics.mojo
+++ b/src/decimo/bigint/arithmetics.mojo
@@ -118,6 +118,34 @@ comptime CUTOFF_BURNIKEL_ZIEGLER: Int = 96
 # ===----------------------------------------------------------------------=== #
 
 
+comptime _ADD_SEGMENT_MIN: Int = 32
+"""Words below which `_add_words()` keeps its single carry chain.
+
+Under this the four-way split costs more in setup and stitching than the
+shorter dependency chain buys back.
+"""
+
+
+@always_inline
+def _propagate_carry[
+    o: Origin[mut=True]
+](rp: Pointer[UInt64, o], start: Int, end: Int, carry: UInt64) -> UInt64:
+    """Adds `carry` at `start`, rippling while it meets words of all ones.
+
+    Returns what leaves `end`. A word that is not all ones absorbs the carry,
+    so this reads one word in almost every call.
+    """
+    if carry == 0:
+        return 0
+    for i in range(start, end):
+        var word = rp[unsafe_offset=i]
+        if word != UInt64.MAX:
+            rp[unsafe_offset=i] = word + 1
+            return 0
+        rp[unsafe_offset=i] = 0
+    return 1
+
+
 @always_inline
 def _add_words[
     o: Origin[mut=True],
@@ -146,6 +174,70 @@ def _add_words[
     Returns:
         The carry out of the highest word, 0 or 1.
     """
+    # One carry chain is a loop-carried dependency of add, compare and or,
+    # which measured 1.7 cycles a word where GMP's `ADCS` chain runs at 1.0.
+    # Four chains break it: the array is cut into four segments that add with
+    # no carry in, so nothing in the loop body depends on anything else in
+    # it, and the carries between segments are stitched afterwards. The
+    # stitch is cheap because an incoming carry only travels while it meets
+    # words of all ones.
+    #
+    # The four are interleaved in one loop rather than run as four loops:
+    # separate loops are independent on paper, but the reorder window does
+    # not span a segment, so the core would never overlap them.
+    if n >= _ADD_SEGMENT_MIN:
+        var size = n >> 2
+        var o1 = size
+        var o2 = size * 2
+        var o3 = size * 3
+        var c0 = UInt64(0)
+        var c1 = UInt64(0)
+        var c2 = UInt64(0)
+        var c3 = UInt64(0)
+
+        for i in range(size):
+            var x0 = ap[unsafe_offset=i]
+            var s0 = x0 + bp[unsafe_offset=i]
+            var t0 = s0 + c0
+            rp[unsafe_offset=i] = t0
+            c0 = UInt64(s0 < x0) | UInt64(t0 < s0)
+
+            var x1 = ap[unsafe_offset=o1 + i]
+            var s1 = x1 + bp[unsafe_offset=o1 + i]
+            var t1 = s1 + c1
+            rp[unsafe_offset=o1 + i] = t1
+            c1 = UInt64(s1 < x1) | UInt64(t1 < s1)
+
+            var x2 = ap[unsafe_offset=o2 + i]
+            var s2 = x2 + bp[unsafe_offset=o2 + i]
+            var t2 = s2 + c2
+            rp[unsafe_offset=o2 + i] = t2
+            c2 = UInt64(s2 < x2) | UInt64(t2 < s2)
+
+            var x3 = ap[unsafe_offset=o3 + i]
+            var s3 = x3 + bp[unsafe_offset=o3 + i]
+            var t3 = s3 + c3
+            rp[unsafe_offset=o3 + i] = t3
+            c3 = UInt64(s3 < x3) | UInt64(t3 < s3)
+
+        # The last segment carries whatever `n` did not divide by four.
+        for i in range(o3 + size, n):
+            var x = ap[unsafe_offset=i]
+            var y = bp[unsafe_offset=i]
+            var sum_xy = x + y
+            var total = sum_xy + c3
+            rp[unsafe_offset=i] = total
+            c3 = UInt64(sum_xy < x) | UInt64(total < sum_xy)
+
+        # Stitch. `_propagate_carry()` walks only while it meets all-ones
+        # words, which is why four chains cost about four extra words of
+        # work rather than four extra passes.
+        var carry = carry_in
+        carry = c0 | _propagate_carry(rp, 0, o1, carry)
+        carry = c1 | _propagate_carry(rp, o1, o2, carry)
+        carry = c2 | _propagate_carry(rp, o2, o3, carry)
+        return c3 | _propagate_carry(rp, o3, n, carry)
+
     var carry = carry_in
     for i in range(n):
         var x = ap[unsafe_offset=i]


### PR DESCRIPTION
Subtracting in place built a whole negated copy of its right operand to flip one sign bit, which allocates as soon as the coefficient outgrows the inline words. The sign is an argument now, and `x -= y` costs what `x += y` costs — it was 3.3x at a hundred digits.

`BigInt` addition was latency-bound on its carry chain at 1.75 cycles a word against GMP's 1.0. It runs on four interleaved chains now and stitches the carries afterwards, which is 1.6x from 260 words up and about 1.05 cycles a word. It does not reach multiply or divide, measured: additions are a small share of those.

The rest is documentation. Three items on the performance list were costed before base 2^64 and the block pool landed; measured again, Newton reciprocal division and radix-4 for the NTT are both dropped, and the slow `divide` and `parse` turn out to be the extension build running the same Mojo code at 2.8x.